### PR TITLE
Removed moment.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#116](https://github.com/dirigeants/klasa/pull/116)] Added the Timestamp class to replace `moment.js`. (kyranet)
 - [[#113](https://github.com/dirigeants/klasa/pull/113)] Added disableNaturalPrefix. (kyranet)
 - [[`550ac275c8`](https://github.com/dirigeants/klasa/commit/550ac275c849c285692ffff5c4e99cb53753a85b) ([#109](https://github.com/dirigeants/klasa/pull/109)) Added the keys `COMMAND_EVAL_DESCRIPTION`, `COMMAND_UNLOAD_DESCRIPTION`, `COMMAND_TRANSFER_DESCRIPTION`, `COMMAND_RELOAD_DESCRIPTION`, `COMMAND_REBOOT_DESCRIPTION`, `COMMAND_PING_DESCRIPTION`, `COMMAND_INVITE_DESCRIPTION`, `COMMAND_INFO_DESCRIPTION`, `COMMAND_ENABLE_DESCRIPTION`, `COMMAND_DISABLE_DESCRIPTION`, `COMMAND_CONF_SERVER_DESCRIPTION`, `COMMAND_CONF_SERVER`, `COMMAND_CONF_USER_DESCRIPTION`, `COMMAND_CONF_USER`, `COMMAND_STATS` and `COMMAND_STATS_DESCRIPTION` to the en-US language. (Pandraghon)
 - [[`6f16689144`](https://github.com/dirigeants/klasa/commit/6f1668914401bfa8d3e08f81594e5eedd514ccce) ([#104](https://github.com/dirigeants/klasa/pull/104)) Added `regexPrefix` as an option for `KlasaClientOptions`. (MrJacz)
@@ -61,6 +62,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#116](https://github.com/dirigeants/klasa/pull/116)] Removed `moment.js` from the dependency list. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Removed a bunch of extendables. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) **[PERF]** Removed `CommandMessage` proxy in favor of the brand new `KlasaMessage`. As in *Node.js 9.2.0*, Proxy creation performs 37M ops/sec, and property access 1.7M ops/sec (all pieces after Inhibitors use that proxy). As it's now removed, property access should perform around 520M ops/sec (~305 times faster). (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Removed the `messageDelete` event. (kyranet)

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "docs": "npx jsdoc -c ./.docstrap.json -R README.md"
   },
   "dependencies": {
-    "fs-nextra": "^0.3.2",
-    "moment": "^2.19.3"
+    "fs-nextra": "^0.3.2"
   },
   "peerDependencies": {
     "discord.js": "github:hydrabolt/discord.js#master"
   },
   "devDependencies": {
-    "eslint": "^4.12.1",
+    "@types/node": "8.0.57",
+    "eslint": "^4.13.0",
     "ink-docstrap": "github:bdistin/docstrap#klasa",
     "jsdoc": "github:jsdoc3/jsdoc",
     "markdownlint-cli": "^0.5.0",

--- a/src/commands/General/Chat Bot Info/stats.js
+++ b/src/commands/General/Chat Bot Info/stats.js
@@ -1,6 +1,5 @@
-const { Command, version: klasaVersion } = require('klasa');
+const { Command, version: klasaVersion, Timestamp } = require('klasa');
 const { version: discordVersion } = require('discord.js');
-const moment = require('moment');
 
 module.exports = class extends Command {
 
@@ -14,7 +13,7 @@ module.exports = class extends Command {
 	async run(msg) {
 		return msg.sendCode('asciidoc', msg.language.get('COMMAND_STATS',
 			(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2),
-			moment(Date.now() - (process.uptime() * 1000)).toNow(true),
+			Timestamp.toNow(Date.now() - (process.uptime() * 1000), true),
 			this.client.users.size.toLocaleString(),
 			this.client.guilds.size.toLocaleString(),
 			this.client.channels.size.toLocaleString(),

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ module.exports = {
 	RichMenu: require('./lib/util/RichMenu'),
 	ReactionHandler: require('./lib/util/ReactionHandler'),
 	Stopwatch: require('./lib/util/Stopwatch'),
+	Timestamp: require('./lib/util/Timestamp'),
 	Command: require('./lib/structures/Command'),
 	Event: require('./lib/structures/Event'),
 	Extendable: require('./lib/structures/Extendable'),

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -55,7 +55,7 @@ class KlasaClient extends Discord.Client {
 	 * @property {WriteableStream} [stderr=process.stderr] Error stream
 	 * @property {boolean} [useColor=false] Whether the client console should use colors
 	 * @property {Colors} [colors] Color formats to use
-	 * @property {(boolean|string)} [timestamps=true] Whether to use timestamps or not, or the moment format of the timestamp you want to use
+	 * @property {(boolean|string)} [timestamps=true] Whether to use timestamps or not, or the Timestamp format of the timestamp you want to use
 	 */
 
 	/**

--- a/src/lib/util/Console.js
+++ b/src/lib/util/Console.js
@@ -1,6 +1,6 @@
 const { Console } = require('console');
 const Colors = require('./Colors');
-const moment = require('moment');
+const Timestamp = require('./Timestamp');
 const { inspect } = require('util');
 
 /**
@@ -134,10 +134,10 @@ class KlasaConsole extends Console {
 
 		/**
 		 * Whether or not timestamps should be enabled for this console.
-		 * @since 0.4.0
-		 * @type {(boolean|string)}
+		 * @since 0.5.0
+		 * @type {Timestamp}
 		 */
-		this.timestamps = timestamps === true ? 'YYYY-MM-DD HH:mm:ss' : timestamps;
+		this.template = timestamps !== false ? new Timestamp(timestamps === true ? 'YYYY-MM-DD HH:mm:ss' : timestamps) : null;
 
 		/**
 		 * Whether or not this console should use colors.
@@ -198,7 +198,7 @@ class KlasaConsole extends Console {
 		const color = this.colors[type.toLowerCase()] || {};
 		const message = color.message || {};
 		const time = color.time || {};
-		const timestamp = this.timestamps ? `${this.timestamp(`[${moment().format(this.timestamps)}]`, time)} ` : '';
+		const timestamp = this.template ? `${this.template.display(time)} ` : '';
 		super[color.type || 'log'](data.split('\n').map(str => `${timestamp}${this.messages(str, message)}`).join('\n'));
 	}
 

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -1,0 +1,211 @@
+const SECOND = 1000;
+const MINUTE = SECOND * 60;
+const HOUR = MINUTE * 60;
+const DAY = HOUR * 24;
+
+/* eslint-disable id-length, complexity */
+const TOKENS = {
+	Y: 4,
+	Q: 1,
+	M: 4,
+	D: 4,
+	d: 1,
+	X: 1,
+	x: 1,
+	H: 2,
+	h: 2,
+	a: 1,
+	A: 1,
+	m: 2,
+	s: 2,
+	S: 3,
+	Z: 2
+};
+/* eslint-enable id-length */
+
+const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+/**
+ * Klasa's Timestamp class, parses the pattern once, displays the desired Date or UNIX timestamp with the selected pattern.
+ */
+class Timestamp {
+
+	/**
+	 * @typedef  {Object} TimestampObject
+	 * @property {string} type The type of the current variable.
+	 * @property {string} [content] The content of the type. Only accessible if the type is 'literal'.
+	 */
+
+	/**
+	 * Starts a new Timestamp and parses the pattern.
+	 * @since 0.5.0
+	 * @param {string} pattern The pattern to parse.
+	 */
+	constructor(pattern) {
+		/**
+		 * @since 0.5.0
+		 * @type {string}
+		 */
+		this.pattern = pattern;
+		/**
+		 * @since 0.5.0
+		 * @type {TimestampObject[]}
+		 * @private
+		 */
+		this._template = [];
+		this._patch(pattern);
+	}
+
+	/**
+	 * Display the current date with the current pattern.
+	 * @since 0.5.0
+	 * @param {(Date|number|string)} time The time to display.
+	 * @returns {string}
+	 */
+	display(time = Date.now()) {
+		let output = '';
+		const parsedTime = time instanceof Date ? time : new Date(time);
+		for (const entry of this._template) {
+			output += entry.content || this._parse(entry.type, parsedTime);
+		}
+		return output;
+	}
+
+	/**
+	 * Edits the current pattern.
+	 * @since 0.5.0
+	 * @param {string} pattern The new pattern for this instance.
+	 * @returns {Timestamp}
+	 */
+	edit(pattern) {
+		this.pattern = pattern;
+		this._template = [];
+		this._patch(pattern);
+		return this;
+	}
+
+	/**
+	 * Parses the current variable.
+	 * @since 0.5.0
+	 * @param {string} type The type of variable
+	 * @param {Date} time The current time.
+	 * @returns {string}
+	 * @private
+	 */
+	_parse(type, time) {
+		switch (type) {
+			// Dates
+			case 'Y':
+			case 'YY': return String(time.getFullYear()).slice(0, 2);
+			case 'YYY':
+			case 'YYYY': return String(time.getFullYear());
+			case 'Q': return String((time.getMonth() + 1) / 3);
+			case 'M':
+			case 'MM': return String(time.getMonth() + 1);
+			case 'MMM':
+			case 'MMMM': return months[time.getMonth()];
+			case 'D': return String(time.getDate());
+			case 'DD': return String(time.getDate()).padStart(2, '0');
+			case 'DDD':
+			case 'DDDD': {
+				const start = new Date(time.getFullYear(), 0, 0);
+				const diff = ((time.getMilliseconds() - start.getMilliseconds()) + (start.getTimezoneOffset() - time.getTimezoneOffset())) * MINUTE;
+				return String(Math.floor(diff / DAY));
+			}
+			case 'd': {
+				const day = String(time.getDate());
+				if (day.endsWith('1')) return `${day}st`;
+				if (day.endsWith('2')) return `${day}nd`;
+				if (day.endsWith('3')) return `${day}rd`;
+				return `${day}th`;
+			}
+			case 'X': return String(time.valueOf() / SECOND);
+			case 'x': return String(time.valueOf());
+
+			// Times
+			case 'H': return String(time.getHours());
+			case 'HH': return String(time.getHours()).padStart(2, '0');
+			case 'h': return String(time.getHours() % 12);
+			case 'hh': return String(time.getHours() % 12).padStart(2, '0');
+			case 'a': return time.getHours() < 12 ? 'am' : 'pm';
+			case 'A': return time.getHours() < 12 ? 'AM' : 'PM';
+			case 'm': return String(time.getMinutes());
+			case 'mm': return String(time.getMinutes()).padStart(2, '0');
+			case 's': return String(time.getSeconds());
+			case 'ss': return String(time.getSeconds()).padStart(2, '0');
+			case 'S': return String(time.getMilliseconds());
+			case 'SS': return String(time.getMilliseconds()).padStart(2, '0');
+			case 'SSS': return String(time.getMilliseconds()).padStart(3, '0');
+			case 'Z':
+			case 'ZZ': {
+				const offset = time.getTimezoneOffset();
+				return `${offset >= 0 ? '+' : '-'}${String(offset / -60).padStart(2, '0')}:${String(offset % 60).padStart(2, '0')}`;
+			}
+			default: return type;
+		}
+	}
+
+	/**
+	 * Parses the pattern.
+	 * @since 0.5.0
+	 * @param {string} pattern The pattern to parse.
+	 * @private
+	 */
+	_patch(pattern) {
+		for (let i = 0; i < pattern.length; i++) {
+			let current = '';
+			const currentChar = pattern[i];
+			if (currentChar in TOKENS) {
+				current += currentChar;
+				while (pattern[i + 1] === currentChar && current.length < TOKENS[currentChar]) current += pattern[++i];
+				this._template.push({ type: current });
+			} else if (currentChar === '[') {
+				while (i + 1 < pattern.length && pattern[i + 1] !== ']') current += pattern[++i];
+				i++;
+				this._template.push({ type: 'literal', content: current });
+			} else {
+				current += currentChar;
+				while (i + 1 < pattern.length && !(pattern[i + 1] in TOKENS)) current += pattern[++i];
+				this._template.push({ type: 'literal', content: current });
+			}
+		}
+	}
+
+	/**
+	 * Shows the userfriendly duration of time between a period and now.
+	 * @param {(Date|number|string)} earlier The time to compare.
+	 * @param {*} showIn Whether the output should be prefixed.
+	 * @returns {string};
+	 */
+	static toNow(earlier, showIn) {
+		if (!(earlier instanceof Date)) earlier = new Date(earlier);
+		const returnString = showIn ? 'in ' : '';
+		let duration = (Date.now() - earlier) / 1000;
+
+		// Compare the duration in seconds
+		if (duration < 45) return `${returnString}seconds`;
+		else if (duration < 90) return `${returnString}a minute`;
+
+		// Compare the duration in minutes
+		duration /= 60;
+		if (duration < 45) return `${returnString + Math.round(duration)} minutes`;
+		else if (duration < 90) return `${returnString}an hour`;
+
+		// Compare the duration in hours
+		duration /= 60;
+		if (duration < 22) return `${returnString + Math.round(duration)} hours`;
+		else if (duration < 36) return `${returnString}a day`;
+
+		// Compare the duration in days
+		duration /= 24;
+		if (duration < 26) return `${returnString + Math.round(duration)} days`;
+		else if (duration < 46) return `${returnString}a month`;
+		else if (duration < 320) return `${returnString + Math.round(duration / 30)} months`;
+		else if (duration < 548) return `${returnString}a year`;
+
+		return `${returnString + Math.floor(duration / 365)} years`;
+	}
+
+}
+
+module.exports = Timestamp;

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -173,9 +173,10 @@ class Timestamp {
 
 	/**
 	 * Shows the userfriendly duration of time between a period and now.
+	 * @since 0.5.0
 	 * @param {(Date|number|string)} earlier The time to compare.
-	 * @param {*} showIn Whether the output should be prefixed.
-	 * @returns {string};
+	 * @param {boolean} [showIn] Whether the output should be prefixed.
+	 * @returns {string}
 	 */
 	static toNow(earlier, showIn) {
 		if (!(earlier instanceof Date)) earlier = new Date(earlier);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -699,6 +699,8 @@ declare module 'klasa' {
 		public static flatten(data: any, useColors: boolean): string;
 	}
 
+	export { KlasaConsole as Console };
+
 	export class Stopwatch {
 		public constructor(digits?: number);
 		private _start: number;
@@ -715,7 +717,19 @@ declare module 'klasa' {
 		public toString(): string;
 	}
 
-	export { KlasaConsole as Console };
+	export class Timestamp {
+		public constructor(pattern: string);
+		public pattern: string;
+		private _template: TimestampObject[];
+
+		public display(time: Date | number | string): string;
+		public edit(pattern: string): this;
+
+		private _parse(type: string, time: Date): string;
+		private _patch(pattern: string): void;
+
+		static toNow(earlier: Date | number | string, showIn?: boolean): string;
+	}
 
 	// Structures
 	export class Piece {
@@ -1226,6 +1240,11 @@ declare module 'klasa' {
 		debug?: boolean;
 		verbose?: boolean;
 		wtf?: boolean;
+	};
+
+	export type TimestampObject = {
+		type: string;
+		content?: string;
 	};
 
 	export type PermissionLevel = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -728,7 +728,7 @@ declare module 'klasa' {
 		private _parse(type: string, time: Date): string;
 		private _patch(pattern: string): void;
 
-		static toNow(earlier: Date | number | string, showIn?: boolean): string;
+		public static toNow(earlier: Date | number | string, showIn?: boolean): string;
 	}
 
 	// Structures

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -681,7 +681,7 @@ declare module 'klasa' {
 		public constructor(options: KlasaConsoleConfig);
 		public readonly stdout: NodeJS.WritableStream;
 		public readonly stderr: NodeJS.WritableStream;
-		public timestaamps: boolean | string;
+		public template?: Timestamp;
 		public useColors: boolean;
 		public colors: KlasaConsoleColorsOption;
 


### PR DESCRIPTION
### Description of the PR
Closes #89 by replacing `moment.js` with a way much more performant class: `Timestamp`.
The patterns from `Timestamp` is very similar to `moment.js`, only major diference is that `Do` gets replaced to `d`/`dd`.

The `Timestamp` class pattern parser checks if a character is a variable (if it's not wrapped into the literal tags `[` and `]`) and appends them as much times as they're valid. For example the token `Y` can be repeated up to 4 times (`Y`/`YY`/`YYY`/`YYYY`) but the token `m` can be repeated only twice.

Another perk of `Timestamp` is that it parses the pattern only once instead of parsing it on the fly, allowing its performance to be over 29 times faster compared to `moment.js` in simple patterns, and it will not fail a build nor is [ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) (Regular Expression Denial of Service) vulnerable (we're not using RegExp for the pattern parsing and validating).

Said parser isn't enormous: it's just **18 lines of code long**. (Thanks to @bdistin for optimizing the original version).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added the Timestamp class to replace `moment.js`.
- Removed `moment.js` from the dependency list.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
