### PR TITLE
Make the <ReactionHandler>.prompt translatable

### DIFF
--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -32,6 +32,7 @@ module.exports = class extends Language {
 			RESOLVER_MINMAX_BOTH: (name, min, max, suffix) => `${name} must be between ${min} and ${max}${suffix}.`,
 			RESOLVER_MINMAX_MIN: (name, min, suffix) => `${name} must be greater than ${min}${suffix}.`,
 			RESOLVER_MINMAX_MAX: (name, max, suffix) => `${name} must be less than ${max}${suffix}.`,
+			REACTIONHANDLER_PROMPT: 'Which page would you like to jump to?',
 			COMMANDMESSAGE_MISSING: 'Missing one or more required arguments after end of input.',
 			COMMANDMESSAGE_MISSING_REQUIRED: (name) => `${name} is a required argument.`,
 			COMMANDMESSAGE_MISSING_OPTIONALS: (possibles) => `Missing a required option: (${possibles})`,

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -18,7 +18,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @memberof RichMenu
 	 * @property {Function} [filter] A filter function to add to the ReactionHandler
 	 * @property {boolean} [stop = true] If a stop reaction should be included
-	 * @property {string} [prompt = 'Which page would you like to jump to?'] The prompt to be used when awaiting user input on a page to jump to
+	 * @property {string} [prompt = msg.language.get('REACTIONHANDLER_PROMPT')] The prompt to be used when awaiting user input on a page to jump to
 	 * @property {number} [startPage = 0] The page to start the RichMenu on
 	 * @property {number} [max] The maximum total amount of reactions to collect
 	 * @property {number} [maxEmojis] The maximum number of emojis to collect
@@ -64,7 +64,7 @@ class ReactionHandler extends ReactionCollector {
 		 * @since 0.4.0
 		 * @type {string}
 		 */
-		this.prompt = this.options.prompt || 'Which page would you like to jump to?';
+		this.prompt = this.options.prompt || msg.language.get('REACTIONHANDLER_PROMPT');
 
 		/**
 		 * The time until the reaction collector closes automatically

--- a/src/lib/util/RichDisplay.js
+++ b/src/lib/util/RichDisplay.js
@@ -31,7 +31,7 @@ class RichDisplay {
 	 * @property {boolean} [stop = true] If a stop reaction should be included
 	 * @property {boolean} [jump = true] If a jump reaction should be included
 	 * @property {boolean} [firstLast = true] If a first and last reaction should be included
-	 * @property {string} [prompt = 'Which page would you like to jump to?'] The prompt to be used when awaiting user input on a page to jump to
+	 * @property {string} [prompt = msg.language.get('REACTIONHANDLER_PROMPT')] The prompt to be used when awaiting user input on a page to jump to
 	 * @property {number} [startPage = 0] The page to start the RichDisplay on
 	 * @property {number} [max] The maximum total amount of reactions to collect
 	 * @property {number} [maxEmojis] The maximum number of emojis to collect

--- a/src/lib/util/RichMenu.js
+++ b/src/lib/util/RichMenu.js
@@ -47,7 +47,7 @@ class RichMenu extends RichDisplay {
 	 * @memberof RichMenu
 	 * @property {Function} [filter] A filter function to add to the ReactionHandler (Recieves: Reaction, User)
 	 * @property {boolean} [stop = true] If a stop reaction should be included
-	 * @property {string} [prompt = 'Which page would you like to jump to?'] The prompt to be used when awaiting user input on a page to jump to
+	 * @property {string} [prompt = msg.language.get('REACTIONHANDLER_PROMPT')] The prompt to be used when awaiting user input on a page to jump to
 	 * @property {number} [startPage = 0] The page to start the RichMenu on
 	 * @property {number} [max] The maximum total amount of reactions to collect
 	 * @property {number} [maxEmojis] The maximum number of emojis to collect


### PR DESCRIPTION
### Description of the PR
Make the <ReactionHandler>.prompt translatable

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added the language key REACTIONHANDLER_PROMPT

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
