### PR TITLE
Fix Transfer Command

### DIFF
--- a/src/commands/System/transfer.js
+++ b/src/commands/System/transfer.js
@@ -23,7 +23,7 @@ module.exports = class extends Command {
 			})
 			.catch((err) => {
 				this.client.emit('error', err.stack);
-				return msg.sendMessage(`Transfer of ${piece.type}: ${piece.name} to Client has failed. Please check your Console.`);
+				return msg.sendMessage(`Transfer of ${piece.type}: ${piece.name || piece.help.name} to Client has failed. Please check your Console.`);
 			});
 	}
 

--- a/src/commands/System/transfer.js
+++ b/src/commands/System/transfer.js
@@ -1,6 +1,6 @@
 const { Command } = require('../../index');
 const fs = require('fs-nextra');
-const { resolve, join, sep } = require('path');
+const { resolve, join } = require('path');
 
 module.exports = class extends Command {
 

--- a/src/commands/System/transfer.js
+++ b/src/commands/System/transfer.js
@@ -13,12 +13,12 @@ module.exports = class extends Command {
 	}
 
 	async run(msg, [piece]) {
-		const name = piece.type === 'command' ? join(...piece.help.fullCategory) : piece.name;
-		const fileLocation = resolve(this.client.coreBaseDir, `${piece.type}s`, name);
+		const file = piece.type === 'command' ? join(...piece.help.fullCategory) : piece.file;
+		const fileLocation = resolve(this.client.coreBaseDir, `${piece.type}s`, file);
 		await fs.access(fileLocation).catch(() => { throw '❌ That file has been transfered already or never existed.'; });
-		return fs.copy(fileLocation, resolve(this.client.clientBaseDir, `${piece.type}s`, name))
+		return fs.copy(fileLocation, resolve(this.client.clientBaseDir, `${piece.type}s`, file))
 			.then(() => {
-				this.client[`${piece.type}s`].load(resolve(this.client.clientBaseDir, `${piece.type}s`), name.split(sep));
+				this.client[`${piece.type}s`].load(resolve(this.client.clientBaseDir, `${piece.type}s`), piece.file || piece.help.fullCategory);
 				return msg.sendMessage(`✅ Successfully Transferred ${piece.type}: ${piece.name || piece.help.name}`);
 			})
 			.catch((err) => {

--- a/src/commands/System/transfer.js
+++ b/src/commands/System/transfer.js
@@ -1,6 +1,6 @@
 const { Command } = require('../../index');
 const fs = require('fs-nextra');
-const { resolve, join } = require('path');
+const { resolve, join, sep } = require('path');
 
 module.exports = class extends Command {
 
@@ -18,8 +18,8 @@ module.exports = class extends Command {
 		await fs.access(fileLocation).catch(() => { throw '❌ That file has been transfered already or never existed.'; });
 		return fs.copy(fileLocation, resolve(this.client.clientBaseDir, `${piece.type}s`, name))
 			.then(() => {
-				this.client[`${piece.type}s`].load(this.client.clientBaseDir, [`${piece.type}s`, name]);
-				return msg.sendMessage(`✅ Successfully Transferred ${piece.type}: ${piece.help.name}`);
+				this.client[`${piece.type}s`].load(resolve(this.client.clientBaseDir, `${piece.type}s`), name.split(sep));
+				return msg.sendMessage(`✅ Successfully Transferred ${piece.type}: ${piece.name || piece.help.name}`);
 			})
 			.catch((err) => {
 				this.client.emit('error', err.stack);

--- a/src/commands/System/transfer.js
+++ b/src/commands/System/transfer.js
@@ -18,8 +18,8 @@ module.exports = class extends Command {
 		await fs.access(fileLocation).catch(() => { throw '❌ That file has been transfered already or never existed.'; });
 		return fs.copy(fileLocation, resolve(this.client.clientBaseDir, `${piece.type}s`, name))
 			.then(() => {
-				this.client[`${piece.type}s`].load(resolve(this.client.clientBaseDir, `${piece.type}s`), name).catch((response) => { throw `❌ ${response}`; });
-				return msg.sendMessage(`✅ Successfully Transferred ${piece.type}: ${piece.name}`);
+				this.client[`${piece.type}s`].load(this.client.clientBaseDir, [`${piece.type}s`, name]);
+				return msg.sendMessage(`✅ Successfully Transferred ${piece.type}: ${piece.help.name}`);
 			})
 			.catch((err) => {
 				this.client.emit('error', err.stack);

--- a/src/finalizers/commandlogging.js
+++ b/src/finalizers/commandlogging.js
@@ -8,7 +8,7 @@ const { Finalizer } = require('../index');
 module.exports = class extends Finalizer {
 
 	constructor(...args) {
-		super(...args, 'commandCooldown', {});
+		super(...args, 'commandLogging', {});
 	}
 
 	run(msg, mes, start) {

--- a/src/lib/stores/CommandStore.js
+++ b/src/lib/stores/CommandStore.js
@@ -28,7 +28,7 @@ module.exports = class CommandStore extends Collection {
 	set(command) {
 		if (!(command instanceof Command)) return this.client.emit('error', 'Only commands may be stored in the CommandStore.');
 		const existing = this.get(command.name);
-		if (existing) existing.delete();
+		if (existing) this.delete(existing);
 		super.set(command.help.name, command);
 		command.conf.aliases.forEach(alias => this.aliases.set(alias, command));
 		return command;

--- a/src/lib/stores/EventStore.js
+++ b/src/lib/stores/EventStore.js
@@ -43,17 +43,17 @@ module.exports = class EventStore extends Collection {
 	}
 
 	load(dir, file) {
-		const evt = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
-		delete require.cache[join(dir, ...file)];
+		const evt = this.set(new (require(join(dir, file)))(this.client, dir, file));
+		delete require.cache[join(dir, file)];
 		return evt;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
+		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
+		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
 		return this.size;
 	}
 

--- a/src/lib/stores/EventStore.js
+++ b/src/lib/stores/EventStore.js
@@ -3,7 +3,7 @@ const { Collection } = require('discord.js');
 const fs = require('fs-nextra');
 const Event = require('../structures/Event');
 
-module.exports = class CommandStore extends Collection {
+module.exports = class EventStore extends Collection {
 
 	constructor(client) {
 		super();

--- a/src/lib/stores/FinalizerStore.js
+++ b/src/lib/stores/FinalizerStore.js
@@ -37,17 +37,17 @@ module.exports = class FinalizerStore extends Collection {
 	}
 
 	load(dir, file) {
-		const fin = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
-		delete require.cache[join(dir, ...file)];
+		const fin = this.set(new (require(join(dir, file)))(this.client, dir, file));
+		delete require.cache[join(dir, file)];
 		return fin;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
+		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
+		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
 		return this.size;
 	}
 

--- a/src/lib/stores/FinalizerStore.js
+++ b/src/lib/stores/FinalizerStore.js
@@ -14,8 +14,17 @@ module.exports = class FinalizerStore extends Collection {
 
 	set(finalizer) {
 		if (!(finalizer instanceof Finalizer)) return this.client.emit('error', 'Only finalizers may be stored in the FinalizerStore.');
+		const existing = this.get(finalizer.name);
+		if (existing) this.delete(existing);
 		super.set(finalizer.name, finalizer);
 		return finalizer;
+	}
+
+	delete(name) {
+		const finalizer = this.resolve(name);
+		if (!finalizer) return false;
+		super.delete(finalizer.name);
+		return true;
 	}
 
 	init() {
@@ -28,17 +37,17 @@ module.exports = class FinalizerStore extends Collection {
 	}
 
 	load(dir, file) {
-		const fin = this.set(new (require(join(dir, file)))(this.client, dir, file));
-		delete require.cache[join(dir, file)];
+		const fin = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
+		delete require.cache[join(dir, ...file)];
 		return fin;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
+		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
+		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
 		return this.size;
 	}
 

--- a/src/lib/stores/InhibitorStore.js
+++ b/src/lib/stores/InhibitorStore.js
@@ -37,17 +37,17 @@ module.exports = class InhibitorStore extends Collection {
 	}
 
 	load(dir, file) {
-		const inh = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
-		delete require.cache[join(dir, ...file)];
+		const inh = this.set(new (require(join(dir, file)))(this.client, dir, file));
+		delete require.cache[join(dir, file)];
 		return inh;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
+		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
+		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
 		return this.size;
 	}
 

--- a/src/lib/stores/InhibitorStore.js
+++ b/src/lib/stores/InhibitorStore.js
@@ -3,7 +3,7 @@ const { Collection } = require('discord.js');
 const fs = require('fs-nextra');
 const Inhibitor = require('../structures/Inhibitor');
 
-module.exports = class FinalizerStore extends Collection {
+module.exports = class InhibitorStore extends Collection {
 
 	constructor(client) {
 		super();

--- a/src/lib/stores/InhibitorStore.js
+++ b/src/lib/stores/InhibitorStore.js
@@ -14,8 +14,17 @@ module.exports = class InhibitorStore extends Collection {
 
 	set(inhibitor) {
 		if (!(inhibitor instanceof Inhibitor)) return this.client.emit('error', 'Only inhibitors may be stored in the InhibitorStore.');
+		const existing = this.get(inhibitor.name);
+		if (existing) this.delete(existing);
 		super.set(inhibitor.name, inhibitor);
 		return inhibitor;
+	}
+
+	delete(name) {
+		const inhibitor = this.resolve(name);
+		if (!inhibitor) return false;
+		super.delete(inhibitor.name);
+		return true;
 	}
 
 	init() {
@@ -28,17 +37,17 @@ module.exports = class InhibitorStore extends Collection {
 	}
 
 	load(dir, file) {
-		const inh = this.set(new (require(join(dir, file)))(this.client, dir, file));
-		delete require.cache[join(dir, file)];
+		const inh = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
+		delete require.cache[join(dir, ...file)];
 		return inh;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
+		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
+		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
 		return this.size;
 	}
 

--- a/src/lib/stores/MonitorStore.js
+++ b/src/lib/stores/MonitorStore.js
@@ -14,8 +14,17 @@ module.exports = class MonitorStore extends Collection {
 
 	set(monitor) {
 		if (!(monitor instanceof Monitor)) return this.client.emit('error', 'Only monitors may be stored in the MonitorStore.');
+		const existing = this.get(monitor.name);
+		if (existing) this.delete(existing);
 		super.set(monitor.name, monitor);
 		return monitor;
+	}
+
+	delete(name) {
+		const monitor = this.resolve(name);
+		if (!monitor) return false;
+		super.delete(monitor.name);
+		return true;
 	}
 
 	init() {
@@ -28,17 +37,17 @@ module.exports = class MonitorStore extends Collection {
 	}
 
 	load(dir, file) {
-		const mon = this.set(new (require(join(dir, file)))(this.client, dir, file));
-		delete require.cache[join(dir, file)];
+		const mon = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
+		delete require.cache[join(dir, ...file)];
 		return mon;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
+		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
+		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
 		return this.size;
 	}
 

--- a/src/lib/stores/MonitorStore.js
+++ b/src/lib/stores/MonitorStore.js
@@ -3,7 +3,7 @@ const { Collection } = require('discord.js');
 const fs = require('fs-nextra');
 const Monitor = require('../structures/Monitor');
 
-module.exports = class FinalizerStore extends Collection {
+module.exports = class MonitorStore extends Collection {
 
 	constructor(client) {
 		super();

--- a/src/lib/stores/MonitorStore.js
+++ b/src/lib/stores/MonitorStore.js
@@ -37,17 +37,17 @@ module.exports = class MonitorStore extends Collection {
 	}
 
 	load(dir, file) {
-		const mon = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
-		delete require.cache[join(dir, ...file)];
+		const mon = this.set(new (require(join(dir, file)))(this.client, dir, file));
+		delete require.cache[join(dir, file)];
 		return mon;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
+		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
+		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
 		return this.size;
 	}
 

--- a/src/lib/stores/ProviderStore.js
+++ b/src/lib/stores/ProviderStore.js
@@ -37,17 +37,17 @@ module.exports = class ProviderStore extends Collection {
 	}
 
 	load(dir, file) {
-		const pro = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
-		delete require.cache[join(dir, ...file)];
+		const pro = this.set(new (require(join(dir, file)))(this.client, dir, file));
+		delete require.cache[join(dir, file)];
 		return pro;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
+		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
+		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
 		return this.size;
 	}
 

--- a/src/lib/stores/ProviderStore.js
+++ b/src/lib/stores/ProviderStore.js
@@ -3,7 +3,7 @@ const { Collection } = require('discord.js');
 const fs = require('fs-nextra');
 const Provider = require('../structures/Provider');
 
-module.exports = class FinalizerStore extends Collection {
+module.exports = class ProviderStore extends Collection {
 
 	constructor(client) {
 		super();

--- a/src/lib/stores/ProviderStore.js
+++ b/src/lib/stores/ProviderStore.js
@@ -14,8 +14,17 @@ module.exports = class ProviderStore extends Collection {
 
 	set(provider) {
 		if (!(provider instanceof Provider)) return this.client.emit('error', 'Only providers may be stored in the ProviderStore.');
+		const existing = this.get(provider.name);
+		if (existing) this.delete(existing);
 		super.set(provider.name, provider);
 		return provider;
+	}
+
+	delete(name) {
+		const provider = this.resolve(name);
+		if (!provider) return false;
+		super.delete(provider.name);
+		return true;
 	}
 
 	init() {
@@ -28,17 +37,17 @@ module.exports = class ProviderStore extends Collection {
 	}
 
 	load(dir, file) {
-		const pro = this.set(new (require(join(dir, file)))(this.client, dir, file));
-		delete require.cache[join(dir, file)];
+		const pro = this.set(new (require(join(dir, ...file)))(this.client, dir, ...file));
+		delete require.cache[join(dir, ...file)];
 		return pro;
 	}
 
 	async loadAll() {
 		this.clear();
 		const coreFiles = await fs.readdir(this.coreDir).catch(() => { fs.ensureDir(this.coreDir).catch(err => this.client.emit('errorlog', err)); });
-		if (coreFiles) await Promise.all(coreFiles.map(this.load.bind(this, this.coreDir)));
+		if (coreFiles) await Promise.all(coreFiles.map(file => this.load(this.coreDir, [file])));
 		const userFiles = await fs.readdir(this.userDir).catch(() => { fs.ensureDir(this.userDir).catch(err => this.client.emit('errorlog', err)); });
-		if (userFiles) await Promise.all(userFiles.map(this.load.bind(this, this.userDir)));
+		if (userFiles) await Promise.all(userFiles.map(file => this.load(this.userDir, [file])));
 		return this.size;
 	}
 


### PR DESCRIPTION
This changes transfer so that it passes an array to ...join, instead of the String being concat into
` S\y\s\t\e\m\c\o\m\m\a\n\d\j\s`

Also fixes 'Reloaded undefined' `piece.name -> piece.help.name`

Removed the unnecessary .catch() because .load() is not a promise anymore.

You should consider doing `require("klasa");` instead of `require('index');` because when users transfer they will get errors when trying to load the new command because index is not defined in the local directory, thus making it seem like the transferred failed even if it didn't. Requiring klasa inside commands will fix this.