### PR TITLE
Fixed the reaction handler using endpoints without permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#148](https://github.com/dirigeants/klasa/pull/148)] Fixed ReactionHandler trying to remove reactions from other users or clear all reactions from a message even when the client doesn't have permissions in the guild or is in DMs [#147](https://github.com/dirigeants/klasa/issues/147). (kyranet)
 - [[#142](https://github.com/dirigeants/klasa/pull/142)] Fixed a critical bug in nested objects when using the JSON provider. Note: `Object.assign` doesn't merge nested objects. (kyranet)
 - [[#141](https://github.com/dirigeants/klasa/pull/141)] Fixed `KlasaConsoleConfigs` not defaulting correctly. (bdistin)
 - [[#141](https://github.com/dirigeants/klasa/pull/141)] Fixed wrong sharding behaviour when using PM2 in a non-sharded bot. (bdistin)

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -126,7 +126,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @readonly
 	 */
 	get unreactable() {
-		return this.message.guild && this.message.guild.permissionsFor(this.message.guild.me).has('MANAGE_MESSAGES');
+		return Boolean(this.message.guild) && this.message.channel.permissionsFor(this.message.guild.me).has('MANAGE_MESSAGES');
 	}
 
 	/**

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -111,11 +111,11 @@ class ReactionHandler extends ReactionCollector {
 
 		this._queueEmojiReactions(emojis.slice(0));
 		this.on('collect', (reaction, reactionAgain, user) => {
-			reaction.remove(user);
+			if (this.unreactable) reaction.remove(user);
 			this[this.methodMap.get(reaction.emoji.name)](user);
 		});
 		this.on('end', () => {
-			if (this.reactionsDone) this.message.clearReactions();
+			if (this.reactionsDone && this.unreactable) this.message.clearReactions();
 		});
 	}
 

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -126,8 +126,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @readonly
 	 */
 	get unreactable() {
-		if (!this.message.guild) return false;
-		return this.message.guild.permissionsFor(this.message.guild.me).has('MANAGE_MESSAGES');
+		return this.message.guild && this.message.guild.permissionsFor(this.message.guild.me).has('MANAGE_MESSAGES');
 	}
 
 	/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -265,6 +265,7 @@ declare module 'klasa' {
 		public awaiting: boolean;
 		public selection: Promise<number>;
 		public reactionsDone: boolean;
+		public readonly unreactable: boolean;
 
 		public first(): void;
 		public back(): void;


### PR DESCRIPTION
### Description of the PR

Fixes #147 

When using RichDisplay/RichMenu in channels where the bot does not have the `MANAGE_MESSAGES` permission or in DMs, the ReactionHandler instance was trying to delete the reactions from the user, and clear all reactions when the ReactionHandler stops/finishes. Both actions can only be executed in a guild and with the previously mentioned permissions.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed ReactionHandler trying to remove reactions from other users or clear all reactions from a message even when the client doesn't have permissions in the guild or is in DMs

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
