### PR TITLE
Make all piece defaults available for customization in KlasaClientOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docs
 
 \.vscode/
 \.idea/
+desktop.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
-- [[#130](https://github.com/dirigeants/klasa/pull/130)] Added `KlasaClientOptions.cmdDeleting` to change the default value for `Command.deletable` when not given. (kyranet)
+- [[#130](https://github.com/dirigeants/klasa/pull/130)] Added a new option in `KlasaClientOptions` to allow developers to set their own defaults for each kind of piece. (bdistin)
 - [[#128](https://github.com/dirigeants/klasa/pull/128)] Added the `monitorError` event. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added the default gateways to `GatewayDriver` defaulted by null to reflect in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added `Schema` (the previous got renamed to `SchemaFolder`), reducing duplicated code and bringing more code consistency. (kyranet)
@@ -50,6 +50,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#130](https://github.com/dirigeants/klasa/pull/130)] Updated the documentation and some outdated typings. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Moved the gateway resolvers from `GatewayDriver` (as getters) to `constants.GATEWAY_RESOLVERS`. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] `Schema#manager` and `SchemaPiece#manager` got renamed to `Schema#gateway` and `SchemaPiece#gateway`. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Updated typings.
@@ -84,6 +85,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#130](https://github.com/dirigeants/klasa/pull/130)] Removed `KlasaClientOptions.quotedStringSupport` in favor of the new per-piece defaults. (bdistin)
 - [[#121](https://github.com/dirigeants/klasa/pull/121)] Removed `GatewaySQL`. (kyranet)
 - [[#116](https://github.com/dirigeants/klasa/pull/116)] Removed `moment.js` from the dependency list. (kyranet)
 - [[`2915d31b92`](https://github.com/dirigeants/klasa/commit/2915d31b92c8ea4b9202edfdb146a2d8b36ad8d6)] ([#43](https://github.com/dirigeants/klasa/pull/43)) Removed a bunch of extendables. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#130](https://github.com/dirigeants/klasa/pull/130)] Added `KlasaClientOptions.deletableCommands` to change the default value for `Command.deletable` when not given. (kyranet)
 - [[#128](https://github.com/dirigeants/klasa/pull/128)] Added the `monitorError` event. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added the default gateways to `GatewayDriver` defaulted by null to reflect in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added `Schema` (the previous got renamed to `SchemaFolder`), reducing duplicated code and bringing more code consistency. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
-- [[#130](https://github.com/dirigeants/klasa/pull/130)] Added `KlasaClientOptions.deletableCommands` to change the default value for `Command.deletable` when not given. (kyranet)
+- [[#130](https://github.com/dirigeants/klasa/pull/130)] Added `KlasaClientOptions.cmdDeleting` to change the default value for `Command.deletable` when not given. (kyranet)
 - [[#128](https://github.com/dirigeants/klasa/pull/128)] Added the `monitorError` event. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added the default gateways to `GatewayDriver` defaulted by null to reflect in the documentation. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Added `Schema` (the previous got renamed to `SchemaFolder`), reducing duplicated code and bringing more code consistency. (kyranet)

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -4,8 +4,8 @@ module.exports = class extends Event {
 
 	run(message) {
 		if (message.command && message.command.deletable && message.responses) {
-			if (Array.isArray(this.responses)) for (const msg of this.responses) msg.delete();
-			else this.responses.delete();
+			if (Array.isArray(message.responses)) for (const msg of message.responses) msg.delete();
+			else message.responses.delete();
 		}
 	}
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -32,17 +32,16 @@ class KlasaClient extends Discord.Client {
 	 * @property {object} [provider] The provider to use in Klasa
 	 * @property {KlasaConsoleConfig} [console={}] Config options to pass to the client console
 	 * @property {KlasaConsoleEvents} [consoleEvents={}] Config options to pass to the client console
+	 * @property {KlasaPieceDefaults} [pieceDefaults={}] Overrides the defaults for all pieces
 	 * @property {string} [language='en-US'] The default language Klasa should opt-in for the commands
 	 * @property {number} [promptTime=30000] The amount of time in milliseconds prompts should last
 	 * @property {boolean} [ignoreBots=true] Whether or not this bot should ignore other bots
 	 * @property {boolean} [ignoreSelf=true] Whether or not this bot should ignore itself
 	 * @property {boolean} [cmdPrompt=false] Whether the bot should prompt missing parameters
-	 * @property {boolean} [cmdDeleting=false] Whether the bot should delete responses if the command is deleted
 	 * @property {boolean} [cmdEditing=false] Whether the bot should update responses if the command is edited
 	 * @property {boolean} [cmdLogging=false] Whether the bot should log command usage
 	 * @property {boolean} [typing=false] Whether the bot should type while processing commands
 	 * @property {boolean} [preserveConfigs=true] Whether the bot should preserve (non-default) configs when removed from a guild
-	 * @property {boolean} [quotedStringSupport=false] Whether the bot should default to using quoted string support in arg parsing, or not (overridable per command)
 	 * @property {(string|Function)} [readyMessage=`Successfully initialized. Ready to serve ${this.guilds.size} guilds.`] readyMessage to be passed throughout Klasa's ready event
 	 * @property {string} [ownerID] The discord user id for the user the bot should respect as the owner (gotten from Discord api if not provided)
 	 * @property {RegExp} [regexPrefix] The regular expression prefix if one is provided
@@ -67,6 +66,19 @@ class KlasaClient extends Discord.Client {
 	 * @property {boolean} [debug=false] If the debug event should be enabled by default
 	 * @property {boolean} [verbose=false] If the verbose event should be enabled by default
 	 * @property {boolean} [wtf=true] If the wtf event should be enabled by default
+	 * @memberof KlasaClient
+	 */
+
+	/**
+	 * @typedef {Object} KlasaPieceDefaults
+	 * @property {Object} [commands={}] The default command options
+	 * @property {Object} [events={}] The default event options
+	 * @property {Object} [extendables={}] The default extendable options
+	 * @property {Object} [finalizers={}] The default finalizer options
+	 * @property {Object} [inhibitors={}] The default inhibitor options
+	 * @property {Object} [languages={}] The default language options
+	 * @property {Object} [monitors={}] The default monitor options
+	 * @property {Object} [providers={}] The default provider options
 	 * @memberof KlasaClient
 	 */
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -60,25 +60,25 @@ class KlasaClient extends Discord.Client {
 
 	/**
 	 * @typedef {Object} KlasaConsoleEvents
-	 * @property {boolean} [log=true] If the log event should be enabled by default
-	 * @property {boolean} [warn=true] If the warn event should be enabled by default
-	 * @property {boolean} [error=true] If the error event should be enabled by default
 	 * @property {boolean} [debug=false] If the debug event should be enabled by default
+	 * @property {boolean} [error=true] If the error event should be enabled by default
+	 * @property {boolean} [log=true] If the log event should be enabled by default
 	 * @property {boolean} [verbose=false] If the verbose event should be enabled by default
+	 * @property {boolean} [warn=true] If the warn event should be enabled by default
 	 * @property {boolean} [wtf=true] If the wtf event should be enabled by default
 	 * @memberof KlasaClient
 	 */
 
 	/**
 	 * @typedef {Object} KlasaPieceDefaults
-	 * @property {Object} [commands={}] The default command options
-	 * @property {Object} [events={}] The default event options
-	 * @property {Object} [extendables={}] The default extendable options
-	 * @property {Object} [finalizers={}] The default finalizer options
-	 * @property {Object} [inhibitors={}] The default inhibitor options
-	 * @property {Object} [languages={}] The default language options
-	 * @property {Object} [monitors={}] The default monitor options
-	 * @property {Object} [providers={}] The default provider options
+	 * @property {CommandOptions} [commands={}] The default command options
+	 * @property {EventOptions} [events={}] The default event options
+	 * @property {ExtendableOptions} [extendables={}] The default extendable options
+	 * @property {FinalizerOptions} [finalizers={}] The default finalizer options
+	 * @property {InhibitorOptions} [inhibitors={}] The default inhibitor options
+	 * @property {LanguageOptions} [languages={}] The default language options
+	 * @property {MonitorOptions} [monitors={}] The default monitor options
+	 * @property {ProviderOptions} [providers={}] The default provider options
 	 * @memberof KlasaClient
 	 */
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -37,6 +37,7 @@ class KlasaClient extends Discord.Client {
 	 * @property {boolean} [ignoreBots=true] Whether or not this bot should ignore other bots
 	 * @property {boolean} [ignoreSelf=true] Whether or not this bot should ignore itself
 	 * @property {boolean} [cmdPrompt=false] Whether the bot should prompt missing parameters
+	 * @property {boolean} [cmdDeleting=false] Whether the bot should delete responses if the command is deleted
 	 * @property {boolean} [cmdEditing=false] Whether the bot should update responses if the command is edited
 	 * @property {boolean} [cmdLogging=false] Whether the bot should log command usage
 	 * @property {boolean} [typing=false] Whether the bot should type while processing commands

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -27,7 +27,7 @@ class Command {
 	 * @property {(string|Function)} [description=''] The help description for the command
 	 * @property {string} [usage=''] The usage string for the command
 	 * @property {?string} [usageDelim=undefined] The string to deliminate the command input for usage
-	 * @property {boolean} [quotedStringSupport=this.client.options.quotedStringSupport] Whether args for this command should not deliminated inside quotes
+	 * @property {boolean} [quotedStringSupport=this.client.options.commands.quotedStringSupport] Whether args for this command should not deliminated inside quotes
 	 * @property {(string|Function)} [extendedHelp=msg.language.get('COMMAND_HELP_NO_EXTENDED')] Extended help strings
 	 * @memberof Command
 	 */

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -96,7 +96,7 @@ class Command {
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
-		this.deletable = options.deletable || this.client.options.cmdDeleting;
+		this.deletable = 'deletable' in options ? options.deletable : this.client.options.cmdDeleting;
 
 		/**
 		 * The name of the command
@@ -174,7 +174,7 @@ class Command {
 		 * @since 0.2.1
 		 * @type {boolean}
 		 */
-		this.quotedStringSupport = options.quotedStringSupport || this.client.options.quotedStringSupport;
+		this.quotedStringSupport = 'quotedStringSupport' in options ? options.quotedStringSupport : this.client.options.quotedStringSupport;
 
 		/**
 		 * The full category for the command

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -96,7 +96,7 @@ class Command {
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
-		this.deletable = options.deletable;
+		this.deletable = options.deletable || this.client.options.deletableCommands;
 
 		/**
 		 * The name of the command

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -96,7 +96,7 @@ class Command {
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
-		this.deletable = options.deletable || this.client.options.deletableCommands;
+		this.deletable = options.deletable || this.client.options.cmdDeleting;
 
 		/**
 		 * The name of the command

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -1,6 +1,5 @@
 const Piece = require('./interfaces/Piece');
 const { mergeDefault } = require('../util/util');
-const constants = require('../util/constants');
 const ParsedUsage = require('../usage/ParsedUsage');
 
 /**
@@ -41,7 +40,7 @@ class Command {
 	 * @param {CommandOptions} [options={}] Optional Command settings
 	 */
 	constructor(client, dir, file, options = {}) {
-		options = mergeDefault(constants.DEFAULTS.COMMAND, options);
+		options = mergeDefault(client.options.pieceDefaults.commands, options);
 
 		/**
 		 * @since 0.0.1
@@ -85,7 +84,7 @@ class Command {
 		this.nsfw = options.nsfw;
 
 		/**
-		 * Whether this command shound not be able to be disabled in a guild or not
+		 * Whether this command should not be able to be disabled in a guild or not
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
@@ -96,7 +95,7 @@ class Command {
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
-		this.deletable = 'deletable' in options ? options.deletable : this.client.options.cmdDeleting;
+		this.deletable = options.deletable;
 
 		/**
 		 * The name of the command
@@ -174,7 +173,7 @@ class Command {
 		 * @since 0.2.1
 		 * @type {boolean}
 		 */
-		this.quotedStringSupport = 'quotedStringSupport' in options ? options.quotedStringSupport : this.client.options.quotedStringSupport;
+		this.quotedStringSupport = options.quotedStringSupport;
 
 		/**
 		 * The full category for the command

--- a/src/lib/structures/Event.js
+++ b/src/lib/structures/Event.js
@@ -1,4 +1,5 @@
 const Piece = require('./interfaces/Piece');
+const { mergeDefault } = require('../util/util');
 
 /**
  * Base class for all Klasa Events. See {@tutorial CreatingEvents} for more information how to use this class
@@ -23,6 +24,8 @@ class Event {
 	 * @param {EventOptions} [options={}] The Event options
 	 */
 	constructor(client, dir, file, options = {}) {
+		options = mergeDefault(client.options.pieceDefaults.events, options);
+
 		/**
 		 * @since 0.0.1
 		 * @type {KlasaClient}
@@ -62,7 +65,7 @@ class Event {
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.enabled = 'enabled' in options ? options.enabled : true;
+		this.enabled = options.enabled;
 	}
 
 	/**

--- a/src/lib/structures/Extendable.js
+++ b/src/lib/structures/Extendable.js
@@ -1,4 +1,5 @@
 const Piece = require('./interfaces/Piece');
+const { mergeDefault } = require('../util/util');
 const Discord = require('discord.js');
 
 /**
@@ -26,6 +27,8 @@ class Extendable {
 	 * @param {ExtendableOptions} options The options for this extendable
 	 */
 	constructor(client, dir, file, appliesTo = [], options = {}) {
+		options = mergeDefault(client.options.pieceDefaults.extendables, options);
+
 		/**
 		 * @since 0.0.1
 		 * @type {KlasaClient}
@@ -72,7 +75,7 @@ class Extendable {
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.enabled = 'enabled' in options ? options.enabled : true;
+		this.enabled = options.enabled;
 
 		/**
 		 * The target library to apply this extendable to

--- a/src/lib/structures/Finalizer.js
+++ b/src/lib/structures/Finalizer.js
@@ -1,4 +1,5 @@
 const Piece = require('./interfaces/Piece');
+const { mergeDefault } = require('../util/util');
 
 /**
  * Base class for all Klasa Finalizers. See {@tutorial CreatingFinalizers} for more information how to use this class
@@ -23,6 +24,8 @@ class Finalizer {
 	 * @param {FinalizerOptions} [options={}] Optional Finalizer settings
 	 */
 	constructor(client, dir, file, options = {}) {
+		options = mergeDefault(client.options.pieceDefaults.finalizers, options);
+
 		/**
 		 * @since 0.0.1
 		 * @type {KlasaClient}
@@ -62,7 +65,7 @@ class Finalizer {
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.enabled = 'enabled' in options ? options.enabled : true;
+		this.enabled = options.enabled;
 	}
 
 	/**

--- a/src/lib/structures/Inhibitor.js
+++ b/src/lib/structures/Inhibitor.js
@@ -1,4 +1,5 @@
 const Piece = require('./interfaces/Piece');
+const { mergeDefault } = require('../util/util');
 
 /**
  * Base class for all Klasa Inhibitors. See {@tutorial CreatingInhibitors} for more information how to use this class
@@ -24,6 +25,8 @@ class Inhibitor {
 	 * @param {InhibitorOptions} [options={}] Optional Inhibitor settings
 	 */
 	constructor(client, dir, file, options = {}) {
+		options = mergeDefault(client.options.pieceDefaults.inhibitors, options);
+
 		/**
 		 * @since 0.0.1
 		 * @type {KlasaClient}
@@ -63,14 +66,14 @@ class Inhibitor {
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.enabled = 'enabled' in options ? options.enabled : true;
+		this.enabled = options.enabled;
 
 		/**
 		 * If this inhibitor is meant for spamProtection (disables the inhibitor while generating help)
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.spamProtection = 'spamProtection' in options ? options.spamProtection : false;
+		this.spamProtection = options.spamProtection;
 	}
 
 	/**

--- a/src/lib/structures/Language.js
+++ b/src/lib/structures/Language.js
@@ -1,4 +1,5 @@
 const Piece = require('./interfaces/Piece');
+const { mergeDefault } = require('../util/util');
 
 /**
  * Base class for all Klasa Languages. See {@tutorial CreatingLanguages} for more information how to use this class
@@ -23,6 +24,8 @@ class Language {
 	 * @param {LanguageOptions} [options={}] Optional Language settings
 	 */
 	constructor(client, dir, file, options = {}) {
+		options = mergeDefault(client.options.pieceDefaults.languages, options);
+
 		/**
 		 * @since 0.2.1
 		 * @type {KlasaClient}
@@ -62,7 +65,7 @@ class Language {
 		 * @since 0.2.1
 		 * @type {boolean}
 		 */
-		this.enabled = 'enabled' in options ? options.enabled : true;
+		this.enabled = options.enabled;
 	}
 
 	/**

--- a/src/lib/structures/Monitor.js
+++ b/src/lib/structures/Monitor.js
@@ -1,4 +1,5 @@
 const Piece = require('./interfaces/Piece');
+const { mergeDefault } = require('../util/util');
 
 /**
  * Base class for all Klasa Monitors. See {@tutorial CreatingMonitors} for more information how to use this class
@@ -26,6 +27,8 @@ class Monitor {
 	 * @param {MonitorOptions} [options={}] Optional Monitor settings
 	 */
 	constructor(client, dir, file, options = {}) {
+		options = mergeDefault(client.options.pieceDefaults.monitors, options);
+
 		/**
 		 * @since 0.0.1
 		 * @type {KlasaClient}
@@ -65,28 +68,28 @@ class Monitor {
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.enabled = 'enabled' in options ? options.enabled : true;
+		this.enabled = options.enabled;
 
 		/**
 		 * Whether the monitor ignores bots or not
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.ignoreBots = 'ignoreBots' in options ? options.ignoreBots : true;
+		this.ignoreBots = options.ignoreBots;
 
 		/**
 		 * Whether the monitor ignores itself or not
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.ignoreSelf = 'ignoreSelf' in options ? options.ignoreSelf : true;
+		this.ignoreSelf = options.ignoreSelf;
 
 		/**
 		 * Whether the monitor ignores others or not
 		 * @since 0.4.0
 		 * @type {boolean}
 		 */
-		this.ignoreOthers = 'ignoreOthers' in options ? options.ignoreOthers : true;
+		this.ignoreOthers = options.ignoreOthers;
 	}
 
 	/**

--- a/src/lib/structures/Provider.js
+++ b/src/lib/structures/Provider.js
@@ -1,4 +1,5 @@
 const Piece = require('./interfaces/Piece');
+const { mergeDefault } = require('../util/util');
 
 /**
  * Base class for all Klasa Providers. See {@tutorial CreatingProviders} for more information how to use this class
@@ -13,7 +14,7 @@ class Provider {
 	 * @property {string} [name=theFileName] The name of the provider
 	 * @property {boolean} [enabled=true] Whether the provider is enabled or not
 	 * @property {string} [description=''] The provider description
-	 * @property {boolean} [sql=false] If the provider provides to a sql datasource
+	 * @property {boolean} [sql=false] If the provider provides to a sql data source
 	 * @memberof Provider
 	 */
 
@@ -25,6 +26,8 @@ class Provider {
 	 * @param {ProviderOptions} [options={}] Optional Provider settings
 	 */
 	constructor(client, dir, file, options = {}) {
+		options = mergeDefault(client.options.pieceDefaults.providers, options);
+
 		/**
 		 * @since 0.0.1
 		 * @type {KlasaClient}
@@ -64,28 +67,28 @@ class Provider {
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.enabled = 'enabled' in options ? options.enabled : true;
+		this.enabled = options.enabled;
 
 		/**
 		 * The description of the provider
 		 * @since 0.0.1
 		 * @type {string}
 		 */
-		this.description = options.description || '';
+		this.description = options.description;
 
 		/**
-		 * If the provider provides to a sql datasource
+		 * If the provider provides to a sql data source
 		 * @since 0.0.1
 		 * @type {boolean}
 		 */
-		this.sql = 'sql' in options ? options.sql : false;
+		this.sql = options.sql;
 
 		/**
 		 * If the provider is designed to handle cache operations
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
-		this.cache = 'cache' in options ? options.cache : false;
+		this.cache = options.cache;
 	}
 
 	/**

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -36,7 +36,6 @@ exports.DEFAULTS = {
 		autoAliases: true,
 		botPerms: [],
 		cooldown: 0,
-		deletable: false,
 		description: '',
 		enabled: true,
 		guarded: false,

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -5,6 +5,7 @@ exports.DEFAULTS = {
 
 	CLIENT: {
 		clientBaseDir: dirname(require.main.filename),
+		cmdDeleting: false,
 		cmdEditing: false,
 		cmdLogging: false,
 		cmdPrompt: false,
@@ -18,7 +19,6 @@ exports.DEFAULTS = {
 			warn: true,
 			wtf: true
 		},
-		deletableCommands: false,
 		ignoreBots: true,
 		ignoreSelf: true,
 		language: 'en-US',

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -18,6 +18,7 @@ exports.DEFAULTS = {
 			warn: true,
 			wtf: true
 		},
+		deletableCommands: false,
 		ignoreBots: true,
 		ignoreSelf: true,
 		language: 'en-US',

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -26,24 +26,49 @@ exports.DEFAULTS = {
 		preserveConfigs: true,
 		promptTime: 30000,
 		provider: { engine: 'json' },
-		quotedStringSupport: false,
 		readyMessage: (client) => `Successfully initialized. Ready to serve ${client.guilds.size} guilds.`,
-		typing: false
-	},
-
-	COMMAND: {
-		aliases: [],
-		autoAliases: true,
-		botPerms: [],
-		cooldown: 0,
-		description: '',
-		enabled: true,
-		guarded: false,
-		nsfw: false,
-		permLevel: 0,
-		requiredConfigs: [],
-		runIn: ['text', 'dm', 'group'],
-		usage: ''
+		typing: false,
+		pieceDefaults: {
+			commands: {
+				aliases: [],
+				autoAliases: true,
+				botPerms: [],
+				cooldown: 0,
+				description: '',
+				enabled: true,
+				guarded: false,
+				nsfw: false,
+				permLevel: 0,
+				requiredConfigs: [],
+				runIn: ['text', 'dm', 'group'],
+				usage: '',
+				quotedStringSupport: false,
+				deletable: false
+			},
+			events: { enabled: true },
+			extendables: {
+				enabled: true,
+				klasa: false
+			},
+			finalizers: { enabled: true },
+			inhibitors: {
+				enabled: true,
+				spamProtection: false
+			},
+			languages: { enabled: true },
+			monitors: {
+				enabled: true,
+				ignoreBots: true,
+				ignoreSelf: true,
+				ignoreOthers: true
+			},
+			providers: {
+				enabled: true,
+				sql: false,
+				cache: false,
+				description: ''
+			}
+		}
 	}
 
 };

--- a/tutorials/CreatingCommands.md
+++ b/tutorials/CreatingCommands.md
@@ -36,21 +36,21 @@ module.exports = class extends Command {
 
 ## Configuration
 
-| Name                    | Default                             | Type    | Description                                                                 |
-| ----------------------- | ----------------------------------- | ------- | --------------------------------------------------------------------------- |
-| **name**                | `theFileName`                       | string  | The name of the command                                                     |
-| **enabled**             | `true`                              | boolean | Whether the command is enabled or not                                       |
-| **runIn**               | `['text', 'dm', 'group']`           | Array   | What channel types the command should run in                                |
-| **cooldown**            | `0`                                 | number  | The amount of time before the user can run the command again in seconds     |
-| **aliases**             | `[]`                                | Array   | Any comand aliases                                                          |
-| **permLevel**           | `0`                                 | number  | The required permission level to use the command                            |
-| **botPerms**            | `[]`                                | Array   | The required Discord permissions for the bot to use this command            |
-| **requiredConfigs**     | `[]`                                | Array   | The required guild configs to use this command                              |
-| **description**         | `''`                                | string  | The help description for the command                                        |
-| **usage**               | `''`                                | string  | The usage string for the command See. {@tutorial UnderstandingUsageStrings} |
-| **usageDelim**          | `''`                                | string  | The string to deliminate the command input for usage                        |
-| **quotedStringSupport** | `client.config.quotedStringSupport` | boolean | Wheter args for this command should not deliminated inside quotes           |
-| **extendedHelp**        | `'No extended help available.'`     | string  | Extended help strings                                                       |
+| Name                    | Default                                       | Type    | Description                                                                 |
+| ----------------------- | --------------------------------------------- | ------- | --------------------------------------------------------------------------- |
+| **name**                | `theFileName`                                 | string  | The name of the command                                                     |
+| **enabled**             | `true`                                        | boolean | Whether the command is enabled or not                                       |
+| **runIn**               | `['text', 'dm', 'group']`                     | Array   | What channel types the command should run in                                |
+| **cooldown**            | `0`                                           | number  | The amount of time before the user can run the command again in seconds     |
+| **aliases**             | `[]`                                          | Array   | Any comand aliases                                                          |
+| **permLevel**           | `0`                                           | number  | The required permission level to use the command                            |
+| **botPerms**            | `[]`                                          | Array   | The required Discord permissions for the bot to use this command            |
+| **requiredConfigs**     | `[]`                                          | Array   | The required guild configs to use this command                              |
+| **description**         | `''`                                          | string  | The help description for the command                                        |
+| **usage**               | `''`                                          | string  | The usage string for the command See. {@tutorial UnderstandingUsageStrings} |
+| **usageDelim**          | `''`                                          | string  | The string to deliminate the command input for usage                        |
+| **quotedStringSupport** | `client.options.commands.quotedStringSupport` | boolean | Wheter args for this command should not deliminated inside quotes           |
+| **extendedHelp**        | `'No extended help available.'`               | string  | Extended help strings                                                       |
 
 > All commands are required to return an [Object Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) you can do that by adding the `async` keyword to the function, there's no need to change anything else.
 

--- a/tutorials/GettingStarted.md
+++ b/tutorials/GettingStarted.md
@@ -36,31 +36,32 @@ new Client({
 
 | Name                       | Default                   | Type               | Description                                                                         |
 | -------------------------- | ------------------------- | ------------------ | ----------------------------------------------------------------------------------- |
-| **clientOptions**          | `{}`                      | Object             | These are passed directly to the discord.js library. They are optional.¹            |
-| **prefix**                 | `undefined`               | string/regex/array | The default prefix(es) when the bot first boots up.²                                |
-| **permissionLevels**       | `defaultPermissionLevels` | PermissionLevels   | The permission levels to use with this bot                                          |
 | **clientBaseDir**          | see below³                | string             | The directory where all piece folders can be found                                  |
-| **commandMessageLifetime** | `1800`                    | number             | The threshold for when comand messages should be sweeped in seconds since last edit |
-| **provider**               | `json`                    | string             | The provider to use in Klasa                                                        |
-| **language**               | `en-US`                   | string             | The default language Klasa should opt-in for the commands                           |
-| **promptTime**             | `30000`                   | number             | The amount of time in milliseconds prompts should last                              |
-| **ignoreBots**             | `true`                    | boolean            | Whether or not this bot should ignore other bots                                    |
-| **ignoreSelf**             | `client.user.bot`         | boolean            | Whether or not this bot should ignore itself (true for bots, false for selfbots)    |
-| **cmdPrompt**              | `false`                   | boolean            | Whether the bot should prompt missing parameters                                    |
+| **clientOptions**          | `{}`                      | Object             | These are passed directly to the discord.js library. They are optional.¹            |
+| **cmdDeleting**            | `false`                   | boolean            | Whether the bot should delete responses if the command is deleted                   |
 | **cmdEditing**             | `false`                   | boolean            | Whether the bot should update responses if the command is edited                    |
 | **cmdLogging**             | `false`                   | boolean            | Whether the bot should log command usage                                            |
+| **cmdPrompt**              | `false`                   | boolean            | Whether the bot should prompt missing parameters                                    |
+| **commandMessageLifetime** | `1800`                    | number             | The threshold for when comand messages should be sweeped in seconds since last edit |
+| **ignoreBots**             | `true`                    | boolean            | Whether or not this bot should ignore other bots                                    |
+| **ignoreSelf**             | `client.user.bot`         | boolean            | Whether or not this bot should ignore itself (true for bots, false for selfbots)    |
+| **language**               | `en-US`                   | string             | The default language Klasa should opt-in for the commands                           |
+| **ownerID**                | see below⁶                | string             | The discord id for the user the bot should respect as the owner                     |
+| **permissionLevels**       | `defaultPermissionLevels` | PermissionLevels   | The permission levels to use with this bot                                          |
+| **prefix**                 | `undefined`               | string/regex/array | The default prefix(es) when the bot first boots up.²                                |
+| **promptTime**             | `30000`                   | number             | The amount of time in milliseconds prompts should last                              |
+| **provider.engine**        | `json`                    | string             | The provider to use in Klasa                                                        |
 | **quotedStringSupport**    | `false`                   | boolean            | Whether the bot should default to using quoted string support⁴                      |
-| **typing**                 | `false`                   | boolean            | Whether the bot should type while processing commands.                              |
 | **readyMessage**           | see below⁵                | string/function    | readyMessage to be passed through to Klasa's ready event.                           |
-| **ownerID**                | see below⁶                | string             | The discord id for the user the bot should respect as the owner                     |                  |
-| **regexPrefix**            | `null`                    | regex              | The regular expression prefix if one is provided               |
+| **regexPrefix**            | `null`                    | regex              | The regular expression prefix if one is provided                                    |
+| **typing**                 | `false`                   | boolean            | Whether the bot should type while processing commands.                              |
 
->1: For more information on which D.JS options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/master/typedef/ClientOptions).  
->2: This option becomes useless after first boot, since the prefix is written to the default configuration system. Pass an array to accept multiple prefixes.  
->3: The directory of the main file. `path.dirname(require.main.filename)`  
->4: quotedStringSupport is overridable per command  
->5: `Successfully initialized. Ready to serve ${client.guilds.size} guilds.`  
->6: ID gotten from the Discord api if not provided: `client.application.owner.id`  
+>1: For more information on which D.JS options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/master/typedef/ClientOptions).
+>2: This option becomes useless after first boot, since the prefix is written to the default configuration system. Pass an array to accept multiple prefixes.
+>3: The directory of the main file. `path.dirname(require.main.filename)`
+>4: quotedStringSupport is overridable per command
+>5: `Successfully initialized. Ready to serve ${client.guilds.size} guilds.`
+>6: ID gotten from the Discord api if not provided: `client.application.owner.id`
 
 ## Running the bot
 

--- a/tutorials/GettingStarted.md
+++ b/tutorials/GettingStarted.md
@@ -32,12 +32,11 @@ new Client({
 }).login('your-bot-token');
 ```
 
-### Configuration Options: [KlasaClientConfig]{@link KlasaClient.KlasaClientConfig}
+### Configuration Options: [KlasaClientOptions]{@link KlasaClient.KlasaClientOptions}
 
 | Name                       | Default                   | Type               | Description                                                                         |
 | -------------------------- | ------------------------- | ------------------ | ----------------------------------------------------------------------------------- |
-| **clientBaseDir**          | see below³                | string             | The directory where all piece folders can be found                                  |
-| **clientOptions**          | `{}`                      | Object             | These are passed directly to the discord.js library. They are optional.¹            |
+| **clientBaseDir**          | see below¹                | string             | The directory where all piece folders can be found                                  |
 | **cmdDeleting**            | `false`                   | boolean            | Whether the bot should delete responses if the command is deleted                   |
 | **cmdEditing**             | `false`                   | boolean            | Whether the bot should update responses if the command is edited                    |
 | **cmdLogging**             | `false`                   | boolean            | Whether the bot should log command usage                                            |
@@ -46,9 +45,9 @@ new Client({
 | **ignoreBots**             | `true`                    | boolean            | Whether or not this bot should ignore other bots                                    |
 | **ignoreSelf**             | `client.user.bot`         | boolean            | Whether or not this bot should ignore itself (true for bots, false for selfbots)    |
 | **language**               | `en-US`                   | string             | The default language Klasa should opt-in for the commands                           |
-| **ownerID**                | see below⁶                | string             | The discord id for the user the bot should respect as the owner                     |
+| **ownerID**                | see below²                | string             | The discord id for the user the bot should respect as the owner                     |
 | **permissionLevels**       | `defaultPermissionLevels` | PermissionLevels   | The permission levels to use with this bot                                          |
-| **prefix**                 | `undefined`               | string/regex/array | The default prefix(es) when the bot first boots up.²                                |
+| **prefix**                 | `undefined`               | string/array       | The default prefix(es) when the bot first boots up.³                                |
 | **promptTime**             | `30000`                   | number             | The amount of time in milliseconds prompts should last                              |
 | **provider.engine**        | `json`                    | string             | The provider to use in Klasa                                                        |
 | **quotedStringSupport**    | `false`                   | boolean            | Whether the bot should default to using quoted string support⁴                      |
@@ -56,12 +55,13 @@ new Client({
 | **regexPrefix**            | `null`                    | regex              | The regular expression prefix if one is provided                                    |
 | **typing**                 | `false`                   | boolean            | Whether the bot should type while processing commands.                              |
 
->1: For more information on which D.JS options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/master/typedef/ClientOptions).
->2: This option becomes useless after first boot, since the prefix is written to the default configuration system. Pass an array to accept multiple prefixes.
->3: The directory of the main file. `path.dirname(require.main.filename)`
+>1: The directory of the main file. `path.dirname(require.main.filename)`
+>2: ID gotten from the Discord api if not provided: `client.application.owner.id`
+>3: You can pass an array to accept multiple prefixes.
 >4: quotedStringSupport is overridable per command
 >5: `Successfully initialized. Ready to serve ${client.guilds.size} guilds.`
->6: ID gotten from the Discord api if not provided: `client.application.owner.id`
+
+> KlasaClientOptions are merged with discord.js' ClientOptions, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/master/typedef/ClientOptions).
 
 ## Running the bot
 

--- a/tutorials/UnderstandingPermissionLevels.md
+++ b/tutorials/UnderstandingPermissionLevels.md
@@ -50,7 +50,7 @@ Client.defaultPermissionLevels
 	// let some group of people who solved some easteregg clues use a special command/some custom non-admin role
     .addLevel(6, false, (client, msg) => msg.guild && msg.member.permissions.has('ADMINISTRATOR'))
 	// Make the requirements to use the conf command stricter than just who can add the bot to the guild
-    .addLevel(8, false, (client, msg) => client.config.botSupportTeam.includes(msg.author.id));
+    .addLevel(8, false, (client, msg) => client.configs.botSupportTeam.includes(msg.author.id));
 	// add a role above guild owners that let your support team help setup/troubleshoot on other guilds.
 
 new Client(config).login(config.token);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1162,7 +1162,7 @@ declare module 'klasa' {
 	export type KlasaProviderOptions = {
 		engine: string;
 		[key: string]: string | object;
-	}
+	};
 
 	export type ExecOptions = {
 		cwd?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1126,13 +1126,13 @@ declare module 'klasa' {
 
 	export type KlasaClientOptions = {
 		clientBaseDir?: string;
+		cmdDeleting?: boolean;
 		cmdEditing?: boolean;
 		cmdLogging?: boolean;
 		cmdPrompt?: boolean;
 		commandMessageLifetime?: number;
 		console?: KlasaConsoleConfig;
 		consoleEvents?: KlasaConsoleEvents;
-		deletableCommands: boolean;
 		ignoreBots?: boolean;
 		ignoreSelf?: boolean;
 		language?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1132,6 +1132,7 @@ declare module 'klasa' {
 		commandMessageLifetime?: number;
 		console?: KlasaConsoleConfig;
 		consoleEvents?: KlasaConsoleEvents;
+		deletableCommands: boolean;
 		ignoreBots?: boolean;
 		ignoreSelf?: boolean;
 		language?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -711,11 +711,12 @@ declare module 'klasa' {
 
 	export type constants = {
 		DEFAULTS: {
-			CLIENT: KlasaConstantsClient,
-			COMMAND: KlasaConstantsCommand,
-			GATEWAY_GUILDS_RESOLVER: (guildResolvable: string | KlasaGuild) => KlasaGuild,
-			GATEWAY_USERS_RESOLVER: (userResolvable: string | KlasaUser) => KlasaUser,
-			GATEWAY_CLIENTSTORAGE_RESOLVER: (clientResolvable: string | KlasaClient) => ClientUser
+			CLIENT: KlasaConstantsClient
+		};
+		GATEWAY_RESOLVERS: {
+			GUILDS: (guildResolvable: string | KlasaGuild) => KlasaGuild,
+			USERS: (userResolvable: string | KlasaUser) => KlasaUser,
+			CLIENT_STORAGE: (clientResolvable: string | KlasaClient) => ClientUser
 		};
 	};
 
@@ -1126,7 +1127,6 @@ declare module 'klasa' {
 
 	export type KlasaClientOptions = {
 		clientBaseDir?: string;
-		cmdDeleting?: boolean;
 		cmdEditing?: boolean;
 		cmdLogging?: boolean;
 		cmdPrompt?: boolean;
@@ -1138,18 +1138,31 @@ declare module 'klasa' {
 		language?: string;
 		ownerID?: string;
 		permissionLevels?: PermissionLevels;
+		pieceDefaults?: KlasaPieceDefaults;
 		prefix?: string;
 		preserveConfigs?: boolean;
 		promptTime?: number;
-		provider?: {
-			engine: string,
-			[key: string]: string | object
-		};
-		quotedStringSupport?: boolean;
+		provider?: KlasaProviderOptions;
 		readyMessage?: (client: KlasaClient) => string;
 		regexPrefix?: RegExp;
 		typing?: boolean;
 	} & ClientOptions;
+
+	export type KlasaPieceDefaults = {
+		commands?: CommandOptions;
+		events?: EventOptions;
+		extendables?: ExtendableOptions;
+		finalizers?: FinalizerOptions;
+		inhibitors?: InhibitorOptions;
+		languages?: LanguageOptions;
+		monitors?: MonitorOptions;
+		providers?: ProviderOptions;
+	};
+
+	export type KlasaProviderOptions = {
+		engine: string;
+		[key: string]: string | object;
+	}
 
 	export type ExecOptions = {
 		cwd?: string;
@@ -1181,28 +1194,21 @@ declare module 'klasa' {
 		ignoreBots: true;
 		ignoreSelf: true;
 		language: 'en-US';
+		pieceDefaults: {
+			commands: CommandOptions,
+			events: EventOptions,
+			extendables: ExtendableOptions,
+			finalizers: FinalizerOptions,
+			inhibitors: InhibitorOptions,
+			languages: LanguageOptions,
+			monitors: MonitorOptions,
+			providers: ProviderOptions
+		};
 		preserveConfigs: true;
 		promptTime: 30000;
 		provider: {};
-		quotedStringSupport: false;
 		readyMessage: (client: KlasaClient) => string;
 		typing: false;
-	};
-
-	export type KlasaConstantsCommand = {
-		aliases: string[];
-		autoAliases: true;
-		botPerms: string[];
-		cooldown: 0;
-		deletable: false;
-		description: string;
-		enabled: true;
-		guarded: false;
-		nsfw: false;
-		permLevel: 0;
-		requiredConfigs: string[];
-		runIn: string[];
-		usage: string;
 	};
 
 	export type GatewayOptions = {
@@ -1326,15 +1332,17 @@ declare module 'klasa' {
 
 	export type CommandOptions = {
 		aliases?: string[];
+		autoAliases?: boolean;
 		botPerms?: string[];
 		cooldown?: number;
+		deletable?: boolean;
 		description?: string | ((msg: KlasaMessage) => string);
 		enabled?: boolean;
 		extendedHelp?: string | ((msg: KlasaMessage) => string);
 		name?: string;
 		permLevel?: number;
 		quotedStringSupport?: boolean;
-		requiredSettings?: string[];
+		requiredConfigs?: string[];
 		runIn?: string[];
 		usage?: string;
 		usageDelim?: string;


### PR DESCRIPTION
### Description of the PR

This PR aims to provide ~~an option to default the value `Command.deletable` when not providen.~~ developers a new option in `KlasaClientOptions` where they can insert their default values for each kind of piece. For example:

```javascript
const { Client } = require('klasa');

new Client({
    prefix: '$',
    pieceDefaults: {
        commands: { quotedStringSupport: true },
        extendables: { enabled: false },
        monitors: { ignoreOthers: false }
    }
}).login('...');
```

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:
- Added a new option in `KlasaClientOptions` to allow developers to set their own defaults for each kind of piece.
- ~~Added `KlasaClientOptions.deletableCommands` to change the default value for `Command.deletable` when not given.~~

**Changed**:
- Updated the documentation and some outdated typings.

**Removed**:
- Removed `KlasaClientOptions.quotedStringSupport` in favor of the new per-piece defaults.

**Notes**:
- ~~I have noticed that `Command.quotedStringSupport` will always be `true` even when the developer wants it to be disabled (`false`), and this change will do the same for `Command.deletable` (perhaps use `Object.assign` to modify the defaults in the line 44 of `src/lib/structures/Command.js`?)~~

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
