### PR TITLE
Redesigned log output

### DIFF
--- a/src/events/log.js
+++ b/src/events/log.js
@@ -29,7 +29,7 @@ module.exports = class extends Event {
 
 		const format = this.formats[type || 'log'];
 		let timestamp = this.client.config.disableLogTimestamps ? '' : `[${moment().format('YYYY-MM-DD HH:mm:ss')}]`;
-		if ('time' in format) timestamp = format.type(timestamp);
+		if ('time' in format) timestamp = format.time(timestamp);
 		// eslint-disable-next-line no-console
 		console[format.logger || 'log'](data.split('\n').map(str => `${timestamp}${format.msg ? format.msg(timestamp ? ` ${str}` : str) : timestamp ? ` ${str}` : str}`).join('\n'));
 	}

--- a/src/events/log.js
+++ b/src/events/log.js
@@ -3,10 +3,22 @@ const moment = require('moment');
 const chalk = require('chalk');
 const { inspect } = require('util');
 
-const clk = new chalk.constructor({ enabled: true });
-
-
 module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args);
+
+		const clk = new chalk.constructor({ enabled: !this.client.config.disableLogColor });
+
+		this.formats = {
+			verbose: { time: clk.grey, msg: clk.grey, logger: 'log' },
+			debug: { time: clk.magenta, logger: 'log' },
+			log: { time: clk.blue },
+			warn: { time: clk.black.bgYellow },
+			error: { time: clk.bgRed },
+			wtf: { time: clk.bold.underline.bgRed, msg: clk.bold.underline.bgRed, logger: 'error' }
+		};
+	}
 
 	run(data, type = 'log') {
 		type = type.toLowerCase();
@@ -15,32 +27,11 @@ module.exports = class extends Event {
 		if (typeof data === 'object' && typeof data !== 'string' && !Array.isArray(data)) data = inspect(data, { depth: 0, colors: true });
 		if (Array.isArray(data)) data = data.join('\n');
 
-		let timestamp = '';
-		if (!this.client.config.disableLogTimestamps) {
-			timestamp = `[${moment().format('YYYY-MM-DD HH:mm:ss')}]`;
-			if (!this.client.config.disableLogColor) {
-				switch (type) {
-					case 'debug':
-						timestamp = clk.bgMagenta(timestamp);
-						break;
-					case 'warn':
-						timestamp = clk.black.bgYellow(timestamp);
-						break;
-					case 'error':
-						timestamp = clk.bgRed(timestamp);
-						break;
-					case 'log':
-						timestamp = clk.bgBlue(timestamp);
-						break;
-					// no default
-				}
-			}
-			timestamp += ' ';
-		}
-
-		if (type === 'debug') type = 'log';
+		const format = this.formats[type] || 'log';
+		let timestamp = this.client.config.disableLogTimestamps ? '' : `[${moment().format('YYYY-MM-DD HH:mm:ss')}]`;
+		if ('time' in format) timestamp = format.type(timestamp);
 		// eslint-disable-next-line no-console
-		console[type](data.split('\n').map(str => timestamp + str).join('\n'));
+		console[format.logger || 'log'](data.split('\n').map(str => `${timestamp}${format.msg ? format.msg(timestamp ? ` ${str}` : str) : timestamp ? ` ${str}` : str}`).join('\n'));
 	}
 
 };

--- a/src/events/log.js
+++ b/src/events/log.js
@@ -28,8 +28,7 @@ module.exports = class extends Event {
 		if (Array.isArray(data)) data = data.join('\n');
 
 		const format = this.formats[type || 'log'];
-		let timestamp = this.client.config.disableLogTimestamps ? '' : `[${moment().format('YYYY-MM-DD HH:mm:ss')}]`;
-		if ('time' in format) timestamp = format.time(timestamp);
+		const timestamp = this.client.config.disableLogTimestamps ? '' : format.time(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`);
 		// eslint-disable-next-line no-console
 		console[format.logger || 'log'](data.split('\n').map(str => `${timestamp}${format.msg ? format.msg(timestamp ? ` ${str}` : str) : timestamp ? ` ${str}` : str}`).join('\n'));
 	}

--- a/src/events/log.js
+++ b/src/events/log.js
@@ -27,7 +27,7 @@ module.exports = class extends Event {
 		if (typeof data === 'object' && typeof data !== 'string' && !Array.isArray(data)) data = inspect(data, { depth: 0, colors: true });
 		if (Array.isArray(data)) data = data.join('\n');
 
-		const format = this.formats[type] || 'log';
+		const format = this.formats[type || 'log'];
 		let timestamp = this.client.config.disableLogTimestamps ? '' : `[${moment().format('YYYY-MM-DD HH:mm:ss')}]`;
 		if ('time' in format) timestamp = format.type(timestamp);
 		// eslint-disable-next-line no-console

--- a/src/events/verbose.js
+++ b/src/events/verbose.js
@@ -1,0 +1,9 @@
+const { Event } = require('klasa');
+
+module.exports = class extends Event {
+
+	run(log) {
+		this.client.emit('log', log, 'verbose');
+	}
+
+};

--- a/src/events/wtf.js
+++ b/src/events/wtf.js
@@ -1,0 +1,13 @@
+const { Event } = require('klasa');
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { enabled: false });
+	}
+
+	run(failure) {
+		this.client.emit('log', failure, 'wtf');
+	}
+
+};


### PR DESCRIPTION
- Added `wtf` (What a Terrible Failure, according to Android's Log class) and `verbose` log levels
- Added event shortcuts for the new levels (`wtf` is disabled by default to avoid usage due to its nature)

### Refactoring
- Log formatting is now managed through `this.format` in [log.js](https://github.com/HellPie/klasa/blob/log-update/src/events/log.js#L13-L20).
- Console method to use is also managed there.

### Restyling
- Every log level except for `error`, `warn` and `wtf` only colors the text, not the background, to better show warns and errors.
- Level `verbose` is colored grey (chalk `dim` does not work in most Windows environments) to not spam too many colors for those who will need to read the logs
- Level `wtf` is marked as underlined and bold, and highlights the entire message to be instantly recognizable due to the fact it should only be used for extreme case scenarios and "Terrible Failures".

### Screenshot testing how this pr will change logs:
![image](https://user-images.githubusercontent.com/2611921/30107956-b2d1f892-9300-11e7-963a-86380ee1356b.png)
