### PR TITLE
Added KlasaMessage#reply due to message editing and fixed promptTime …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Added `Provider.cache`. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Added GatewaySQL (extends Gateway, overriding the methods for better SQL parsing). (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Added `Gateway#insertEntry`, which inserts a new `Configuration` entry to the cache and sync if possible. (kyranet)
+- [[#126](https://github.com/dirigeants/klasa/pull/126)] Added `KlasaMessage#reply` due to message editing (MrJacz)
 
 ### Changed
 
@@ -102,6 +103,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Fixed multiple minor issues. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Store loader not showing error stack. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) JSON provider loading files that are not JSON. (kyranet)
+- [[#126](https://github.com/dirigeants/klasa/pull/126)] promptTime spelling mistake in Constants (MrJacz)
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#126](https://github.com/dirigeants/klasa/pull/126)] Added `KlasaMessage#reply` due to message editing (MrJacz)
 - [[#121](https://github.com/dirigeants/klasa/pull/121)] Added `constants` and `Util.mergeDefault` (bdistin) added `Util.isClass` (kyranet)
 - [[#121](https://github.com/dirigeants/klasa/pull/121)] Added `GatewayStorage`, containing `SettingGateway`'s core (kyranet)
 - [[#121](https://github.com/dirigeants/klasa/pull/121)] Added a new gateway called `clientStorage`, for client-wide configs (kyranet)
@@ -40,7 +41,6 @@ NOTE: For the contributors, you add new entries to this document following this 
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Added `Provider.cache`. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Added GatewaySQL (extends Gateway, overriding the methods for better SQL parsing). (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Added `Gateway#insertEntry`, which inserts a new `Configuration` entry to the cache and sync if possible. (kyranet)
-- [[#126](https://github.com/dirigeants/klasa/pull/126)] Added `KlasaMessage#reply` due to message editing (MrJacz)
 
 ### Changed
 
@@ -87,6 +87,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#126](https://github.com/dirigeants/klasa/pull/126)] promptTime spelling mistake in Constants (MrJacz)
 - [[#118](https://github.com/dirigeants/klasa/pull/118)] Fixed `SchemaPiece#modify` not editing the datatype from the SQL database when using a SQL provider. (kyranet)
 - [[#118](https://github.com/dirigeants/klasa/pull/118)] Fixed `NULL` not being resolved correctly in `_parseSQLValue` (kyranet)
 - [[#115](https://github.com/dirigeants/klasa/pull/115)] Fixed Schema's updates not reflecting in other shards. (kyranet)
@@ -103,7 +104,6 @@ NOTE: For the contributors, you add new entries to this document following this 
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Fixed multiple minor issues. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Store loader not showing error stack. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) JSON provider loading files that are not JSON. (kyranet)
-- [[#126](https://github.com/dirigeants/klasa/pull/126)] promptTime spelling mistake in Constants (MrJacz)
 
 ## 0.4.0
 

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -277,6 +277,23 @@ module.exports = Structures.extend('Message', Message => {
 		}
 
 		/**
+		 * Replies to the message that will be editable via command editing (if nothing is attached)
+		 * @since 0.0.1
+		 * @param {StringResolvable} [content] The content to send
+		 * @param {MessageOptions} [options] The D.JS message options
+		 * @returns {Promise<KlasaMessage|KlasaMessage[]>}
+		 */
+		reply(content, options) {
+			if (!options && typeof content === 'object' && !(content instanceof Array)) {
+				options = content;
+				content = '';
+			} else if (!options) {
+				options = {};
+			}
+			return this.sendMessage(content, Object.assign(options, { reply: this.member || this.author }));
+		}
+
+		/**
 		 * Validates and resolves args into parameters
 		 * @since 0.0.1
 		 * @private

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -192,7 +192,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @returns {Promise<KlasaMessage|KlasaMessage[]>}
 		 */
 		sendMessage(content, options) {
-			if (!options && isObject(options)) {
+			if (!options && isObject(content)) {
 				options = content;
 				content = '';
 			} else if (!options) {
@@ -244,7 +244,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @returns {Promise<KlasaMessage|KlasaMessage[]>}
 		 */
 		sendEmbed(embed, content, options) {
-			if (!options && isObject(options)) {
+			if (!options && isObject(content)) {
 				options = content;
 				content = '';
 			} else if (!options) {
@@ -284,7 +284,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @returns {Promise<KlasaMessage|KlasaMessage[]>}
 		 */
 		reply(content, options) {
-			if (!options && typeof content === 'object' && !(content instanceof Array)) {
+			if (!options && isObject(content)) {
 				options = content;
 				content = '';
 			} else if (!options) {

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -16,7 +16,7 @@ exports.DEFAULTS = {
 			wtf: true
 		},
 		language: 'en-US',
-		prompTime: 30000,
+		promptTime: 30000,
 		ignoreBots: true,
 		ignoreSelf: true,
 		cmdPrompt: false,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -235,7 +235,8 @@ declare module 'klasa' {
 		public sendEmbed(embed: MessageEmbed, content?: StringResolvable, options?: MessageOptions): Promise<KlasaMessage | KlasaMessage[]>;
 		public sendCode(lang: string, content: StringResolvable, options?: MessageOptions): Promise<KlasaMessage | KlasaMessage[]>;
 		public send(content?: StringResolvable, options?: MessageOptions | MessageAttachment | MessageEmbed): Promise<KlasaMessage | KlasaMessage[]>;
-
+		public reply(content?: StringResolvable, options?: MessageOptions | MessageAttachment | MessageEmbed): Promise<KlasaMessage | KlasaMessage[]>;
+		
 		private validateArgs(): Promise<any[]>;
 		private multiPossibles(possible: number, validated: boolean): Promise<any[]>;
 		private static getArgs(msg: KlasaMessage): string[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -236,7 +236,7 @@ declare module 'klasa' {
 		public sendCode(lang: string, content: StringResolvable, options?: MessageOptions): Promise<KlasaMessage | KlasaMessage[]>;
 		public send(content?: StringResolvable, options?: MessageOptions | MessageAttachment | MessageEmbed): Promise<KlasaMessage | KlasaMessage[]>;
 		public reply(content?: StringResolvable, options?: MessageOptions | MessageAttachment | MessageEmbed): Promise<KlasaMessage | KlasaMessage[]>;
-		
+
 		private validateArgs(): Promise<any[]>;
 		private multiPossibles(possible: number, validated: boolean): Promise<any[]>;
 		private static getArgs(msg: KlasaMessage): string[];


### PR DESCRIPTION
### Description of the PR
Extends Discord.js#Message#Reply due to message editing and fixes the spelling mistake for promptTime in Constants

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)
KlasaMessage#reply
promtTime spelling mistake
-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
