### PR TITLE
Fixed ClientStorage configs not updating across shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#145](https://github.com/dirigeants/klasa/pull/145)] Fixed ClientStorage configs not updating across shards, and added a missing check in some `broadcastEval`s. (kyranet)
 - [[#142](https://github.com/dirigeants/klasa/pull/142)] Fixed a critical bug in nested objects when using the JSON provider. Note: `Object.assign` doesn't merge nested objects. (kyranet)
 - [[#141](https://github.com/dirigeants/klasa/pull/141)] Fixed `KlasaConsoleConfigs` not defaulting correctly. (bdistin)
 - [[#141](https://github.com/dirigeants/klasa/pull/141)] Fixed wrong sharding behaviour when using PM2 in a non-sharded bot. (bdistin)

--- a/src/lib/settings/SchemaFolder.js
+++ b/src/lib/settings/SchemaFolder.js
@@ -406,7 +406,12 @@ class SchemaFolder extends Schema {
 	 */
 	async _shardSyncSchema(piece, action, force) {
 		if (!this.client.sharded) return;
-		await this.client.shard.broadcastEval(`this.gateways.${this.gateway.type}._shardSync(${piece.path.split('.')}, ${JSON.stringify(piece)}, ${action}, ${force});`);
+		await this.client.shard.broadcastEval(`
+			if (this.shard.id !== ${this.client.shard.id}) {
+				this.gateways.${this.gateway.type}._shardSync(
+					${JSON.stringify(piece.path.split('.'))}, ${JSON.stringify(piece)}, ${action}, ${force});
+			}
+		`);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR

This PR adds a missing check in SchemaFolder's cross-shard updating (to not update itself) and fixes the event `configUpdateEntry` to also update ClientStorage's entries.

This PR also fixes a *SchemaFolder's cross-shard updater* bug: the first parameter, `path`, accepts an array, and a stringified array has the format of `management,roles,administrator` instead of `["management","roles","administrator"]`, resulting on errors for sharded bots.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Fixes**:

- Fixed ClientStorage configs not updating across shards, and added a missing check in some `broadcastEval`s.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
