### PR TITLE
Command handler improvements

### DIFF
--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -37,7 +37,6 @@ class KlasaClient extends Discord.Client {
 	 * @property {KlasaConsoleEvents} [consoleEvents={}] Config options to pass to the client console
 	 * @property {boolean} [ignoreBots=true] Whether or not this bot should ignore other bots
 	 * @property {boolean} [ignoreSelf=true] Whether or not this bot should ignore itself
-	 * @property {RegExp} [prefixMention] The prefix mention for your bot (Automatically Generated)
 	 * @property {boolean} [cmdPrompt=false] Whether the bot should prompt missing parameters
 	 * @property {boolean} [cmdEditing=false] Whether the bot should update responses if the command is edited
 	 * @property {boolean} [cmdLogging=false] Whether the bot should log command usage
@@ -382,7 +381,6 @@ class KlasaClient extends Discord.Client {
 	 * @private
 	 */
 	async _ready() {
-		this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
 		if (this.config.ignoreBots === undefined) this.config.ignoreBots = true;
 		if (this.config.ignoreSelf === undefined) this.config.ignoreSelf = this.user.bot;
 		if (this.user.bot) this.application = await super.fetchApplication();

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -7,7 +7,6 @@ module.exports = class extends Monitor {
 		this.prefixes = new Map();
 		this.prefixMention = null;
 		this.prefixMentionLength = null;
-		this.nickPrefixMenthionLength = null;
 		this.nick = new RegExp('^<@!');
 	}
 
@@ -42,7 +41,7 @@ module.exports = class extends Monitor {
 	}
 
 	getPrefix(msg) {
-		if (this.prefixMention.test(msg.content)) return { length: this.nick.test(msg.content) ? this.nickPrefixMenthionLength : this.prefixMentionLength, regex: this.prefixMention };
+		if (this.prefixMention.test(msg.content)) return { length: this.nick.test(msg.content) ? this.prefixMentionLength + 1 : this.prefixMentionLength, regex: this.prefixMention };
 		const prefix = msg.guildSettings.prefix || this.client.config.prefix;
 		if (prefix instanceof Array) {
 			for (let i = prefix.length - 1; i >= 0; i--) {
@@ -117,8 +116,7 @@ module.exports = class extends Monitor {
 	init() {
 		this.ignoreSelf = this.client.user.bot;
 		this.prefixMention = new RegExp(`^<@!?${this.client.user.id}>`);
-		this.prefixMentionLength = 3 + this.client.user.id.length;
-		this.nickPrefixMenthionLength = 4 + this.client.user.id.length;
+		this.prefixMentionLength = this.client.user.id.length + 3;
 	}
 
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -959,7 +959,6 @@ declare module 'klasa' {
 		consoleEvents?: KlasaConsoleEvents;
 		ignoreBots?: boolean;
 		ignoreSelf?: boolean;
-		prefixMention?: RegExp;
 		cmdPrompt?: boolean;
 		cmdEditing?: boolean;
 		cmdLogging?: boolean;


### PR DESCRIPTION
startsWith is slower than regex.test with a ^, and especially so when cached, instead of recreated every time a message is run (also eliminates regex.exec to get the prefix length).