### PR TITLE
Added docs for CreatingCustomArguments

### DIFF
--- a/tutorials/CreatingCustomArguments.md
+++ b/tutorials/CreatingCustomArguments.md
@@ -1,5 +1,7 @@
 One of the best features from Klasa's (and Komada's) usage is that you can extend its functionality by adding new types, to achieve that, we will use our {@link Extendable}s. We will create an empty extendable, called `emoji.js`, and aim it to Klasa:
 
+> **Note**: The following argument type type is already included in klasa, and is just an explanation of how it works.
+
 ```javascript
 const { Extendable } = require('klasa');
 
@@ -16,7 +18,7 @@ module.exports = class extends Extendable {
 };
 ```
 
-Note that the class we want to extend to add new types to usage is **{@link ArgResolver}**, which belongs to `klasa`, so we put only `'ArgResolver'` to the classes we want to extend, and select `klasa: true` in the {@link ExtendableOptions}.
+> **Note**: that the class we want to extend to add new types to usage is **{@link ArgResolver}**, which belongs to `klasa`, so we put only `'ArgResolver'` to the classes we want to extend, and select `klasa: true` in the {@link ExtendableOptions}.
 
 Each method in ArgResolver takes 5 parameters:
 
@@ -56,8 +58,8 @@ How does the new extendable or custom argument work?
 1. Let's consider arg is `<:klasa:354702113147846666>`. The result of `exec`uting `REGEX_EMOJI` on that string gives an array-like object: `['<:klasa:354702113147846666>', '354702113147846666', index: 0, input: '<:klasa:354702113147846666>']`.
 1. There are cases the argument does not match, in that case, `results` would be `null`. So we verify its existence and get the first grouping match: `(\d{17,19})`, which gets the **id** of the emoji, and as we see in the result, it is in the second index: `'354702113147846666'`, and we get the emoji with said id.
 1. If `results` was null, `emoji` would be `null` too due to the ternary condition, but there is also the possibility of emoji being undefined: when the client does not have the Emoji instance cached or is in a guild the bot is not in. The case is, **if the emoji is valid and found, we should return it**.
-1. If the emoji was valid and found, we do not run the two next steps, 4 and 5. The fourth line of code inside `extend` handles optional arguments: if it's optional or it's a repeating tag, it should not throw, but return null.
-1. Finally, the argument was required and/or not looping/repeating, so we should throw an error. That error must be a string and you can use i18n to have localized errors.
+1. If the emoji was valid and found, we do not run the two next steps, 4 and 5. The fourth line of code inside `extend` handles optional arguments: if it's optional and it's not a repeating tag, it should not throw, but return null.
+1. Finally, the argument was required and/or looping/repeating, so we should throw an error. That error must be a string and you can use i18n to have localized errors.
 
 And now, you can use this type in a command! For example, the following:
 

--- a/tutorials/CreatingCustomArguments.md
+++ b/tutorials/CreatingCustomArguments.md
@@ -1,0 +1,81 @@
+One of the best features from Klasa's (and Komada's) usage is that you can extend its functionality by adding new types, to achieve that, we will use our {@link Extendable}s. We will create an empty extendable, called `emoji.js`, and aim it to Klasa:
+
+```javascript
+const { Extendable } = require('klasa');
+
+module.exports = class extends Extendable {
+
+	constructor(...args) {
+		super(...args, ['ArgResolver'], { klasa: true });
+	}
+
+	extend() {
+		// `this` reffers to the parent class, and not this one. You cannot use super
+	}
+
+};
+```
+
+Note that the class we want to extend to add new types to usage is **{@link ArgResolver}**, which belongs to `klasa`, so we put only `'ArgResolver'` to the classes we want to extend, and select `klasa: true` in the {@link ExtendableOptions}.
+
+Each method in ArgResolver takes 5 parameters:
+
+| Name             | Type                 | Description                            |
+| ---------------- | -------------------- | -------------------------------------- |
+| **arg**          | string               | The parameter given to parse           |
+| **currentUsage** | Object               | The current usage                      |
+| **possible**     | number               | The possible's index                   |
+| **repeat**       | boolean              | If it is a looping/repeating arg       |
+| **msg**          | {@link KlasaMessage} | The message that triggered the command |
+
+```javascript
+const { Extendable } = require('klasa');
+const REGEX_EMOJI = /^(?:<a?:\w{2,32}:)?(\d{17,19})>?$/;
+
+module.exports = class extends Extendable {
+
+	constructor(...args) {
+		super(...args, ['ArgResolver'], { klasa: true });
+	}
+
+	async extend(arg, currentUsage, possible, repeat, msg) {
+		const results = REGEX_EMOJI.exec(arg);
+		const emoji = results ? this.client.emojis.get(results[1]) : null;
+		if (emoji) return emoji;
+		if (currentUsage.type === 'optional' && !repeat) return null;
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_EMOJI', currentUsage.possibles[possible].name);
+	}
+
+};
+```
+
+> **Note**: All methods from ArgResolver must return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+How does the new extendable or custom argument work?
+
+1. Let's consider arg is `<:klasa:354702113147846666>`. The result of `exec`uting `REGEX_EMOJI` on that string gives an array-like object: `['<:klasa:354702113147846666>', '354702113147846666', index: 0, input: '<:klasa:354702113147846666>']`.
+2. There are cases the argument does not match, in that case, `results` would be `null`. So we verify its existence and get the first grouping match: `(\d{17,19})`, which gets the **id** of the emoji, and as we see in the result, it is in the second index: `'354702113147846666'`, and we get the emoji with said id.
+3. If `results` was null, `emoji` would be `null` too due to the ternary condition, but there is also the possibility of emoji being undefined: when the client does not have the Emoji instance cached or is in a guild the bot is not in. The case is, **if the emoji is valid and found, we should return it**.
+4. If the emoji was valid and found, we do not run the two next steps, 4 and 5. The fourth line of code inside `extend` handles optional arguments: if it's optional or it's a repeating tag, it should not throw, but return null.
+5. Finally, the argument was required and/or not looping/repeating, so we should throw an error. That error must be a string and you can use i18n to have localized errors.
+
+And now, you can use this type in a command! For example, the following:
+
+```javascript
+const { Command } = require('klasa');
+
+module.exports = class extends Command {
+
+	constructor(...args) {
+		super(...args, {
+			description: 'Get the name of an emoji.',
+			usage: '<emoji:emoji>'
+		});
+	}
+
+	run(msg, [emoji]) {
+		return msg.sendMessage(`The name of the emoji ${emoji} is: ${emoji.name}`);
+	}
+
+};
+```

--- a/tutorials/CreatingCustomArguments.md
+++ b/tutorials/CreatingCustomArguments.md
@@ -54,10 +54,10 @@ module.exports = class extends Extendable {
 How does the new extendable or custom argument work?
 
 1. Let's consider arg is `<:klasa:354702113147846666>`. The result of `exec`uting `REGEX_EMOJI` on that string gives an array-like object: `['<:klasa:354702113147846666>', '354702113147846666', index: 0, input: '<:klasa:354702113147846666>']`.
-2. There are cases the argument does not match, in that case, `results` would be `null`. So we verify its existence and get the first grouping match: `(\d{17,19})`, which gets the **id** of the emoji, and as we see in the result, it is in the second index: `'354702113147846666'`, and we get the emoji with said id.
-3. If `results` was null, `emoji` would be `null` too due to the ternary condition, but there is also the possibility of emoji being undefined: when the client does not have the Emoji instance cached or is in a guild the bot is not in. The case is, **if the emoji is valid and found, we should return it**.
-4. If the emoji was valid and found, we do not run the two next steps, 4 and 5. The fourth line of code inside `extend` handles optional arguments: if it's optional or it's a repeating tag, it should not throw, but return null.
-5. Finally, the argument was required and/or not looping/repeating, so we should throw an error. That error must be a string and you can use i18n to have localized errors.
+1. There are cases the argument does not match, in that case, `results` would be `null`. So we verify its existence and get the first grouping match: `(\d{17,19})`, which gets the **id** of the emoji, and as we see in the result, it is in the second index: `'354702113147846666'`, and we get the emoji with said id.
+1. If `results` was null, `emoji` would be `null` too due to the ternary condition, but there is also the possibility of emoji being undefined: when the client does not have the Emoji instance cached or is in a guild the bot is not in. The case is, **if the emoji is valid and found, we should return it**.
+1. If the emoji was valid and found, we do not run the two next steps, 4 and 5. The fourth line of code inside `extend` handles optional arguments: if it's optional or it's a repeating tag, it should not throw, but return null.
+1. Finally, the argument was required and/or not looping/repeating, so we should throw an error. That error must be a string and you can use i18n to have localized errors.
 
 And now, you can use this type in a command! For example, the following:
 

--- a/tutorials/names.json
+++ b/tutorials/names.json
@@ -31,6 +31,9 @@
 	"UnderstandingUsageStrings": {
 		"title": "Understanding Usage Strings"
 	},
+	"CreatingCustomArguments": {
+		"title": "Creating Custom Arguments"
+	},
 	"UnderstandingPermissionLevels": {
 		"title": "Understanding Permission Levels"
 	},


### PR DESCRIPTION
### Description of the PR

This PR adds a new page to the tutorials page, which explains how to make our own custom arguments or types for usage. To do so, this PR also finishes with one of the items from the 1.0.0 Milestone.

The new tutorial page includes a step-by-step explained extendable for a type called **emoji**, including the extendable's options, the argument types for ArgResolver's methods, their types, and how to use them.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added CreatingCustomArguments tutorial.

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
