### PR TITLE
msg.send() updated

### DIFF
--- a/src/extendables/send.js
+++ b/src/extendables/send.js
@@ -6,7 +6,7 @@ module.exports = class extends Extendable {
 		super(...args, ['Message']);
 	}
 
-	extend(content, options) {
+	extend(content = '', options = {}) {
 		return this.sendMessage(content, options);
 	}
 


### PR DESCRIPTION
Updated this as msg.send with embeds is borked as you couldn't do `msg.send({embed: lol});` 