### PR TITLE
Update help.js

### DIFF
--- a/src/commands/System/help.js
+++ b/src/commands/System/help.js
@@ -28,7 +28,7 @@ module.exports = class extends Command {
 		for (let cat = 0; cat < categories.length; cat++) {
 			helpMessage.push(`**${categories[cat]} Commands**: \`\`\`asciidoc`);
 			const subCategories = Object.keys(help[categories[cat]]);
-			for (let subCat = 0; subCat < subCategories.length; subCat++) helpMessage.push(`= ${subCategories[subCat]} =`, `${help[categories[cat]][subCategories[subCat]].join('\n')}\n`);
+			for (let subCat = 0; subCat < subCategories.length; subCat++) helpMessage.push(`= ${subCategories[subCat]} =`, `${help[categories[cat]][subCategories[subCat]].join('\n')}\n\`\`\``);
 			helpMessage.push('```\n\u200b');
 		}
 


### PR DESCRIPTION
Better appearance on Mobile

Still having complaints from users that now the text is too clumped and would look better if there was a space after each one? Any ideas how to do that. Ive tried doing \n but no luck