### PR TITLE
Added SchemaPiece#modify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#115](https://github.com/dirigeants/klasa/pull/115)] Added `isObject` method to `Util`. (kyranet)
+- [[#115](https://github.com/dirigeants/klasa/pull/115)] Added `SchemaPiece#modify`, allowing users to modify a SP's options. (kyranet)
 - [[#113](https://github.com/dirigeants/klasa/pull/113)] Added disableNaturalPrefix. (kyranet)
 - [[`550ac275c8`](https://github.com/dirigeants/klasa/commit/550ac275c849c285692ffff5c4e99cb53753a85b) ([#109](https://github.com/dirigeants/klasa/pull/109)) Added the keys `COMMAND_EVAL_DESCRIPTION`, `COMMAND_UNLOAD_DESCRIPTION`, `COMMAND_TRANSFER_DESCRIPTION`, `COMMAND_RELOAD_DESCRIPTION`, `COMMAND_REBOOT_DESCRIPTION`, `COMMAND_PING_DESCRIPTION`, `COMMAND_INVITE_DESCRIPTION`, `COMMAND_INFO_DESCRIPTION`, `COMMAND_ENABLE_DESCRIPTION`, `COMMAND_DISABLE_DESCRIPTION`, `COMMAND_CONF_SERVER_DESCRIPTION`, `COMMAND_CONF_SERVER`, `COMMAND_CONF_USER_DESCRIPTION`, `COMMAND_CONF_USER`, `COMMAND_STATS` and `COMMAND_STATS_DESCRIPTION` to the en-US language. (Pandraghon)
 - [[`6f16689144`](https://github.com/dirigeants/klasa/commit/6f1668914401bfa8d3e08f81594e5eedd514ccce) ([#104](https://github.com/dirigeants/klasa/pull/104)) Added `regexPrefix` as an option for `KlasaClientOptions`. (MrJacz)
@@ -74,6 +76,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed typings not including the `isFunction` method in Util. (kyranet)
+- [[#114](https://github.com/dirigeants/klasa/pull/114)] Fixed a typo in `UnderstandingSettingGateway.md`. (Pandraghon)
 - [[`ede5894763`](https://github.com/dirigeants/klasa/commit/ede58947635bba77ebac32e94551e6246a61d1ad)] Fixed a typo in the help command. (bdistin)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) A lot of things in Typings and marked a lot of private methods properly. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Typos in languages. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#115](https://github.com/dirigeants/klasa/pull/115)] Added the events `schemaKeyAdd`, `schemaKeyRemove` and `schemaKeyUpdate`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Added `isObject` method to `Util`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Added `SchemaPiece#modify`, allowing users to modify a SP's options. (kyranet)
 - [[#113](https://github.com/dirigeants/klasa/pull/113)] Added disableNaturalPrefix. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed some issues from ESLint's betrayal. (MrJacz with kyranet)
+- [[#115](https://github.com/dirigeants/klasa/pull/115)] Improved object check for `Message#sendMessage` and `Message#send`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed typings not including the `isFunction` method in Util. (kyranet)
 - [[#114](https://github.com/dirigeants/klasa/pull/114)] Fixed a typo in `UnderstandingSettingGateway.md`. (Pandraghon)
 - [[`ede5894763`](https://github.com/dirigeants/klasa/commit/ede58947635bba77ebac32e94551e6246a61d1ad)] Fixed a typo in the help command. (bdistin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed Schema's updates not reflecting in other shards. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed some issues from ESLint's betrayal. (MrJacz with kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Improved object check for `Message#sendMessage` and `Message#send`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed typings not including the `isFunction` method in Util. (kyranet)

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -593,6 +593,27 @@ KlasaClient.defaultPermissionLevels = new PermLevels()
  * @param {Piece} piece The piece that was disabled
  */
 
+/**
+ * Emitted when a new key or folder is added to the Schema.
+ * @event KlasaClient#schemaKeyAdd
+ * @since 0.5.0
+ * @param {(Schema|SchemaPiece)} key The key that was added.
+ */
+
+/**
+ * Emitted when a key or folder has been removed from the Schema.
+ * @event KlasaClient#schemaKeyRemove
+ * @since 0.5.0
+ * @param {(Schema|SchemaPiece)} key The key that was removed.
+ */
+
+/**
+ * Emitted when a key's properties are modified.
+ * @event KlasaClient#schemaKeyUpdate
+ * @since 0.5.0
+ * @param {SchemaPiece} key The piece that was updated.
+ */
+
 process.on('unhandledRejection', (err) => {
 	if (!err) return;
 	console.error(`Uncaught Promise Error: \n${err.stack || err}`);

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -1,4 +1,5 @@
 const { Structures, splitMessage } = require('discord.js');
+const { isObject } = require('../util/util');
 
 module.exports = Structures.extend('Message', Message => {
 	/**
@@ -191,7 +192,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @returns {Promise<KlasaMessage|KlasaMessage[]>}
 		 */
 		sendMessage(content, options) {
-			if (!options && typeof content === 'object' && !Array.isArray(content)) {
+			if (!options && isObject(options)) {
 				options = content;
 				content = '';
 			} else if (!options) {
@@ -243,7 +244,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @returns {Promise<KlasaMessage|KlasaMessage[]>}
 		 */
 		sendEmbed(embed, content, options) {
-			if (!options && typeof content === 'object') {
+			if (!options && isObject(options)) {
 				options = content;
 				content = '';
 			} else if (!options) {

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -218,7 +218,7 @@ class Gateway {
 	async createEntry(input) {
 		const target = await this.validate(input).then(output => output && output.id ? output.id : output);
 		const cache = this.cache.get(this.type, target);
-		if (cache && cache.existsInDB) return configs;
+		if (cache && cache.existsInDB) return cache;
 		await this.provider.create(this.type, target);
 		const configs = cache || new Configuration(this, { id: target });
 		configs.existsInDB = true;

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -366,7 +366,7 @@ class Gateway {
 	 * @since 0.5.0
 	 * @param {string[]} path The key's path.
 	 * @param {Object} data The data to insert.
-	 * @param {('add'|'delete')} action Whether the piece got added or removed.
+	 * @param {('add'|'delete'|'update')} action Whether the piece got added or removed.
 	 * @param {boolean} force Whether the key got added with force or not.
 	 * @private
 	 */
@@ -380,9 +380,11 @@ class Gateway {
 		if (action === 'add') {
 			if (parsed.type === 'Folder') piece = route[key] = new Schema(this.client, this, parsed, route, key);
 			else piece = route[key] = new SchemaPiece(this.client, this, parsed, route, key);
-		} else {
+		} else if (action === 'delete') {
 			piece = route[key];
 			delete route[key];
+		} else {
+			route[key]._patch(parsed);
 		}
 		if (force) await route.force(action, key, piece);
 	}

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -149,7 +149,7 @@ class Gateway {
 	 * @param {boolean} [download=true] Whether this Gateway should download the data from the database.
 	 */
 	async init(download = true) {
-		await this.initSchema().then(schema => { this.schema = new Schema(this.client, this, schema, null, ''); });
+		await this.initSchema();
 		await this.initTable();
 		if (download) await this.sync();
 	}
@@ -170,15 +170,17 @@ class Gateway {
 	/**
 	 * Inits the schema, creating a file if it does not exist, and returning the current schema or the default.
 	 * @since 0.5.0
-	 * @returns {Promise<Object>}
+	 * @returns {Promise<Schema>}
 	 * @private
 	 */
 	async initSchema() {
 		const baseDir = resolve(this.client.clientBaseDir, 'bwd');
 		await fs.ensureDir(baseDir);
 		this.filePath = resolve(baseDir, `${this.type}_Schema.json`);
-		return fs.readJSON(this.filePath)
+		const schema = await fs.readJSON(this.filePath)
 			.catch(() => fs.outputJSONAtomic(this.filePath, this.defaultSchema).then(() => this.defaultSchema));
+		this.schema = new Schema(this.client, this, schema, null, '');
+		return this.schema;
 	}
 
 	/**

--- a/src/lib/settings/Schema.js
+++ b/src/lib/settings/Schema.js
@@ -460,7 +460,7 @@ class Schema {
 	 * Sync all shards' schemas.
 	 * @since 0.5.0
 	 * @param {(Schema|SchemaPiece)} piece The piece to send.
-	 * @param {('add'|'delete')} action Whether the piece got added or removed.
+	 * @param {('add'|'delete'|'update')} action Whether the piece got added or removed.
 	 * @param {boolean} force Whether the piece got modified with force or not.
 	 * @private
 	 */

--- a/src/lib/settings/Schema.js
+++ b/src/lib/settings/Schema.js
@@ -143,6 +143,8 @@ class Schema {
 		} else if (force) {
 			await this.force('add', key, folder);
 		}
+
+		// TODO(kyranet): Implement schemaKeyAdd event.
 		return this.manager.schema;
 	}
 
@@ -169,6 +171,8 @@ class Schema {
 		} else if (force) {
 			await this.force('delete', key, folder);
 		}
+
+		// TODO(kyranet): Implement schemaKeyRemove event.
 		return this.manager.schema;
 	}
 
@@ -218,6 +222,8 @@ class Schema {
 		} else if (force) {
 			await this.force('add', key, this[key]);
 		}
+
+		// TODO(kyranet): Implement schemaKeyAdd event.
 		return this.manager.schema;
 	}
 
@@ -262,6 +268,8 @@ class Schema {
 		} else if (force) {
 			await this.force('delete', key, schemaPiece);
 		}
+
+		// TODO(kyranet): Implement schemaKeyRemove event.
 		return this.manager.schema;
 	}
 

--- a/src/lib/settings/Schema.js
+++ b/src/lib/settings/Schema.js
@@ -457,7 +457,7 @@ class Schema {
 	}
 
 	/**
-	 * Sync this shard's schema.
+	 * Sync all shards' schemas.
 	 * @since 0.5.0
 	 * @param {(Schema|SchemaPiece)} piece The piece to send.
 	 * @param {('add'|'delete')} action Whether the piece got added or removed.

--- a/src/lib/settings/Schema.js
+++ b/src/lib/settings/Schema.js
@@ -144,7 +144,7 @@ class Schema {
 			await this.force('add', key, folder);
 		}
 
-		// TODO(kyranet): Implement schemaKeyAdd event.
+		if (this.client.listenerCount('schemaKeyAdd')) this.client.emit('schemaKeyAdd', folder);
 		return this.manager.schema;
 	}
 
@@ -172,7 +172,7 @@ class Schema {
 			await this.force('delete', key, folder);
 		}
 
-		// TODO(kyranet): Implement schemaKeyRemove event.
+		if (this.client.listenerCount('schemaKeyRemove')) this.client.emit('schemaKeyRemove', folder);
 		return this.manager.schema;
 	}
 
@@ -223,7 +223,7 @@ class Schema {
 			await this.force('add', key, this[key]);
 		}
 
-		// TODO(kyranet): Implement schemaKeyAdd event.
+		if (this.client.listenerCount('schemaKeyAdd')) this.client.emit('schemaKeyAdd', this[key]);
 		return this.manager.schema;
 	}
 
@@ -269,7 +269,7 @@ class Schema {
 			await this.force('delete', key, schemaPiece);
 		}
 
-		// TODO(kyranet): Implement schemaKeyRemove event.
+		if (this.client.listenerCount('schemaKeyRemove')) this.client.emit('schemaKeyRemove', schemaPiece);
 		return this.manager.schema;
 	}
 

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -264,6 +264,7 @@ class SchemaPiece {
 	/**
 	 * Checks if options.type is valid.
 	 * @param {string} type The parameter to validate.
+	 * @private
 	 */
 	_schemaCheckType(type) {
 		if (typeof type !== 'string') throw new TypeError(`[KEY] ${this} - Parameter type must be a string.`);
@@ -273,6 +274,7 @@ class SchemaPiece {
 	/**
 	 * Checks if options.array is valid.
 	 * @param {boolean} array The parameter to validate.
+	 * @private
 	 */
 	_schemaCheckArray(array) {
 		if (typeof array !== 'boolean') throw new TypeError(`[KEY] ${this} - Parameter array must be a boolean.`);
@@ -281,6 +283,7 @@ class SchemaPiece {
 	/**
 	 * Checks if options.default is valid.
 	 * @param {AddOptions} options The options to validate.
+	 * @private
 	 */
 	_schemaCheckDefault(options) {
 		if (options.array === true) {
@@ -298,6 +301,7 @@ class SchemaPiece {
 	 * Checks if options.min and options.max are valid.
 	 * @param {number} min The options.min parameter to validate.
 	 * @param {number} max The options.max parameter to validate.
+	 * @private
 	 */
 	_schemaCheckLimits(min, max) {
 		if (min !== null && !isNumber(min)) throw new TypeError(`[KEY] ${this} - Parameter min must be a number or null.`);
@@ -308,6 +312,7 @@ class SchemaPiece {
 	/**
 	 * Checks if options.configurable is valid.
 	 * @param {boolean} configurable The parameter to validate.
+	 * @private
 	 */
 	_schemaCheckConfigurable(configurable) {
 		if (typeof configurable !== 'boolean') throw new TypeError(`[KEY] ${this} - Parameter configurable must be a boolean.`);
@@ -317,6 +322,7 @@ class SchemaPiece {
 	 * Generate a new SQL datatype.
 	 * @param {string} [sql] The new SQL datatype.
 	 * @returns {string}
+	 * @private
 	 */
 	_generateSQLDatatype(sql) {
 		return typeof sql === 'string' ? sql : (this.type === 'integer' || this.type === 'float' ? 'INTEGER' :

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -201,9 +201,9 @@ class SchemaPiece {
 	 */
 	async modify(options) {
 		// Check if the 'options' parameter is an object.
-		const edited = new Set();
-
 		if (!isObject(options)) throw new TypeError(`SchemaPiece#modify expected an object as a parameter. Got: ${typeof options}`);
+
+		const edited = new Set();
 		if (typeof options.default !== 'undefined' && this.default !== options.default) {
 			this._schemaCheckDefault(Object.assign(this.toJSON(), options));
 			this.default = options.default;
@@ -233,7 +233,9 @@ class SchemaPiece {
 			if (this.manager.sql && this.manager.provider.updateColumn === 'function') {
 				this.manager.provider.updateColumn(this.manager.type, this.key, this._generateSQLDatatype(options.sql));
 			}
+			// TODO(kyranet): Implement force mode.
 		}
+		// TODO(kyranet): Implement schemaKeyUpdate event.
 
 		return this;
 	}
@@ -242,7 +244,7 @@ class SchemaPiece {
 	 * Check if the key is properly configured.
 	 * @since 0.5.0
 	 * @param {AddOptions} options The options to parse.
-	 * @returns {boolean}
+	 * @returns {true}
 	 * @private
 	 */
 	init(options) {

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -263,6 +263,7 @@ class SchemaPiece {
 
 	/**
 	 * Checks if options.type is valid.
+	 * @since 0.5.0
 	 * @param {string} type The parameter to validate.
 	 * @private
 	 */
@@ -273,6 +274,7 @@ class SchemaPiece {
 
 	/**
 	 * Checks if options.array is valid.
+	 * @since 0.5.0
 	 * @param {boolean} array The parameter to validate.
 	 * @private
 	 */
@@ -282,6 +284,7 @@ class SchemaPiece {
 
 	/**
 	 * Checks if options.default is valid.
+	 * @since 0.5.0
 	 * @param {AddOptions} options The options to validate.
 	 * @private
 	 */
@@ -299,6 +302,7 @@ class SchemaPiece {
 
 	/**
 	 * Checks if options.min and options.max are valid.
+	 * @since 0.5.0
 	 * @param {number} min The options.min parameter to validate.
 	 * @param {number} max The options.max parameter to validate.
 	 * @private
@@ -311,6 +315,7 @@ class SchemaPiece {
 
 	/**
 	 * Checks if options.configurable is valid.
+	 * @since 0.5.0
 	 * @param {boolean} configurable The parameter to validate.
 	 * @private
 	 */
@@ -320,6 +325,7 @@ class SchemaPiece {
 
 	/**
 	 * Generate a new SQL datatype.
+	 * @since 0.5.0
 	 * @param {string} [sql] The new SQL datatype.
 	 * @returns {string}
 	 * @private

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -253,7 +253,7 @@ class SchemaPiece {
 		if (!isObject(options)) throw new TypeError(`SchemaPiece#init expected an object as a parameter. Got: ${typeof options}`);
 		this._schemaCheckType(this.type);
 		this._schemaCheckArray(this.array);
-		this._schemaCheckDefault(this.default, this.type, this.array);
+		this._schemaCheckDefault(this);
 		this._schemaCheckLimits(this.min, this.max);
 		this._schemaCheckConfigurable(this.configurable);
 

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -233,9 +233,8 @@ class SchemaPiece {
 			if (this.manager.sql && this.manager.provider.updateColumn === 'function') {
 				this.manager.provider.updateColumn(this.manager.type, this.key, this._generateSQLDatatype(options.sql));
 			}
-			// TODO(kyranet): Implement force mode.
+			if (this.client.listenerCount('schemaKeyUpdate')) this.client.emit('schemaKeyUpdate', this);
 		}
-		// TODO(kyranet): Implement schemaKeyUpdate event.
 
 		return this;
 	}

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -204,9 +204,14 @@ class SchemaPiece {
 		if (!isObject(options)) throw new TypeError(`SchemaPiece#modify expected an object as a parameter. Got: ${typeof options}`);
 
 		const edited = new Set();
+		if (typeof options.sql === 'string' && this.sql[1] !== options.sql) {
+			this.sql[1] = options.sql;
+			edited.add('SQL');
+		}
 		if (typeof options.default !== 'undefined' && this.default !== options.default) {
 			this._schemaCheckDefault(Object.assign(this.toJSON(), options));
 			this.default = options.default;
+			if (!edited.has('SQL')) this.sql[1] = this._generateSQLDatatype(options.sql);
 			edited.add('DEFAULT');
 		}
 		if (typeof options.min !== 'undefined' && this.min !== options.min) {
@@ -223,10 +228,6 @@ class SchemaPiece {
 			this._schemaCheckConfigurable(options.configurable);
 			this.configurable = options.configurable;
 			edited.add('CONFIGURABLE');
-		}
-		if (typeof options.sql === 'string' && this.sql[1] !== options.sql) {
-			this.sql[1] = options.sql;
-			edited.add('SQL');
 		}
 		if (edited.size > 0) {
 			await fs.outputJSONAtomic(this.manager.filePath, this.manager.schema.toJSON());

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -233,6 +233,7 @@ class SchemaPiece {
 			if (this.manager.sql && this.manager.provider.updateColumn === 'function') {
 				this.manager.provider.updateColumn(this.manager.type, this.key, this._generateSQLDatatype(options.sql));
 			}
+			await this.parent._shardSyncSchema(this, 'update', false);
 			if (this.client.listenerCount('schemaKeyUpdate')) this.client.emit('schemaKeyUpdate', this);
 		}
 
@@ -333,6 +334,16 @@ class SchemaPiece {
 	_generateSQLDatatype(sql) {
 		return typeof sql === 'string' ? sql : (this.type === 'integer' || this.type === 'float' ? 'INTEGER' :
 			this.max !== null ? `VARCHAR(${this.max})` : 'TEXT') + (this.default !== null ? ` DEFAULT ${SchemaPiece._parseSQLValue(this.default)}` : '');
+	}
+
+	/**
+	 * Patch an object applying all its properties to this instance.
+	 * @since 0.5.0
+	 * @param {Object} object The object to patch.
+	 * @private
+	 */
+	_patch(object) {
+		for (const key of Object.keys(object)) this[key] = object[key];
 	}
 
 	/**

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -137,7 +137,15 @@ class SchemaPiece {
 		 */
 		this.configurable = typeof options.configurable !== 'undefined' ? options.configurable : this.type !== 'any';
 
-		this.init(options);
+		/**
+		 * The path of this SchemaPiece instance.
+		 * @since 0.5.0
+		 * @type {boolean}
+		 * @name SchemaPiece#_inited
+		 * @readonly
+		 * @private
+		 */
+		Object.defineProperty(this, '_inited', { value: this.init(options) });
 	}
 
 	/**
@@ -218,9 +226,11 @@ class SchemaPiece {
 	 * Check if the key is properly configured.
 	 * @since 0.5.0
 	 * @param {AddOptions} options The options to parse.
+	 * @returns {boolean}
 	 * @private
 	 */
 	init(options) {
+		if (this._inited) throw new TypeError(`[INIT] ${this} - Is already init. Aborting re-init.`);
 		// Check if the 'options' parameter is an object.
 		if (!isObject(options)) throw new TypeError(`SchemaPiece#init expected an object as a parameter. Got: ${typeof options}`);
 		this._schemaCheckType(this.type);
@@ -231,6 +241,8 @@ class SchemaPiece {
 
 		this.sql[1] = options.sql || ((this.type === 'integer' || this.type === 'float' ? 'INTEGER' :
 			this.max !== null ? `VARCHAR(${this.max})` : 'TEXT') + (this.default !== null ? ` DEFAULT ${SchemaPiece._parseSQLValue(this.default)}` : ''));
+
+		return true;
 	}
 
 	/**

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -107,15 +107,26 @@ class Util {
 	}
 
 	/**
+	 * Verify if the input is a function.
 	 * @since 0.5.0
-	 * @param {Function} func The function to verify.
+	 * @param {Function} input The function to verify.
 	 * @returns {boolean}
 	 */
-	static isFunction(func) {
-		return typeof func === 'function';
+	static isFunction(input) {
+		return typeof input === 'function';
 	}
 
-	/*
+	/**
+	 * Verify if the input is an object literal (or class).
+	 * @since 0.5.0
+	 * @param {Object} input The object to verify.
+	 * @returns {boolean}
+	 */
+	static isObject(input) {
+		return Object.prototype.toString.call(input) === '[object Object]';
+	}
+
+	/**
 	 * Verify if a number is a finite number.
 	 * @since 0.5.0
 	 * @param {number} input The number to verify.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -123,6 +123,11 @@ declare module 'klasa' {
 		public on(event: 'configDeleteEntry', listener: (entry: Configuration) => void): this;
 		public on(event: 'configCreateEntry', listener: (entry: Configuration) => void): this;
 
+		// Schema Events
+		public on(event: 'schemaKeyAdd', listener: (key: Schema | SchemaPiece) => void): this;
+		public on(event: 'schemaKeyRemove', listener: (key: Schema | SchemaPiece) => void): this;
+		public on(event: 'schemaKeyUpdate', listener: (key: SchemaPiece) => void): this;
+
 		// Klasa Console Custom Events
 		public on(event: 'log', listener: (data: any, type: string) => void): this;
 		public on(event: 'wtf', listener: (failure: Error) => void): this;
@@ -179,6 +184,11 @@ declare module 'klasa' {
 		public once(event: 'configUpdateEntry', listener: (oldEntry: Configuration, newEntry: Configuration, path?: string) => void): this;
 		public once(event: 'configDeleteEntry', listener: (entry: Configuration) => void): this;
 		public once(event: 'configCreateEntry', listener: (entry: Configuration) => void): this;
+
+		// Schema Events
+		public once(event: 'schemaKeyAdd', listener: (key: Schema | SchemaPiece) => void): this;
+		public once(event: 'schemaKeyRemove', listener: (key: Schema | SchemaPiece) => void): this;
+		public once(event: 'schemaKeyUpdate', listener: (key: SchemaPiece) => void): this;
 
 		// Klasa Console Custom Events
 		public once(event: 'log', listener: (data: any, type: string) => void): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -596,7 +596,7 @@ declare module 'klasa' {
 		public resolveString(msg: KlasaMessage, value: any): string;
 		public modify(options: ModifyOptions): Promise<this>;
 
-		private init(options: AddOptions): void;
+		private init(options: AddOptions): true;
 		private _schemaCheckType(type: string): void;
 		private _schemaCheckArray(array: boolean): void;
 		private _schemaCheckDefault(options: AddOptions): void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -602,6 +602,7 @@ declare module 'klasa' {
 		private _schemaCheckDefault(options: AddOptions): void;
 		private _schemaCheckLimits(min: number, max: number): void;
 		private _schemaCheckConfigurable(configurable: boolean): void;
+		private _generateSQLDatatype(sql?: string): string;
 
 		public toJSON(): SchemaPieceJSON;
 		public toString(): string;
@@ -1319,6 +1320,7 @@ declare module 'klasa' {
 		min?: number;
 		max?: number;
 		configurable?: boolean;
+		sql?: string;
 	};
 
 	export type emoji = string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -307,7 +307,9 @@ declare module 'klasa' {
 		public static applyToClass(base: Object, structure: Object, skips?: string[]): void;
 		public static exec(exec: string, options?: ExecOptions): Promise<{ stdout: string, stderr: string }>;
 		public static sleep(delay: number, args?: any): Promise<any>;
+		public static isFunction(input: Function): boolean;
 		public static isNumber(input: number): boolean;
+		public static isObject(input: Object): boolean;
 		public static tryParse(value: any): any;
 	}
 
@@ -590,9 +592,15 @@ declare module 'klasa' {
 		public configurable: boolean;
 
 		public parse(value: any, guild: KlasaGuild): Promise<any>;
-		private init(options: AddOptions): void;
-
 		public resolveString(msg: KlasaMessage, value: any): string;
+		public modify(options: ModifyOptions): Promise<this>;
+
+		private init(options: AddOptions): void;
+		private _schemaCheckType(type: string): void;
+		private _schemaCheckArray(array: boolean): void;
+		private _schemaCheckDefault(options: AddOptions): void;
+		private _schemaCheckLimits(min: number, max: number): void;
+		private _schemaCheckConfigurable(configurable: boolean): void;
 
 		public toJSON(): SchemaPieceJSON;
 		public toString(): string;
@@ -1302,6 +1310,13 @@ declare module 'klasa' {
 		max?: number;
 		array?: boolean;
 		sql?: string;
+		configurable?: boolean;
+	};
+
+	export type ModifyOptions = {
+		default?: any;
+		min?: number;
+		max?: number;
 		configurable?: boolean;
 	};
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -590,6 +590,7 @@ declare module 'klasa' {
 		public max?: number;
 		public sql: [string, string];
 		public configurable: boolean;
+		private readonly _inited: boolean;
 
 		public parse(value: any, guild: KlasaGuild): Promise<any>;
 		public resolveString(msg: KlasaMessage, value: any): string;


### PR DESCRIPTION
### Description of the PR
This PR adds a very requested feature: hability to change SchemaPiece's properties.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added `isObject` method to `Util`.
- Added `SchemaPiece#modify`, allowing users to modify a SP's options.
- Added the events `schemaKeyAdd`, `schemaKeyRemove` and `schemaKeyUpdate`.
- Fixed some issues that ESLint did not report, resulting on critical failures.
- Improved object check for `Message#sendMessage` and `Message#send` to have a proper object check. 

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
