### PR TITLE
Fixed partial cloning bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#150](https://github.com/dirigeants/klasa/pull/150)] Added `util.deepClone` to clone objects. (kyranet)
 - [[#142](https://github.com/dirigeants/klasa/pull/142)] Added several typing-related methods to get deeper (JSDoc) types. (kyranet)
 - [[#138](https://github.com/dirigeants/klasa/pull/138)] Added `util.getTypeName` to get the input's type. (kyranet)
 - [[#136](https://github.com/dirigeants/klasa/pull/136)] Added flag arguments. (bdistin)
@@ -118,6 +119,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#150](https://github.com/dirigeants/klasa/pull/150)] Fixed a wrong type in typings. (kyranet)
+- [[#150](https://github.com/dirigeants/klasa/pull/150)] Fixed a bug where some objects would be partially cloned when adding new keys or defaulting. (kyranet)
 - [[#142](https://github.com/dirigeants/klasa/pull/142)] Fixed a critical bug in nested objects when using the JSON provider. Note: `Object.assign` doesn't merge nested objects. (kyranet)
 - [[#141](https://github.com/dirigeants/klasa/pull/141)] Fixed `KlasaConsoleConfigs` not defaulting correctly. (bdistin)
 - [[#141](https://github.com/dirigeants/klasa/pull/141)] Fixed wrong sharding behaviour when using PM2 in a non-sharded bot. (bdistin)

--- a/src/lib/settings/GatewayStorage.js
+++ b/src/lib/settings/GatewayStorage.js
@@ -1,5 +1,5 @@
 const SchemaFolder = require('./SchemaFolder');
-const { tryParse } = require('../util/util');
+const { tryParse, deepClone } = require('../util/util');
 const { resolve } = require('path');
 const fs = require('fs-nextra');
 
@@ -200,9 +200,9 @@ class GatewayStorage {
 	 * @private
 	 */
 	static _parseSQLValue(value, schemaPiece) {
-		if (typeof value === 'undefined') return schemaPiece.array ? schemaPiece.default.slice(0) : schemaPiece.default;
+		if (typeof value === 'undefined') return deepClone(schemaPiece.default);
 		if (schemaPiece.array) {
-			if (value === null) return schemaPiece.default.slice(0);
+			if (value === null) return deepClone(schemaPiece.default);
 			if (typeof value === 'string') value = tryParse(value);
 			if (Array.isArray(value)) return value.map(val => GatewayStorage._parseSQLValue(val, schemaPiece));
 		} else {

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -92,25 +92,26 @@ class Util {
 	 * @returns {*}
 	 */
 	static deepClone(source) {
+		// Check if it's a primitive (with exception of function and null, which is typeof object)
 		if (typeof source !== 'object' || source === null) return source;
 		if (Array.isArray(source)) {
 			const output = new Array(source.length);
 			for (let i = 0; i < source.length; i++) output[i] = Util.deepClone(source[i]);
 			return output;
 		}
-		if (source instanceof Map) {
+		if (Util.isObject(source)) {
+			const output = {};
+			for (const key in source) output[key] = source[key];
+			return output;
+		}
+		if (source instanceof Map || source instanceof WeakMap) {
 			const output = new source.constructor();
 			for (const [key, value] of source.entries()) output.set(key, Util.deepClone(value));
 			return output;
 		}
-		if (source instanceof Set) {
+		if (source instanceof Set || source instanceof WeakSet) {
 			const output = new source.constructor();
 			for (const value of source.values()) output.add(Util.deepClone(value));
-			return output;
-		}
-		if (Util.isObject(source)) {
-			const output = {};
-			for (const key in source) output[key] = source[key];
 			return output;
 		}
 		return source;

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -86,6 +86,37 @@ class Util {
 	}
 
 	/**
+	 * Deep clone a value
+	 * @since 0.5.0
+	 * @param {*} source The object to clone
+	 * @returns {*}
+	 */
+	static deepClone(source) {
+		if (typeof source !== 'object' || source === null) return source;
+		if (Array.isArray(source)) {
+			const output = new Array(source.length);
+			for (let i = 0; i < source.length; i++) output[i] = Util.deepClone(source[i]);
+			return output;
+		}
+		if (source instanceof Map) {
+			const output = new source.constructor();
+			for (const [key, value] of source.entries()) output.set(key, Util.deepClone(value));
+			return output;
+		}
+		if (source instanceof Set) {
+			const output = new source.constructor();
+			for (const value of source.values()) output.add(Util.deepClone(value));
+			return output;
+		}
+		if (Util.isObject(source)) {
+			const output = {};
+			for (const key in source) output[key] = source[key];
+			return output;
+		}
+		return source;
+	}
+
+	/**
 	 * Applies an interface to a class
 	 * @since 0.1.1
 	 * @param {Object} base The interface to apply to a structure

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -329,6 +329,7 @@ declare module 'klasa' {
 		public static applyToClass(base: object, structure: object, skips?: string[]): void;
 		public static clean(text: string): string;
 		public static codeBlock(lang: string, expression: string): string;
+		public static deepClone(source: any): any;
 		public static exec(exec: string, options?: ExecOptions): Promise<{ stdout: string, stderr: string }>;
 		public static getDeepTypeMap(input: Map<any, any> | WeakMap<object, any> | Collection<any, any>, basic?: string): string;
 		public static getDeepTypeName(input: any): string;
@@ -483,7 +484,7 @@ declare module 'klasa' {
 		public constructor(levels?: number);
 		public requiredLevels: number;
 
-		public addLevel(level: number, brk: boolean, check: (client: KlasaMessage, msg: KlasaMessage) => true): this;
+		public addLevel(level: number, brk: boolean, check: (client: KlasaClient, msg: KlasaMessage) => boolean): this;
 		public set(level: number, obj: PermissionLevel): this;
 		public isValid(): boolean;
 		public debug(): string;


### PR DESCRIPTION
### Description of the PR

This PR fixes the default cloning from the settings system, resulting on impartial clones, while also removing repetitive checks (ternaries checking if the schema is type array), and adds a deepClone function capable to clone arrays, sets, maps, objects, and, virtually, primitives (they are passed by value anyways).

Also removes some dust from #121 where I added an extra check for a custom Gateway for ClientStorage (which got reverted lately in favor of consistency and reduce complexity).

And fixes a bug reported by a user where the type of one of our functions were wrong, causing TSLint to complain.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- `util.deepClone` to clone objects.

**Fixed**:

- Fixed a bug where some objects would be partially cloned when adding new keys or defaulting.
- Fixed a wrong type in typings.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
