### PR TITLE
Simplify permission levels/structure

### DIFF
--- a/src/inhibitors/permissions.js
+++ b/src/inhibitors/permissions.js
@@ -6,9 +6,9 @@ module.exports = class extends Inhibitor {
 		const min = typeof cmd === 'number' ? cmd : cmd.permLevel;
 		const mps = [];
 		let broke = false;
-		for (let i = min; i < 11; i++) {
-			mps.push(this.client.permStructure[i].check(this.client, msg));
-			if (this.client.permStructure[i].break) {
+		for (let i = min; i < this.client.permLevels.size; i++) {
+			mps.push(this.client.permLevels.get(i).check(this.client, msg));
+			if (this.client.permLevels.get(i).break) {
 				broke = true;
 				break;
 			}

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -131,9 +131,9 @@ class KlasaClient extends Discord.Client {
 
 		/**
 		 * The permissions structure for this bot
-		 * @type {validPermStructure}
+		 * @type {PermissionLevels}
 		 */
-		this.permStructure = this.validatePermStructure();
+		this.permLevels = this.validatePermLevels();
 
 		/**
 		 * The threshold for how old command messages can be before sweeping since the last edit in seconds
@@ -205,17 +205,13 @@ class KlasaClient extends Discord.Client {
 	/**
 	 * Validates the permission structure passed to the client
 	 * @private
-	 * @returns {validPermStructure}
+	 * @returns {PermissionLevels}
 	 */
-	validatePermStructure() {
-		const structure = this.config.permStructure instanceof PermLevels ? this.config.permStructure.structure : null;
-		const permStructure = structure || this.config.permStructure || KlasaClient.defaultPermStructure.structure;
-		if (!Array.isArray(permStructure)) throw 'PermStructure must be an array.';
-		if (permStructure.some(perm => typeof perm !== 'object' || typeof perm.check !== 'function' || typeof perm.break !== 'boolean')) {
-			throw 'Perms must be an object with a check function and a break boolean.';
-		}
-		if (permStructure.length !== 11) throw 'Permissions 0-10 must all be defined.';
-		return permStructure;
+	validatePermLevels() {
+		const permLevels = this.config.permsLevels || KlasaClient.defaultPermLevels;
+		if (!(permLevels instanceof PermLevels)) throw new Error('permLevels must be an instance of the PermissionLevels class');
+		if (permLevels.isValid()) return permLevels;
+		throw new Error('Unexpected catastrophic failure at permission level validation!');
 	}
 
 	/**
@@ -321,7 +317,7 @@ class KlasaClient extends Discord.Client {
  * The default PermLevels
  * @type {PermissionLevels}
  */
-KlasaClient.defaultPermStructure = new PermLevels()
+KlasaClient.defaultPermLevels = new PermLevels()
 	.addLevel(0, false, () => true)
 	.addLevel(2, false, (client, msg) => {
 		if (!msg.guild || !msg.guild.settings.modRole) return false;

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -211,7 +211,7 @@ class KlasaClient extends Discord.Client {
 		const permLevels = this.config.permsLevels || KlasaClient.defaultPermLevels;
 		if (!(permLevels instanceof PermLevels)) throw new Error('permLevels must be an instance of the PermissionLevels class');
 		if (permLevels.isValid()) return permLevels;
-		throw new Error('Unexpected catastrophic failure at permission level validation!');
+		throw new Error(permLevels.debug());
 	}
 
 	/**

--- a/src/lib/util/permLevels.js
+++ b/src/lib/util/permLevels.js
@@ -11,17 +11,10 @@ class PermissionLevels extends Map {
 	 */
 
 	/**
-	 * The default amount of permission levels
-	 */
-	static get defaultRequiredLevels() {
-		return 11;
-	}
-
-	/**
 	 * Creates a new PermissionLevels
 	 * @param {number} levels How many permission levels there should be
 	 */
-	constructor(levels = PermissionLevels.defaultRequiredLevels) {
+	constructor(levels = 11) {
 		super();
 
 		/**
@@ -51,20 +44,49 @@ class PermissionLevels extends Map {
 	 * @return {boolean}
 	 */
 	isValid() {
-		/* eslint-disable no-multi-spaces, arrow-body-style, operator-linebreak, indent, no-mixed-spaces-and-tabs */
-		return every(this)((level, index) => {
-			// Trick to replace a switch case or if else. Condition on the left, what's executed on the right. Last one is default.
-			return   typeof level !== 'object'   ? throwE(`Permission level ${index} must be an object`) :
-				typeof level.break !== 'boolean'  ? throwE(`"break" in permission level ${index} must be a boolean`) :
-				typeof level.check !== 'function' ? throwE(`"check" in permission level ${index} must be a function`)
-				                                  : true;
+		return this.every(level => {
+			if (typeof level !== 'object') return false;
+			if (typeof level.break !== 'boolean') return false;
+			if (typeof level.check !== 'function') return false;
+			return true;
 		});
-		/* eslint-enable no-multi-spaces, arrow-body-style, operator-linebreak, indent, no-mixed-spaces-and-tabs */
+	}
+
+	/**
+	 * Checks if all permission levels are valid
+	 * @return {string} Error message(s)
+	 */
+	debug() {
+		const errors = [];
+		this.forEach((level, index) => {
+			if (typeof level !== 'object') {
+				errors.push(`Permission level ${index} must be an object`);
+			}
+			if (typeof level.break !== 'boolean') {
+				errors.push(`"break" in permission level ${index} must be a boolean`);
+			}
+			if (typeof level.check !== 'function') {
+				errors.push(`"check" in permission level ${index} must be a function`);
+			}
+		});
+		return errors.join('\n');
+	}
+
+	/**
+	* Identical to
+	* [Array.every()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every).
+	* @param {Function} fn Function used to test (should return a boolean)
+	* @param {Object} [thisArg] Value to use as `this` when executing function
+	* @returns {boolean}
+	*/
+	every(fn, thisArg) {
+		if (thisArg) fn = fn.bind(thisArg);
+		for (const [key, val] of this) {
+			if (!fn(val, key, this)) return false;
+		}
+		return true;
 	}
 
 }
-
-const throwE = msg => { throw new Error(msg); };
-const every = iterable => func => Array.prototype.every.call(iterable, func);
 
 module.exports = PermissionLevels;

--- a/src/lib/util/permLevels.js
+++ b/src/lib/util/permLevels.js
@@ -39,36 +39,31 @@ class PermissionLevels extends Map {
 		return this.set(level, { break: brk, check });
 	}
 
+	set(level, obj) {
+		if (level < 0) throw new Error(`Cannot set permission level ${level}. Permission levels start at 0.`);
+		else if (level > (this.requiredLevels - 1)) throw new Error(`Cannot set permission level ${level}. Permission levels stop at ${this.requiredLevels - 1}.`);
+		else return super.set(level, obj);
+	}
+
 	/**
 	 * Checks if all permission levels are valid
 	 * @return {boolean}
 	 */
 	isValid() {
-		return this.every(level => {
-			if (typeof level !== 'object') return false;
-			if (typeof level.break !== 'boolean') return false;
-			if (typeof level.check !== 'function') return false;
-			return true;
-		});
+		return this.every(level => typeof level === 'object' && typeof level.break === 'boolean' && typeof level.check === 'function');
 	}
 
 	/**
-	 * Checks if all permission levels are valid
+	 * Returns any errors in the perm levels
 	 * @return {string} Error message(s)
 	 */
 	debug() {
 		const errors = [];
-		this.forEach((level, index) => {
-			if (typeof level !== 'object') {
-				errors.push(`Permission level ${index} must be an object`);
-			}
-			if (typeof level.break !== 'boolean') {
-				errors.push(`"break" in permission level ${index} must be a boolean`);
-			}
-			if (typeof level.check !== 'function') {
-				errors.push(`"check" in permission level ${index} must be a function`);
-			}
-		});
+		for (const [level, index] of this) {
+			if (typeof level !== 'object') errors.push(`Permission level ${index} must be an object`);
+			if (typeof level.break !== 'boolean') errors.push(`"break" in permission level ${index} must be a boolean`);
+			if (typeof level.check !== 'function') errors.push(`"check" in permission level ${index} must be a function`);
+		}
 		return errors.join('\n');
 	}
 

--- a/src/lib/util/permLevels.js
+++ b/src/lib/util/permLevels.js
@@ -41,8 +41,8 @@ class PermissionLevels extends Map {
 
 	set(level, obj) {
 		if (level < 0) throw new Error(`Cannot set permission level ${level}. Permission levels start at 0.`);
-		else if (level > (this.requiredLevels - 1)) throw new Error(`Cannot set permission level ${level}. Permission levels stop at ${this.requiredLevels - 1}.`);
-		else return super.set(level, obj);
+		if (level > (this.requiredLevels - 1)) throw new Error(`Cannot set permission level ${level}. Permission levels stop at ${this.requiredLevels - 1}.`);
+		return super.set(level, obj);
 	}
 
 	/**


### PR DESCRIPTION
Changes:

- `KlasaClient.permStructure` gets replaced with `KlasaClient.permLevels`.
- The `PermissionLevels` class has been simplified. It is now a `Map` itself.
- The amount of `permLevel`s can now be configured when initializing the `PermissionLevels` class, but if not specified the default is still 11: `new PermissionLevels(15)`.

New way to get a `permLevel`: `client.permLevels.get(level)`.
It's also possible to overwrite a level now. If that's bad tell me.