### PR TITLE
Added disableNaturalPrefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#113](https://github.com/dirigeants/klasa/pull/113)] Added disableNaturalPrefix. (kyranet)
 - [[`550ac275c8`](https://github.com/dirigeants/klasa/commit/550ac275c849c285692ffff5c4e99cb53753a85b) ([#109](https://github.com/dirigeants/klasa/pull/109)) Added the keys `COMMAND_EVAL_DESCRIPTION`, `COMMAND_UNLOAD_DESCRIPTION`, `COMMAND_TRANSFER_DESCRIPTION`, `COMMAND_RELOAD_DESCRIPTION`, `COMMAND_REBOOT_DESCRIPTION`, `COMMAND_PING_DESCRIPTION`, `COMMAND_INVITE_DESCRIPTION`, `COMMAND_INFO_DESCRIPTION`, `COMMAND_ENABLE_DESCRIPTION`, `COMMAND_DISABLE_DESCRIPTION`, `COMMAND_CONF_SERVER_DESCRIPTION`, `COMMAND_CONF_SERVER`, `COMMAND_CONF_USER_DESCRIPTION`, `COMMAND_CONF_USER`, `COMMAND_STATS` and `COMMAND_STATS_DESCRIPTION` to the en-US language. (Pandraghon)
 - [[`6f16689144`](https://github.com/dirigeants/klasa/commit/6f1668914401bfa8d3e08f81594e5eedd514ccce) ([#104](https://github.com/dirigeants/klasa/pull/104)) Added `regexPrefix` as an option for `KlasaClientOptions`. (MrJacz)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) A changelog... (kyranet)

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -77,6 +77,14 @@ class GatewayDriver {
 				array: false,
 				sql: `VARCHAR(5) NOT NULL DEFAULT '${this.client.config.language}'`
 			},
+			disableNaturalPrefix: {
+				type: 'boolean',
+				default: false,
+				min: null,
+				max: null,
+				array: false,
+				sql: `BIT(1) NOT NULL DEFAULT 0`
+			},
 			disabledCommands: {
 				type: 'command',
 				default: [],

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -64,9 +64,10 @@ class GatewayDriver {
 			prefix: {
 				type: 'string',
 				default: this.client.config.prefix,
-				array: this.client.config.prefix.constructor.name === 'Array',
 				min: null,
 				max: 10,
+				array: this.client.config.prefix.constructor.name === 'Array',
+				configurable: true,
 				sql: `VARCHAR(10) NOT NULL DEFAULT '${this.client.config.prefix.constructor.name === 'Array' ? JSON.stringify(this.client.config.prefix) : this.client.config.prefix}'`
 			},
 			language: {
@@ -75,6 +76,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: false,
+				configurable: true,
 				sql: `VARCHAR(5) NOT NULL DEFAULT '${this.client.config.language}'`
 			},
 			disableNaturalPrefix: {
@@ -83,6 +85,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: false,
+				configurable: Boolean(this.client.config.regexPrefix),
 				sql: `BIT(1) NOT NULL DEFAULT 0`
 			},
 			disabledCommands: {
@@ -91,6 +94,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: true,
+				configurable: true,
 				sql: 'TEXT'
 			}
 		};

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -47,7 +47,7 @@ module.exports = class extends Monitor {
 
 	getPrefix(msg) {
 		if (this.prefixMention.test(msg.content)) return { length: this.nick.test(msg.content) ? this.prefixMentionLength + 1 : this.prefixMentionLength, regex: this.prefixMention };
-		if (this.client.config.regexPrefix) {
+		if (msg.guildConfigs.disableNaturalPrefix !== true && this.client.config.regexPrefix) {
 			const results = this.client.config.regexPrefix.exec(msg.content);
 			if (results) return { length: results[0].length, regex: this.client.config.regexPrefix };
 		}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -621,7 +621,7 @@ declare module 'klasa' {
 			prefix: SchemaPieceJSON,
 			language: SchemaPieceJSON,
 			disableNaturalPrefix: SchemaPieceJSON,
-			disabledCommands: SchemaPieceJSON,
+			disabledCommands: SchemaPieceJSON
 		};
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -620,7 +620,8 @@ declare module 'klasa' {
 		public readonly defaultDataSchema: {
 			prefix: SchemaPieceJSON,
 			language: SchemaPieceJSON,
-			disabledCommands: SchemaPieceJSON
+			disableNaturalPrefix: SchemaPieceJSON,
+			disabledCommands: SchemaPieceJSON,
 		};
 	}
 


### PR DESCRIPTION
### Description of the PR
Adds a new key to the default guilds' schema: `disableNaturalPrefix`

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added disableNaturalPrefix

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
