### PR TITLE
SQL parser tweaks for SG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
-- [[#117](https://github.com/dirigeants/klasa/pull/117)] Now, if you edit the prefix value in `KlasaClientOptions`, the changes will be reflected in the schema. (kyranet)
+- [[#118](https://github.com/dirigeants/klasa/pull/118)] Now, if you edit the prefix value in `KlasaClientOptions`, the changes will be reflected in the schema. (kyranet)
 - [[#116](https://github.com/dirigeants/klasa/pull/116)] Added the Timestamp class to replace `moment.js`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Added the events `schemaKeyAdd`, `schemaKeyRemove` and `schemaKeyUpdate`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Added `isObject` method to `Util`. (kyranet)
@@ -80,8 +80,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
-- [[#117](https://github.com/dirigeants/klasa/pull/117)] Fixed `SchemaPiece#modify` not editing the datatype from the SQL database when using a SQL provider. (kyranet)
-- [[#117](https://github.com/dirigeants/klasa/pull/117)] Fixed `NULL` not being resolved correctly in `_parseSQLValue` (kyranet)
+- [[#118](https://github.com/dirigeants/klasa/pull/118)] Fixed `SchemaPiece#modify` not editing the datatype from the SQL database when using a SQL provider. (kyranet)
+- [[#118](https://github.com/dirigeants/klasa/pull/118)] Fixed `NULL` not being resolved correctly in `_parseSQLValue` (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed Schema's updates not reflecting in other shards. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed some issues from ESLint's betrayal. (MrJacz with kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Improved object check for `Message#sendMessage` and `Message#send`. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#117](https://github.com/dirigeants/klasa/pull/117)] Now, if you edit the prefix value in `KlasaClientOptions`, the changes will be reflected in the schema. (kyranet)
 - [[#116](https://github.com/dirigeants/klasa/pull/116)] Added the Timestamp class to replace `moment.js`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Added the events `schemaKeyAdd`, `schemaKeyRemove` and `schemaKeyUpdate`. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Added `isObject` method to `Util`. (kyranet)
@@ -79,6 +80,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#117](https://github.com/dirigeants/klasa/pull/117)] Fixed `SchemaPiece#modify` not editing the datatype from the SQL database when using a SQL provider. (kyranet)
+- [[#117](https://github.com/dirigeants/klasa/pull/117)] Fixed `NULL` not being resolved correctly in `_parseSQLValue` (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed Schema's updates not reflecting in other shards. (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed some issues from ESLint's betrayal. (MrJacz with kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Improved object check for `Message#sendMessage` and `Message#send`. (kyranet)

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -365,6 +365,12 @@ class KlasaClient extends Discord.Client {
 		await this.providers.init();
 		await this.gateways.add('guilds', this.gateways.validateGuild, this.gateways.defaultDataSchema, undefined, false);
 		await this.gateways.add('users', this.gateways.validateUser, undefined, undefined, false);
+
+		// Automatic Prefix editing detection.
+		if (typeof this.configs.prefix === 'string' && this.configs.prefix !== this.gateways.guilds.prefix.default) {
+			await this.gateways.guilds.prefix.modify({ default: this.configs.prefix });
+		}
+
 		this.emit('log', `Loaded in ${timer.stop()}.`);
 		return super.login(token);
 	}

--- a/src/lib/settings/GatewaySQL.js
+++ b/src/lib/settings/GatewaySQL.js
@@ -73,8 +73,9 @@ class GatewaySQL extends Gateway {
 	static _parseSQLValue(value, schemaPiece) {
 		if (typeof value !== 'undefined') {
 			if (schemaPiece.array) {
+				if (value === null) return schemaPiece.default.slice(0);
 				if (typeof value === 'string') value = tryParse(value);
-				if (Array.isArray(value)) value.map(val => GatewaySQL.parseSQLValue(val, schemaPiece));
+				if (Array.isArray(value)) value = value.map(val => GatewaySQL.parseSQLValue(val, schemaPiece));
 				return value;
 			}
 			if (schemaPiece.type === 'any') {
@@ -86,7 +87,12 @@ class GatewaySQL extends Gateway {
 				if (typeof value === 'boolean') return value;
 				if (typeof value === 'number') return value === 1;
 				if (typeof value === 'string') return value === 'true';
+			} else if (schemaPiece.type === 'string') {
+				if (typeof value === 'string' && /^\s|\s$/.test(value)) return value.trim();
+				return value;
 			}
+
+			return value;
 		}
 		return schemaPiece.array ? schemaPiece.default.slice(0) : schemaPiece.default;
 	}

--- a/src/lib/settings/GatewaySQL.js
+++ b/src/lib/settings/GatewaySQL.js
@@ -75,7 +75,7 @@ class GatewaySQL extends Gateway {
 			if (schemaPiece.array) {
 				if (value === null) return schemaPiece.default.slice(0);
 				if (typeof value === 'string') value = tryParse(value);
-				if (Array.isArray(value)) value = value.map(val => GatewaySQL.parseSQLValue(val, schemaPiece));
+				if (Array.isArray(value)) value = value.map(val => GatewaySQL._parseSQLValue(val, schemaPiece));
 				return value;
 			}
 			if (schemaPiece.type === 'any') {

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -207,6 +207,7 @@ class SchemaPiece {
 		if (typeof options.sql === 'string' && this.sql[1] !== options.sql) {
 			this.sql[1] = options.sql;
 			edited.add('SQL');
+			if (this.manager.sql) await this.manager.provider.updateColumn(this.manager.type, this.path, options.sql);
 		}
 		if (typeof options.default !== 'undefined' && this.default !== options.default) {
 			this._schemaCheckDefault(Object.assign(this.toJSON(), options));


### PR DESCRIPTION
### Description of the PR
Sometimes, when using SQL, we can't use `TEXT NOT NULL DEFAULT '[]'` to store a stringified array (MySQL) so we use `VARCHAR()` (limited length) or `TEXT` (incredibly long text), the latter defaulting to `NULL`. In this case, we should ensure that if `SchemaPiece#array` is `true`, then the value from the cache must be an array aswell: converting `NULL` into the default array value.

There's also another detail we missed in #115: we can update the SQL datatype, but said change was not being reflected in the database.

And last thing, this PR implements a feature that has been wanted for so long: **prefix default updating**. When you change the value of `prefix` in your `KlasaClientOptions`, it used to do nothing as SG was getting the default value from the schema file. Now it'll change the default value (if it's a string) automatically at startup.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Editing the prefix value in `KlasaClientOptions`, the changes will be reflected in the schema.
- Fixed `SchemaPiece#modify` not editing the datatype from the SQL database when using a SQL provider.
- Fixed `NULL` not being resolved correctly in `_parseSQLValue`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
