### PR TITLE
Swap `_determineEmojis()` signatures

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -213,7 +213,7 @@ declare module 'klasa' {
 		public setInfoPage(embed: MessageEmbed): RichDisplay;
 		public run(msg: ExtendedMessage, options?: RichDisplayRunOptions): Promise<ReactionHandler>;
 		private _footer(): void;
-		private _determineEmojis(emojis: emoji[], stop: boolean): emoji[];
+		private _determineEmojis(emojis: emoji[], stop: boolean, jump: boolean, firstLast: boolean): emoji[];
 		private _handlePageGeneration(cb: Function|RichEmbed): RichEmbed;
 	}
 
@@ -226,7 +226,7 @@ declare module 'klasa' {
 		public addOption(name: string, body: string, inline?: boolean): RichMenu;
 		public run(msg: ExtendedMessage, options?: RichMenuRunOptions): ReactionHandler;
 
-		private _determineEmojis(emojis: emoji[], stop: boolean, jump: boolean, firstLast: boolean): emoji[];
+		private _determineEmojis(emojis: emoji[], stop: boolean): emoji[];
 		private _paginate(): void;
 	}
 


### PR DESCRIPTION
From the code, it seems like `RichDisplay#_determineEmojis()` has the
four-argument signature, whereas `RichMenu#_determineEmojis()` has the
two-argument signature. The typings have them mixed up, so this patch
swaps the signatures to reflect the code.