### PR TITLE
Fix incorrect KlasaClientConfig typing

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -953,6 +953,7 @@ declare module 'klasa' {
 	}
 
 	export type KlasaClientConfig = {
+		clientOptions?: ClientOptions;
 		prefix?: string;
 		permissionLevels?: PermissionLevels;
 		clientBaseDir?: string;
@@ -970,7 +971,7 @@ declare module 'klasa' {
 		quotedStringSupport?: boolean;
 		readyMessage?: string|Function;
 		ownerID?: string;
-	} & ClientOptions;
+	};
 
 	export type KlasaConsoleConfig = {
 		stdout?: NodeJS.WritableStream;


### PR DESCRIPTION
ClientOptions passed to discord.js should be under the `"clientOptions"`
property of KlasaClientConfig, rather than intersected with
KlasaClientConfig itself. This is what the code seems to expect, so this
patch updates the typings accordingly.