### PR TITLE
Fixed Configuration's `updateMany` not parsing arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#130](https://github.com/dirigeants/klasa/pull/130)] Fixed Configuration's `updateMany` not parsing arrays. (kyranet)
 - [[#129](https://github.com/dirigeants/klasa/pull/129)] Fixed identifiers not being resolved correctly when using `Configuration#update`. (kyranet)
 - [[#129](https://github.com/dirigeants/klasa/pull/129)] Fixed both config commands not removing the entries. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Fixed many typos in the documentation. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
-- [[#130](https://github.com/dirigeants/klasa/pull/130)] Fixed Configuration's `updateMany` not parsing arrays. (kyranet)
+- [[#131](https://github.com/dirigeants/klasa/pull/131)] Fixed Configuration's `updateMany` not parsing arrays. (kyranet)
 - [[#129](https://github.com/dirigeants/klasa/pull/129)] Fixed identifiers not being resolved correctly when using `Configuration#update`. (kyranet)
 - [[#129](https://github.com/dirigeants/klasa/pull/129)] Fixed both config commands not removing the entries. (kyranet)
 - [[#125](https://github.com/dirigeants/klasa/pull/125)] Fixed many typos in the documentation. (kyranet)

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -413,7 +413,7 @@ class Configuration {
 			} else if (schema[key].array && !Array.isArray(object[key])) {
 				list.errors.push([schema[key].path, new Error(`${schema[key].path} expects an array as value.`)]);
 			} else {
-				const promise = schema[key].array ?
+				const promise = schema[key].array && schema[key].type !== 'any' ?
 					Promise.all(object[key].map(entry => schema[key].parse(entry, guild)
 						.then(Configuration.getIdentifier)
 						.catch(error => { list.errors.push([schema[key].path, error]); }))) :

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -412,6 +412,8 @@ class Configuration {
 				this._updateMany(cache[key], object[key], schema[key], guild, list, updateObject);
 			} else if (schema[key].array && !Array.isArray(object[key])) {
 				list.errors.push([schema[key].path, new Error(`${schema[key].path} expects an array as value.`)]);
+			} else if (!schema[key].array && schema[key].array !== 'any' && Array.isArray(object[key])) {
+				list.errors.push([schema[key].path, new Error(`${schema[key].path} does not expect an array as value.`)]);
 			} else {
 				const promise = schema[key].array && schema[key].type !== 'any' ?
 					Promise.all(object[key].map(entry => schema[key].parse(entry, guild)

--- a/src/lib/structures/Configuration.js
+++ b/src/lib/structures/Configuration.js
@@ -260,6 +260,7 @@ class Configuration {
 
 		const oldClone = this.client.listenerCount('configUpdateEntry') ? this.clone() : null;
 		const updateObject = {};
+		guild = this.gateway._resolveGuild(guild);
 		this._updateMany(this, object, this.gateway.schema, guild, list, updateObject);
 		await Promise.all(list.promises);
 
@@ -404,25 +405,31 @@ class Configuration {
 	 * @private
 	 */
 	_updateMany(cache, object, schema, guild, list, updateObject) {
-		guild = this.gateway._resolveGuild(guild);
-		const keys = Object.keys(object);
-		for (let i = 0; i < keys.length; i++) {
-			const key = keys[i];
-			if (schema.hasKey(key) === false) continue;
+		for (const key of Object.keys(object)) {
+			if (!schema.hasKey(key)) continue;
 			if (schema[key].type === 'Folder') {
-				if (!updateObject[key]) updateObject[key] = {};
-				this._updateMany(cache[key], object[key], schema[key], guild, list, updateObject[key]);
-				continue;
+				if (!(key in updateObject)) updateObject = updateObject[key] = {};
+				this._updateMany(cache[key], object[key], schema[key], guild, list, updateObject);
+			} else if (schema[key].array && !Array.isArray(object[key])) {
+				list.errors.push([schema[key].path, new Error(`${schema[key].path} expects an array as value.`)]);
+			} else {
+				const promise = schema[key].array ?
+					Promise.all(object[key].map(entry => schema[key].parse(entry, guild)
+						.then(Configuration.getIdentifier)
+						.catch(error => { list.errors.push([schema[key].path, error]); }))) :
+					schema[key].parse(object[key], guild);
+
+				list.promises.push(promise
+					.then(parsed => {
+						const parsedID = schema[key].array ?
+							parsed.filter(entry => typeof entry !== 'undefined') :
+							Configuration.getIdentifier(parsed);
+						updateObject[key] = cache[key] = parsedID;
+						list.keys.push(schema[key].path);
+						list.values.push(parsedID);
+					})
+					.catch(error => list.errors.push([schema.path, error])));
 			}
-			list.promises.push(schema[key].parse(object[key], guild)
-				.then(parsed => {
-					const parsedID = Configuration.getIdentifier(parsed);
-					cache[key] = parsedID;
-					updateObject[key] = parsedID;
-					list.keys.push(schema[key].path);
-					list.values.push(parsedID);
-				})
-				.catch(error => list.errors.push([schema[key].path, error])));
 		}
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -895,7 +895,7 @@ declare module 'klasa' {
 		public dir: string;
 		public file: string;
 
-		public get(term: string, ...args: any[]): string | ((...args: any) => string);
+		public get(term: string, ...args: any[]): string | ((...args: any[]) => string);
 		public abstract init(): any;
 
 		public abstract enable(): Piece;


### PR DESCRIPTION
### Description of the PR

Configuration#updateMany was passing raw values to the parser, even when it's an array. This PR fixes that by parsing each value from the array correctly.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed Configuration's `updateMany` not parsing arrays.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
