### PR TITLE
The Age of Configuration#update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#129](https://github.com/dirigeants/klasa/pull/129)] Fixed identifiers not being resolved correctly when using `Configuration#update`. (kyranet)
 - [[#129](https://github.com/dirigeants/klasa/pull/129)] Fixed both config commands not removing the entries. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Fixed many typos in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Fixed `MessageOptions` not being correctly handled with `StringResolvable`, resulting on code like `msg.send({ embed });` to fail. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#129](https://github.com/dirigeants/klasa/pull/129)] Added `Util#makeObject` to make objects given a path and a value. (kyranet)
+- [[#129](https://github.com/dirigeants/klasa/pull/129)] Added `Configuration#update`, much easier to use than `Configuration#updateOne`, `Configuration#updateArray`, and alias of `Configuration#updateMany` when a json object is providen. (kyranet)
 - [[#128](https://github.com/dirigeants/klasa/pull/128)] Added the `monitorError` event. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added the default gateways to `GatewayDriver` defaulted by null to reflect in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added `Schema` (the previous got renamed to `SchemaFolder`), reducing duplicated code and bringing more code consistency. (kyranet)
@@ -49,6 +51,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#129](https://github.com/dirigeants/klasa/pull/129)] **[OPTIMIZATION]** Like new entries only store the id, `Configuration#update` will upload only the modified keys rather than all of them when using a `json` database. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Moved the gateway resolvers from `GatewayDriver` (as getters) to `constants.GATEWAY_RESOLVERS`. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] `Schema#manager` and `SchemaPiece#manager` got renamed to `Schema#gateway` and `SchemaPiece#gateway`. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Updated typings.
@@ -83,6 +86,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#129](https://github.com/dirigeants/klasa/pull/129)] **[BREAKING]** Removed the methods `Configuration#updateOne`, `Configuration#updateArray`. They're replaced by `Configuration#update`. (kyranet)
 - [[#121](https://github.com/dirigeants/klasa/pull/121)] Removed `GatewaySQL`. (kyranet)
 - [[#116](https://github.com/dirigeants/klasa/pull/116)] Removed `moment.js` from the dependency list. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Removed a bunch of extendables. (kyranet)
@@ -98,6 +102,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#129](https://github.com/dirigeants/klasa/pull/129)] Fixed both config commands not removing the entries. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Fixed many typos in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Fixed `MessageOptions` not being correctly handled with `StringResolvable`, resulting on code like `msg.send({ embed });` to fail. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Fixed a serious security issue in `Configuration#get`. (kyranet)

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -24,12 +24,12 @@ module.exports = class extends Command {
 	}
 
 	async set(msg, key, valueToSet) {
-		const { path } = await msg.guild.configs.updateOne(key, valueToSet.join(' '), msg, true);
+		const { path } = await msg.guild.configs.update(key, valueToSet.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'add' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 
 	async remove(msg, key, valueToRemove) {
-		const { path } = await msg.guild.configs.updateArray('remove', key, valueToRemove.join(' '), msg, true);
+		const { path } = await msg.guild.configs.update(key, valueToRemove.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'remove' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 

--- a/src/commands/General/User Configs/userconf.js
+++ b/src/commands/General/User Configs/userconf.js
@@ -17,12 +17,12 @@ module.exports = class extends Command {
 	}
 
 	async set(msg, key, valueToSet) {
-		const { path } = await msg.author.configs.updateOne(key, valueToSet.join(' '), msg, true);
+		const { path } = await msg.author.configs.update(key, valueToSet.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'add' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 
 	async remove(msg, key, valueToRemove) {
-		const { path } = await msg.author.configs.updateArray('remove', key, valueToRemove.join(' '), msg, true);
+		const { path } = await msg.author.configs.update(key, valueToRemove.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'remove' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -212,7 +212,7 @@ class Configuration {
 		const { parsedID, parsed, path } = await this._reset(key, avoidUnconfigurable);
 		await (this.gateway.sql ?
 			this.gateway.provider.update(this.gateway.type, this.id, key, parsedID) :
-			this.gateway.provider.update(this.gateway.type, this.id, this.toJSON()));
+			this.gateway.provider.update(this.gateway.type, this.id, makeObject(key, parsedID)));
 		return { value: parsed, path };
 	}
 

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -241,7 +241,7 @@ class Configuration {
 	 * Configuration#update({ prefix: 'k!', language: 'es-ES' }, msg.guild);
 	 */
 	update(key, value, guild, { avoidUnconfigurable = false, action = 'auto' } = {}) {
-		if (isObject(key)) return this.updateMany(key, guild);
+		if (isObject(key)) return this.updateMany(key, value);
 		return this._updateSingle(action, key, value, guild, avoidUnconfigurable);
 	}
 

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -379,12 +379,15 @@ class Configuration {
 		}
 
 		const pathData = this.gateway.getPath(key, { avoidUnconfigurable, piece: true });
-		const { parsedID, array, parsed } = pathData.path.array === true ?
-			await this._parseUpdateArray(action, key, value, guild, pathData) :
-			await this._parseUpdateOne(key, value, guild, pathData);
+		if (action === 'remove' && !pathData.path.array) return this._parseReset(key, pathData);
+		const { parsedID, array, parsed } = action === 'remove' && !pathData.path.array ?
+			this._parseReset(key, pathData) :
+			pathData.path.array === true ?
+				await this._parseUpdateArray(action, key, value, guild, pathData) :
+				await this._parseUpdateOne(key, value, guild, pathData);
 
-		if (this.gateway.sql) await this.gateway.provider.update(this.gateway.type, this.id, key, array === null ? parsedID : array);
-		else await this.gateway.provider.update(this.gateway.type, this.id, makeObject(key, array === null ? parsedID : array));
+		if (this.gateway.sql) await this.gateway.provider.update(this.gateway.type, this.id, key, array || parsedID);
+		else await this.gateway.provider.update(this.gateway.type, this.id, makeObject(key, array || parsedID));
 
 		return { value: parsed, path: pathData.path };
 	}

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -312,7 +312,7 @@ class Configuration {
 		guild = this.gateway._resolveGuild(guild);
 
 		const parsed = await path.parse(value, guild);
-		const parsedID = parsed && parsed.id ? parsed.id : parsed;
+		const parsedID = Configuration.getIdentifier(parsed);
 		await this._setValue(parsedID, path, route);
 		return { parsed, parsedID, array: null, path, route };
 	}
@@ -336,7 +336,7 @@ class Configuration {
 		guild = this.gateway._resolveGuild(guild);
 
 		const parsed = await path.parse(value, guild);
-		const parsedID = parsed && parsed.id ? parsed.id : parsed;
+		const parsedID = Configuration.getIdentifier(parsed);
 
 		// Handle entry creation if it does not exist.
 		if (!this.existsInDB) await this.gateway.createEntry(this.id);
@@ -415,8 +415,8 @@ class Configuration {
 				continue;
 			}
 			list.promises.push(schema[key].parse(object[key], guild)
-				.then(result => {
-					const parsedID = result && result.id ? result.id : result;
+				.then(parsed => {
+					const parsedID = Configuration.getIdentifier(parsed);
 					cache[key] = parsedID;
 					updateObject[key] = parsedID;
 					list.keys.push(schema[key].path);
@@ -543,6 +543,20 @@ class Configuration {
 				Configuration._patch(inst[key], data[key], schema[key]) :
 				data[key];
 		}
+	}
+
+	/**
+	 * Get the identifier of a value.
+	 * @since 0.5.0
+	 * @param {*} value The value to get the identifier from
+	 * @returns {*}
+	 * @private
+	 */
+	static getIdentifier(value) {
+		if (typeof value !== 'object' || value === null) return value;
+		if (value.id) return value.id;
+		if (value.name) return value.name;
+		return value;
 	}
 
 }

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -345,7 +345,7 @@ class Configuration {
 		for (let i = 0; i < route.length - 1; i++) cache = cache[route[i]] || {};
 		cache = cache[route[route.length - 1]] || [];
 
-		if (action === 'auto') action = cache.includes(parsedID) ? 'add' : 'remove';
+		if (action === 'auto') action = cache.includes(parsedID) ? 'remove' : 'add';
 		if (action === 'add') {
 			if (cache.includes(parsedID)) throw `The value ${parsedID} for the key ${path.path} already exists.`;
 			cache.push(parsedID);

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -165,6 +165,24 @@ class Util {
 	}
 
 	/**
+	 * Turn a dotted path into a json object.
+	 * @since 0.5.0
+	 * @param {string} path The dotted path
+	 * @param {*} value The value
+	 * @returns {*}
+	 */
+	static makeObject(path, value) {
+		if (path.indexOf('.') === -1) return { [path]: value };
+		const object = {};
+		const route = path.split('.');
+		const lastKey = route.pop();
+		let reference = object;
+		for (const key of route) reference = reference[key] = {};
+		reference[lastKey] = value;
+		return object;
+	}
+
+	/**
 	 * Sets default properties on an object that aren't already specified.
 	 * @since 0.5.0
 	 * @param {Object} def Default properties

--- a/tutorials/IncludedEvents.md
+++ b/tutorials/IncludedEvents.md
@@ -46,9 +46,17 @@ Re-emits the Discord.js debug event as log event, if enabled.
 
 [events/error.js](https://github.com/dirigeants/klasa/blob/master/src/events/error.js)
 
+## guildCreate
+
+Checks if the guild is blacklisted for automatic leaving.
+
+**Source:**
+
+[events/guildCreate.js](https://github.com/dirigeants/klasa/blob/master/src/events/guildCreate.js)
+
 ## guildDelete
 
-Removes SettingGateway entries for the guild.
+If `KlasaClientOptions.preserveConfigs` is set to `false` (defaults to `true` if not set), this event deletes entries from the database to free up space.
 
 **Source:**
 
@@ -70,6 +78,22 @@ Runs monitors.
 
 [events/message.js](https://github.com/dirigeants/klasa/blob/master/src/events/message.js)
 
+## messageDelete
+
+If the message ran a command with the property `deletable` set to `true`, this event will delete the response.
+
+**Source:**
+
+[events/messageDelete.js](https://github.com/dirigeants/klasa/blob/master/src/events/messageDelete.js)
+
+## messageDeleteBulk
+
+Re-emits all the messages deleted to the `messageDelete` event.
+
+**Source:**
+
+[events/messageDeleteBulk.js](https://github.com/dirigeants/klasa/blob/master/src/events/messageDeleteBulk.js)
+
 ## messageUpdate
 
 Re-emits if command editing is enabled, and if the content is not the same, to check and see if the new message is a edited command.
@@ -77,6 +101,14 @@ Re-emits if command editing is enabled, and if the content is not the same, to c
 **Source:**
 
 [events/messageUpdate.js](https://github.com/dirigeants/klasa/blob/master/src/events/messageUpdate.js)
+
+## monitorError
+
+Handles the errors thrown by any of the monitors.
+
+**Source:**
+
+[events/monitorError.js](https://github.com/dirigeants/klasa/blob/master/src/events/monitorError.js)
 
 ## verbose
 

--- a/tutorials/UnderstandingSettingGateway.md
+++ b/tutorials/UnderstandingSettingGateway.md
@@ -70,7 +70,7 @@ What have we done? `client.gateways.guilds.schema` is a **SchemaFolder** instanc
 Now that I have a new key called `modlogs`, I want to configure it outside the `conf` command, how can we do this?
 
 ```javascript
-msg.guild.configs.updateOne('modlogs', '267727088465739778', msg.guild);
+msg.guild.configs.update('modlogs', '267727088465739778', msg.guild);
 ```
 
 Check: {@link Configuration.updateOne}
@@ -80,13 +80,13 @@ Check: {@link Configuration.updateOne}
 Now, I want to **add** a new user user to the `users` key, which takes an array.
 
 ```javascript
-msg.guild.configs.updateArray(msg.guild, 'add', 'users', '146048938242211840', msg.guild);
+msg.guild.configs.update('users', '146048938242211840', msg.guild, { action: 'add' });
 ```
 
 That will add the user `'146048938242211840'` to the `users` array. To remove it:
 
 ```javascript
-msg.guild.configs.updateArray(msg.guild, 'remove', 'users', '146048938242211840', msg.guild);
+msg.guild.configs.update('users', '146048938242211840', msg.guild, { action: 'remove' });
 ```
 
 Check: {@link Configuration.updateArray}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -325,6 +325,7 @@ declare module 'klasa' {
 		public static isNumber(input: number): boolean;
 		public static isObject(input: object): boolean;
 		public static tryParse(value: string): object;
+		public static makeObject(path: string, value: any): object;
 		public static mergeDefault(def: object, given?: object): object;
 	}
 
@@ -648,15 +649,15 @@ declare module 'klasa' {
 		public destroy(): Promise<this>;
 
 		public reset(key: string, avoidUnconfigurable?: boolean): Promise<ConfigurationUpdateResult>;
-		public updateOne(key: string, value: any, guild?: GatewayGuildResolvable, avoidUnconfigurable?: boolean): Promise<ConfigurationUpdateResult>;
-		public updateArray(action: 'add' | 'remove', key: string, value: any, guild?: GatewayGuildResolvable, avoidUnconfigurable?: boolean): Promise<ConfigurationUpdateResult>;
+		public update(key: object, guild?: GatewayGuildResolvable): Promise<ConfigurationUpdateManyResult>;
+		public update(key: string, value?: any, guild?: GatewayGuildResolvable, options?: ConfigurationUpdateOptions): Promise<ConfigurationUpdateResult>;
 		public updateMany(object: any, guild?: GatewayGuildResolvable): Promise<ConfigurationUpdateManyResult>;
 
 		private _reset(key: string, guild: GatewayGuildResolvable, avoidUnconfigurable: boolean): Promise<ConfigurationParseResult>;
 		private _parseReset(key: string, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResult>;
 		private _parseUpdateOne(key: string, value: any, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResult>;
-		private _parseUpdateArray(action: 'add' | 'remove', key: string, value: any, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResultArray>;
-		private _sharedUpdateSingle(action: 'add' | 'remove', key: string, value: any, guild: KlasaGuild, avoidUnconfigurable: boolean): Promise<ConfigurationParseResult | ConfigurationParseResultArray>;
+		private _parseUpdateArray(action: 'add' | 'remove' | 'auto', key: string, value: any, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResultArray>;
+		private _updateSingle(action: 'add' | 'remove' | 'auto', key: string, value: any, guild: KlasaGuild, avoidUnconfigurable: boolean): Promise<ConfigurationParseResult | ConfigurationParseResultArray>;
 		private _updateMany(cache: any, object: any, schema: SchemaFolder, guild: KlasaGuild, list: ConfigurationUpdateManyResult): void;
 		private _setValue(parsedID: string, path: SchemaPiece, route: string[]): Promise<void>;
 		private _patch(data: any): void;
@@ -1218,6 +1219,11 @@ declare module 'klasa' {
 	export type ConfigurationParseOptions = {
 		path: string;
 		route: string[];
+	};
+
+	export type ConfigurationUpdateOptions = {
+		avoidUnconfigurable?: boolean;
+		action?: 'add' | 'remove' | 'auto';
 	};
 
 	export type ConfigurationParseResult = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -658,7 +658,7 @@ declare module 'klasa' {
 		private _parseUpdateOne(key: string, value: any, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResult>;
 		private _parseUpdateArray(action: 'add' | 'remove' | 'auto', key: string, value: any, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResultArray>;
 		private _updateSingle(action: 'add' | 'remove' | 'auto', key: string, value: any, guild: KlasaGuild, avoidUnconfigurable: boolean): Promise<ConfigurationParseResult | ConfigurationParseResultArray>;
-		private _updateMany(cache: any, object: any, schema: SchemaFolder, guild: KlasaGuild, list: ConfigurationUpdateManyResult): void;
+		private _updateMany(cache: any, object: any, schema: SchemaFolder, guild: KlasaGuild, list: ConfigurationUpdateManyResult, updateObject: object): void;
 		private _setValue(parsedID: string, path: SchemaPiece, route: string[]): Promise<void>;
 		private _patch(data: any): void;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -668,6 +668,7 @@ declare module 'klasa' {
 		private static _merge(data: any, folder: SchemaFolder | SchemaPiece): any;
 		private static _clone(data: any, schema: SchemaFolder): any;
 		private static _patch(inst: any, data: any, schema: SchemaFolder): void;
+		private static getIdentifier(value: any): any;
 	}
 
 	// Util


### PR DESCRIPTION
### Description of the PR

~~We should stop breaking configs...~~ This PR aims for much easier use of `Configuration`'s update method by abstracting it and, allow it to use less duplicated code whilst also being more powerful. Therefore, `Configuration#updateOne` and `Configuration#updateArray` are now removed due to their verbose and similarity, they're now a single method, and when updating an array, it'll not longer default to `'add'` when updating an array, but `'auto'`, which adds when it doesn't exist in the array, or removes otherwise.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:
- Added `Util#makeObject` to make objects given a path and a value.
- Added `Configuration#update`, much easier to use than `Configuration#updateOne`, `Configuration#updateArray`, and alias of `Configuration#updateMany` when a json object is providen.

**Changed**:
- **[OPTIMIZATION]** Like new entries only store the id, `Configuration#update` will upload only the modified keys rather than all of them when using a `json` database.

**Removed**:
- **[BREAKING]** Removed the methods `Configuration#updateOne`, `Configuration#updateArray`. They're replaced by `Configuration#update`.

**Fixed**:
- Fixed identifiers not being resolved correctly when using `Configuration#update`.
- Fixed both config commands not removing the entries.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
