### PR TITLE
Added monitorError event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
-- [[#126](https://github.com/dirigeants/klasa/pull/126)] Added the `monitorError` event. (kyranet)
+- [[#128](https://github.com/dirigeants/klasa/pull/128)] Added the `monitorError` event. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added the default gateways to `GatewayDriver` defaulted by null to reflect in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added `Schema` (the previous got renamed to `SchemaFolder`), reducing duplicated code and bringing more code consistency. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added a private tool that ensures the `content` and `options` in `Message#sendMessage` and aliases are processed correctly while also reducing duplicated code. (kyranet w/ bdistin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#126](https://github.com/dirigeants/klasa/pull/126)] Added the `monitorError` event. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added the default gateways to `GatewayDriver` defaulted by null to reflect in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added `Schema` (the previous got renamed to `SchemaFolder`), reducing duplicated code and bringing more code consistency. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added a private tool that ensures the `content` and `options` in `Message#sendMessage` and aliases are processed correctly while also reducing duplicated code. (kyranet w/ bdistin)

--- a/src/events/monitorError.js
+++ b/src/events/monitorError.js
@@ -1,0 +1,9 @@
+const { Event } = require('klasa');
+
+module.exports = class extends Event {
+
+	run(msg, command, params, error) {
+		if (error) this.client.emit('wtf', error.stack ? error.stack : error);
+	}
+
+};

--- a/src/events/monitorError.js
+++ b/src/events/monitorError.js
@@ -1,9 +1,11 @@
 const { Event } = require('klasa');
+const { join } = require('path');
 
 module.exports = class extends Event {
 
-	run(msg, command, params, error) {
-		if (error) this.client.emit('wtf', error.stack ? error.stack : error);
+	run(msg, monitor, error) {
+		this.client.emit('wtf', `[MONITOR] ${join(monitor.dir, monitor.file)}\n${error ?
+			error.stack ? error.stack : error : 'Unknown error'}`);
 	}
 
 };


### PR DESCRIPTION
### Description of the PR

This PR adds the monitorEvent as requested by @bdistin to catch all errors emitted from monitors.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added the `monitorError` event.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
