### PR TITLE
Typings refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#158](https://github.com/dirigeants/klasa/pull/158)] Refactored typings and JSDoc types. (kyranet)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Tweaked `Configuration#update` to accept the overload `(key: string, value: any, options:ConfigurationUpdateOptions)` as opposed of passing `undefined` in the `guild` field between `value` and `options`. (kyranet)
 - [[#155](https://github.com/dirigeants/klasa/pull/155)] Complexity reductions for `SchemaFolder#addKey` and `Colors`. (bdistin)
 - [[`338ebb0eb2`](https://github.com/dirigeants/klasa/commit/338ebb0eb2334810229720eda3abab198d6cc0ba)] Prefixed `Timestamp#_resolveDate`. (bdistin)
@@ -120,6 +121,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#158](https://github.com/dirigeants/klasa/pull/158)] `Configuration#updateMany` is now under `Configuration#update`, in favor of a much less confusing naming. (kyranet)
 - [[`5b0c468362`](https://github.com/dirigeants/klasa/commit/5b0c46836200a57577bbd4aaa5cd463089a3bff0)] Removed `KlasaClient.sharded` as `Client.shard` is now fixed. (bdistin)
 - [[#136](https://github.com/dirigeants/klasa/pull/136)] Removed `util.newError`. (bdistin)
 - [[#129](https://github.com/dirigeants/klasa/pull/129)] **[BREAKING]** Removed the methods `Configuration#updateOne`, `Configuration#updateArray`. They're replaced by `Configuration#update`. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[`692e485d2b`](https://github.com/dirigeants/klasa/commit/692e485d2b7af5bf2b1d29c9e2dc4871f2e04f06)] Implemented the wildcards `?`, `H`, and the scheduling definition `@annually`. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added `time`, `duration`, `date` and `task` types to `ArgResolver`. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added `Duration`, a class helper to resolve human duration input into milliseconds. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added new key to `ClientStorage`: `schedules`. (kyranet)

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   },
   "devDependencies": {
     "@types/node": "^9.3.0",
-    "eslint": "^4.14.0",
+    "eslint": "^4.15.0",
     "ink-docstrap": "github:bdistin/docstrap#klasa",
     "jsdoc": "github:jsdoc3/jsdoc",
     "markdownlint-cli": "^0.6.0",
-    "tslint": "^5.8.0",
+    "tslint": "^5.9.1",
     "typescript": "^2.6.2"
   },
   "engines": {

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -43,7 +43,7 @@ class KlasaClient extends Discord.Client {
 	 * @property {PermissionLevels} [permissionLevels=KlasaClient.defaultPermissionLevels] The permission levels to use with this bot
 	 * @property {string} [clientBaseDir=path.dirname(require.main.filename)] The directory where all piece folders can be found
 	 * @property {number} [commandMessageLifetime=1800] The threshold for how old command messages can be before sweeping since the last edit in seconds
-	 * @property {object} [provider] The provider to use in Klasa
+	 * @property {Object} [provider] The provider to use in Klasa
 	 * @property {KlasaConsoleConfig} [console={}] Config options to pass to the client console
 	 * @property {KlasaConsoleEvents} [consoleEvents={}] Config options to pass to the client console
 	 * @property {KlasaPieceDefaults} [pieceDefaults={}] Overrides the defaults for all pieces
@@ -229,7 +229,7 @@ class KlasaClient extends Discord.Client {
 		/**
 		 * Additional methods to be used elsewhere in the bot
 		 * @since 0.0.1
-		 * @type {object}
+		 * @type {Object}
 		 * @property {class} Collection A discord.js collection
 		 * @property {class} Embed A discord.js Message Embed
 		 * @property {class} MessageCollector A discord.js MessageCollector

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -13,7 +13,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * * A string
 		 * * An array (joined with a new line delimiter to give a string)
 		 * * Any value
-		 * @typedef {string|Array|*} StringResolvable
+		 * @typedef {(string|Array|*)} StringResolvable
 		 * @memberof KlasaMessage
 		 */
 
@@ -153,7 +153,7 @@ module.exports = Structures.extend('Message', Message => {
 		/**
 		 * The usable commands by the author in this message's context
 		 * @since 0.0.1
-		 * @returns {Promise<Collection>} The filtered CommandStore
+		 * @returns {Promise<Collection<string, Command>>} The filtered CommandStore
 		 */
 		async usableCommands() {
 			const col = new Collection();

--- a/src/lib/permissions/PermissionLevels.js
+++ b/src/lib/permissions/PermissionLevels.js
@@ -9,7 +9,7 @@ const { Collection } = require('discord.js');
 class PermissionLevels extends Collection {
 
 	/**
-	 * @typedef {Object} permissionLevelResponse
+	 * @typedef {Object} PermissionLevelsData
 	 * @property {boolean} broke Whether the loop broke execution of higher levels
 	 * @property {boolean} permission Whether the permission level check passed or not
 	 * @memberof PermissionLevels
@@ -51,7 +51,7 @@ class PermissionLevels extends Collection {
 	 * Adds levels to the levels cache to be converted to valid permission structure
 	 * @since 0.2.1
 	 * @param {number} level The permission number for the level you are defining
-	 * @param {permissionLevelResponse} obj Whether the level should break (stop processing higher levels, and inhibit a no permission error)
+	 * @param {PermissionLevelsData} obj Whether the level should break (stop processing higher levels, and inhibit a no permission error)
 	 * @returns {PermissionLevels} This permission levels
 	 * @private
 	 */
@@ -90,7 +90,7 @@ class PermissionLevels extends Collection {
 	 * @since 0.2.1
 	 * @param {KlasaMessage} msg The message to pass to perm level functions
 	 * @param {number} min The minimum permissionLevel ok to pass
-	 * @returns {permissionLevelResponse}
+	 * @returns {PermissionLevelsData}
 	 */
 	async run(msg, min) {
 		const mps = [];

--- a/src/lib/schedule/Schedule.js
+++ b/src/lib/schedule/Schedule.js
@@ -47,6 +47,7 @@ class Schedule {
 
 	/**
 	 * Get all the tasks from the cache
+	 * @since 0.5.0
 	 * @returns {ScheduledTaskOptions[]}
 	 * @private
 	 */

--- a/src/lib/schedule/ScheduledTask.js
+++ b/src/lib/schedule/ScheduledTask.js
@@ -93,6 +93,7 @@ class ScheduledTask {
 	/**
 	 * @since 0.5.0
 	 * @type {Task}
+	 * @readonly
 	 */
 	get task() {
 		return this.client.tasks.get(this.taskName);
@@ -141,7 +142,6 @@ class ScheduledTask {
 	/**
 	 * Delete the task
 	 * @since 0.5.0
-	 * @readonly
 	 * @returns {Promise<Schedule>}
 	 */
 	delete() {

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -19,21 +19,21 @@ class Gateway extends GatewayStorage {
 	 */
 
 	/**
-	 * @typedef {(KlasaGuild|KlasaMessage|external:TextChannel|external:VoiceChannel|external:CategoryChannel|external:Member|external:GuildChannel|external:Role)} GatewayGuildResolvable
-	 * @memberof Gateway
-	 */
-
-	/**
-	 * @typedef {Object} GatewayPathOptions
+	 * @typedef {Object} GatewayGetPathOptions
 	 * @property {boolean} [avoidUnconfigurable=false]
 	 * @property {boolean} [piece=true]
 	 * @memberof Gateway
 	 */
 
 	/**
-	 * @typedef {Object} GatewayPathResult
+	 * @typedef {Object} GatewayGetPathResult
 	 * @property {SchemaPiece} path
 	 * @property {string[]} route
+	 * @memberof Gateway
+	 */
+
+	/**
+	 * @typedef {(KlasaGuild|KlasaMessage|external:TextChannel|external:VoiceChannel|external:CategoryChannel|external:GuildMember|external:Role)} GuildResolvable
 	 * @memberof Gateway
 	 */
 
@@ -214,7 +214,7 @@ class Gateway extends GatewayStorage {
 	 * Resolve a path from a string.
 	 * @since 0.5.0
 	 * @param {string} [key=null] A string to resolve
-	 * @param {GatewayPathOptions} [options={}] Whether the Gateway should avoid configuring the selected key
+	 * @param {GatewayGetPathOptions} [options={}] Whether the Gateway should avoid configuring the selected key
 	 * @returns {GatewayPathResult}
 	 */
 	getPath(key = '', { avoidUnconfigurable = false, piece = true } = {}) {
@@ -284,7 +284,7 @@ class Gateway extends GatewayStorage {
 	/**
 	 * Resolves a guild
 	 * @since 0.5.0
-	 * @param {GatewayGuildResolvable} guild A guild resolvable
+	 * @param {GuildResolvable} guild A guild resolvable
 	 * @returns {?KlasaGuild}
 	 * @private
 	 */

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -7,9 +7,9 @@ const Gateway = require('./Gateway');
 class GatewayDriver {
 
 	/**
-	 * @typedef {Object} SettingsOptions
+	 * @typedef {Object} GatewayDriverAddOptions
 	 * @property {string} [provider]
-	 * @property {boolean} [nice]
+	 * @property {boolean} [nice=false]
 	 * @memberof GatewayDriver
 	 */
 
@@ -159,7 +159,7 @@ class GatewayDriver {
 	 * @param {string} name The name for the new instance
 	 * @param {Function} validateFunction The function that validates the input
 	 * @param {Object} [schema={}] The schema
-	 * @param {SettingsOptions} [options={}] A provider to use. If not specified it'll use the one in the client
+	 * @param {GatewayDriverAddOptions} [options={}] A provider to use. If not specified it'll use the one in the client
 	 * @param {boolean} [download=true] Whether this Gateway should download the data from the database at init
 	 * @returns {Gateway}
 	 * @example

--- a/src/lib/settings/SchemaFolder.js
+++ b/src/lib/settings/SchemaFolder.js
@@ -9,7 +9,7 @@ const fs = require('fs-nextra');
 class SchemaFolder extends Schema {
 
 	/**
-	 * @typedef {Object} AddOptions
+	 * @typedef {Object} SchemaFolderAddOptions
 	 * @property {string} type The type for the key
 	 * @property {*} [default] The default value for the key
 	 * @property {number} [min] The min value for the key (String.length for String, value for number)
@@ -150,7 +150,7 @@ class SchemaFolder extends Schema {
 	 * Add a new key to this folder.
 	 * @since 0.5.0
 	 * @param {string} key The name for the key
-	 * @param {AddOptions} options The key's options to apply
+	 * @param {SchemaFolderAddOptions} options The key's options to apply
 	 * @param {boolean} [force=true] Whether this function call should modify all entries from the database
 	 * @returns {Promise<SchemaFolder>}
 	 */
@@ -335,7 +335,7 @@ class SchemaFolder extends Schema {
 	 * Add a key to the instance.
 	 * @since 0.5.0
 	 * @param {string} key The name of the key
-	 * @param {AddOptions} options The options of the key
+	 * @param {SchemaFolderAddOptions} options The options of the key
 	 * @param {(SchemaFolder|SchemaPiece)} Piece The class to create
 	 * @returns {(SchemaFolder|SchemaPiece)}
 	 * @private
@@ -391,7 +391,7 @@ class SchemaFolder extends Schema {
 	 * Verifies the key add options.
 	 * @since 0.5.0
 	 * @param {string} key The name for the key
-	 * @param {AddOptions} options The key's options to apply
+	 * @param {SchemaFolderAddOptions} options The key's options to apply
 	 * @returns {addOptions}
 	 * @private
 	 */

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -8,24 +8,24 @@ const fs = require('fs-nextra');
 class SchemaPiece extends Schema {
 
 	/**
-	 * @typedef {Object} SchemaPieceJSON
-	 * @property {string} type The type for the key
-	 * @property {*} default The default value for the key
-	 * @property {number} min The min value for the key (String.length for String, value for number)
-	 * @property {number} max The max value for the key (String.length for String, value for number)
-	 * @property {string[]} sql A tuple containing the name of the column and its data type
-	 * @property {boolean} array Whether the key should be stored as Array or not
-	 * @property {boolean} configurable Whether the key should be configurable by the config command or not
-	 * @memberof SchemaPiece
-	 */
-
-	/**
-	 * @typedef {Object} ModifyOptions
+	 * @typedef {Object} SchemaPieceModifyOptions
 	 * @property {*} [default] The new default value
 	 * @property {number} [min] The new minimum range value
 	 * @property {number} [max] The new maximum range value
 	 * @property {boolean} [configurable] The new configurable value
 	 * @property {string} [sql] The new sql datatype
+	 * @memberof SchemaPiece
+	 */
+
+	/**
+	 * @typedef {Object} SchemaPieceJSON
+	 * @property {string} type The type for the key
+	 * @property {*} default The default value for the key
+	 * @property {number} min The min value for the key (String.length for String, value for number)
+	 * @property {number} max The max value for the key (String.length for String, value for number)
+	 * @property {string} sql A tuple containing the name of the column and its data type
+	 * @property {boolean} array Whether the key should be stored as Array or not
+	 * @property {boolean} configurable Whether the key should be configurable by the config command or not
 	 * @memberof SchemaPiece
 	 */
 
@@ -146,7 +146,7 @@ class SchemaPiece extends Schema {
 	/**
 	 * Modify this SchemaPiece's properties.
 	 * @since 0.5.0
-	 * @param {ModifyOptions} options The new options
+	 * @param {SchemaPieceModifyOptions} options The new options
 	 * @returns {Promise<this>}
 	 */
 	async modify(options) {

--- a/src/lib/structures/Extendable.js
+++ b/src/lib/structures/Extendable.js
@@ -11,7 +11,7 @@ const Discord = require('discord.js');
 class Extendable {
 
 	/**
-	 * @typedef {object} ExtendableOptions
+	 * @typedef {Object} ExtendableOptions
 	 * @property {string} [name=theFileName] The name of the extendable
 	 * @property {boolean} [enabled=true] If the extendable is enabled or not
 	 * @property {boolean} [klasa=false] If the extendable is for Klasa instead of Discord.js

--- a/src/lib/util/Colors.js
+++ b/src/lib/util/Colors.js
@@ -3,11 +3,22 @@
 class Colors {
 
 	/**
-	 * @typedef {object} ColorsFormatOptions
-	 * @property {(string | string[])} style
-	 * @property {(number | string | number[] | string[])} background
-	 * @property {(number | string | number[] | string[])} text
+	 * @typedef  {Object} ColorsFormatOptions
+	 * @property {(string|string[])} style
+	 * @property {ColorsFormatType} background
+	 * @property {ColorsFormatType} text
 	 * @memberof Colors
+	 */
+
+	/**
+	 * @typedef  {(string|number|string[]|number[])} ColorsFormatType
+	 */
+
+	/**
+	 * @typedef  {Object} ColorsFormatData
+	 * @property {string[]} opening
+	 * @property {string[]} closing
+	 * @private
 	 */
 
 	constructor() {
@@ -158,6 +169,14 @@ class Colors {
 		return `\u001B[${opening.join(';')}m${string}\u001B[${closing.join(';')}m`;
 	}
 
+	/**
+	 * Apply the style
+	 * @since 0.5.0
+	 * @param {(string|string[])} style The style to apply
+	 * @param {ColorsFormatData} [data={}] The data
+	 * @returns {ColorsFormatData}
+	 * @private
+	 */
 	style(style, { opening = [], closing = [] } = {}) {
 		if (style) {
 			if (Array.isArray(style)) {
@@ -173,10 +192,18 @@ class Colors {
 		return { opening, closing };
 	}
 
+	/**
+	 * Apply the background
+	 * @since 0.5.0
+	 * @param {ColorsFormatType} background The background to apply
+	 * @param {ColorsFormatData} [data={}] The data
+	 * @returns {ColorsFormatData}
+	 * @private
+	 */
 	background(background, { opening = [], closing = [] } = {}) {
 		if (background) {
 			if (typeof background === 'number') {
-				if (Number.isInteger(background) === false) background = Math.round(background);
+				if (!Number.isInteger(background)) background = Math.round(background);
 
 				const number = (background >= 0x100 && background <= 0xFFF) || (background >= 0x100000 && background <= 0xFFFFFF) ?
 					background.toString(16) :
@@ -197,10 +224,18 @@ class Colors {
 		return { opening, closing };
 	}
 
+	/**
+	 * Apply the text format
+	 * @since 0.5.0
+	 * @param {ColorsFormatType} text The text format to apply
+	 * @param {ColorsFormatData} [data={}] The data
+	 * @returns {ColorsFormatData}
+	 * @private
+	 */
 	text(text, { opening = [], closing = [] } = {}) {
 		if (text) {
 			if (typeof text === 'number') {
-				if (Number.isInteger(text) === false) text = Math.round(text);
+				if (!Number.isInteger(text)) text = Math.round(text);
 				opening.push(`38;5;${text}`);
 				closing.push(`${this.CLOSE.text}`);
 			} else if (Array.isArray(text)) {

--- a/src/lib/util/Colors.js
+++ b/src/lib/util/Colors.js
@@ -3,7 +3,7 @@
 class Colors {
 
 	/**
-	 * @typedef  {Object} ColorsFormatOptions
+	 * @typedef {Object} ColorsFormatOptions
 	 * @property {(string|string[])} style
 	 * @property {ColorsFormatType} background
 	 * @property {ColorsFormatType} text
@@ -11,11 +11,11 @@ class Colors {
 	 */
 
 	/**
-	 * @typedef  {(string|number|string[]|number[])} ColorsFormatType
+	 * @typedef {(string|number|string[]|number[])} ColorsFormatType
 	 */
 
 	/**
-	 * @typedef  {Object} ColorsFormatData
+	 * @typedef {Object} ColorsFormatData
 	 * @property {string[]} opening
 	 * @property {string[]} closing
 	 * @private

--- a/src/lib/util/Console.js
+++ b/src/lib/util/Console.js
@@ -11,7 +11,16 @@ const { mergeDefault } = require('./util');
 class KlasaConsole extends Console {
 
 	/**
-	 * @typedef {object} Colors - Time is for the timestamp of the log, message is for the actual output.
+	 * @typedef {Object} KlasaConsoleConfig
+	 * @property {KlasaConsoleColorStyles} [colors]
+	 * @property {NodeJS.WritableStream} [stdout]
+	 * @property {NodeJS.WritableStream} [stderr]
+	 * @property {(boolean|string)} [timestamps]
+	 * @property {boolean} [useColor]
+	 */
+
+	/**
+	 * @typedef {Object} KlasaConsoleColorStyles Time is for the timestamp of the log, message is for the actual output.
 	 * @property {KlasaConsoleColorObjects} debug An object containing a message and time color object
 	 * @property {KlasaConsoleColorObjects} error An object containing a message and time color object
 	 * @property {KlasaConsoleColorObjects} log An object containing a message and time color object
@@ -22,7 +31,7 @@ class KlasaConsole extends Console {
 	 */
 
 	/**
-	 * @typedef {object} KlasaConsoleColorObjects
+	 * @typedef {Object} KlasaConsoleColorObjects
 	 * @property {string} [type='log'] The method from Console this color object should call
 	 * @property {KlasaConsoleMessageObject} message A message object containing colors and styles
 	 * @property {KlasaConsoleTimeObject} time A time object containing colors and styles
@@ -30,23 +39,23 @@ class KlasaConsole extends Console {
 	 */
 
 	/**
-	 * @typedef {object} KlasaConsoleMessageObject
-	 * @property {BackgroundColorTypes} background The background color. Can be a basic string like "red", a hex string, or a RGB array
-	 * @property {TextColorTypes} text The text color. Can be a basic string like "red", a hex string, or a RGB array
-	 * @property {StyleTypes} style A style string from StyleTypes
+	 * @typedef {Object} KlasaConsoleMessageObject
+	 * @property {KlasaConsoleColorTypes} background The background color. Can be a basic string like "red", a hex string, or a RGB array
+	 * @property {KlasaConsoleColorTypes} text The text color. Can be a basic string like "red", a hex string, or a RGB array
+	 * @property {KlasaConsoleStyleTypes} style A style string from KlasaConsoleStyleTypes
 	 * @memberof KlasaConsole
 	 */
 
 	/**
-	 * @typedef {object} KlasaConsoleTimeObject
-	 * @property {BackgroundColorTypes} background The background color. Can be a basic string like "red", a hex string, or a RGB array
-	 * @property {TextColorTypes} text The text color. Can be a basic string like "red", a hex string, a RGB array, or HSL array
-	 * @property {StyleTypes} style A style string from StyleTypes
+	 * @typedef {Object} KlasaConsoleTimeObject
+	 * @property {KlasaConsoleColorTypes} background The background color. Can be a basic string like "red", a hex string, or a RGB array
+	 * @property {KlasaConsoleColorTypes} text The text color. Can be a basic string like "red", a hex string, a RGB array, or HSL array
+	 * @property {KlasaConsoleStyleTypes} style A style string from KlasaConsoleStyleTypes
 	 * @memberof KlasaConsole
 	 */
 
 	/**
-	 * @typedef {*} TextColorTypes - All the valid color types.
+	 * @typedef {*} KlasaConsoleColorTypes - All the valid color types.
 	 * @property {string} black
 	 * @property {string} red
 	 * @property {string} green
@@ -73,32 +82,7 @@ class KlasaConsole extends Console {
 	 */
 
 	/**
-	 * @typedef {*} BackgroundColorTypes - One of these strings, HexStrings, RGB, or HSL are valid types.
-	 * @property {string} black
-	 * @property {string} red
-	 * @property {string} green
-	 * @property {string} blue
-	 * @property {string} magenta
-	 * @property {string} cyan
-	 * @property {string} gray
-	 * @property {string} grey
-	 * @property {string} lightgray
-	 * @property {string} lightgrey
-	 * @property {string} lightred
-	 * @property {string} lightgreen
-	 * @property {string} lightyellow
-	 * @property {string} lightblue
-	 * @property {string} lightmagenta
-	 * @property {string} lightcyan
-	 * @property {string} white
-	 * @property {string} #008000 green
-	 * @property {Array} [255,0,0] red
-	 * @property {Array} [229,50%,50%] blue
-	 * @memberof KlasaConsole
-	 */
-
-	/**
-	 * @typedef {*} StyleTypes
+	 * @typedef {*} KlasaConsoleStyleTypes
 	 * @property {string} normal
 	 * @property {string} bold
 	 * @property {string} dim
@@ -134,7 +118,8 @@ class KlasaConsole extends Console {
 		 * The standard output stream for this console, defaulted to process.stderr.
 		 * @since 0.4.0
 		 * @name KlasaConsole#stdout
-		 * @type {WritableStream}
+		 * @type {NodeJS.WritableStream}
+		 * @readonly
 		 */
 		Object.defineProperty(this, 'stdout', { value: options.stdout });
 
@@ -142,7 +127,8 @@ class KlasaConsole extends Console {
 		 * The standard error output stream for this console, defaulted to process.stderr.
 		 * @since 0.4.0
 		 * @name KlasaConsole#stderr
-		 * @type {WritableStream}
+		 * @type {NodeJS.WritableStream}
+		 * @readonly
 		 */
 		Object.defineProperty(this, 'stderr', { value: options.stderr });
 
@@ -164,7 +150,7 @@ class KlasaConsole extends Console {
 		 * The colors for this console.
 		 * @since 0.4.0
 		 * @name KlasaConsole#colors
-		 * @type {boolean|Colors}
+		 * @type {(boolean|KlasaConsoleColorStyles)}
 		 */
 		this.colors = options.colors;
 	}
@@ -177,7 +163,7 @@ class KlasaConsole extends Console {
 	 * @param {string} [type="log"] The type of log, particularly useful for coloring
 	 */
 	write(data, type = 'log') {
-		data = KlasaConsole.flatten(data, this.useColors);
+		data = KlasaConsole._flatten(data, this.useColors);
 		const color = this.colors[type.toLowerCase()] || {};
 		const timestamp = this.template ? `${this.timestamp(`[${this.template.display()}]`, color.time || {})} ` : '';
 		const shard = this.client.shard ? `${this.shard(`[${this.client.shard.id}]`, color.shard)} ` : '';
@@ -286,8 +272,9 @@ class KlasaConsole extends Console {
 	 * @param {*} data Some data to flatten
 	 * @param {boolean} useColors Whether or not the inspection should color the output
 	 * @returns {string}
+	 * @private
 	 */
-	static flatten(data, useColors) {
+	static _flatten(data, useColors) {
 		if (typeof data === 'undefined' || typeof data === 'number' || data === null) return String(data);
 		if (typeof data === 'string') return data;
 		if (typeof data === 'object') {

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -13,7 +13,7 @@ class ReactionHandler extends ReactionCollector {
 	 */
 
 	/**
-	 * @typedef {object} ReactionHandlerOptions
+	 * @typedef {Object} ReactionHandlerOptions
 	 * @property {Function} [filter] A filter function to add to the ReactionHandler
 	 * @property {boolean} [stop=true] If a stop reaction should be included
 	 * @property {string} [prompt=msg.language.get('REACTIONHANDLER_PROMPT')] The prompt to be used when awaiting user input on a page to jump to

--- a/src/lib/util/RichDisplay.js
+++ b/src/lib/util/RichDisplay.js
@@ -13,7 +13,7 @@ class RichDisplay {
 	 */
 
 	/**
-	 * @typedef {object} RichDisplayEmojisObject
+	 * @typedef {Object} RichDisplayEmojisObject
 	 * @property {emoji} first
 	 * @property {emoji} back
 	 * @property {emoji} forward
@@ -25,7 +25,7 @@ class RichDisplay {
 	 */
 
 	/**
-	 * @typedef {object} RichDisplayRunOptions
+	 * @typedef {Object} RichDisplayRunOptions
 	 * @property {Function} [filter] A filter function to add to the ReactionHandler (Receives: Reaction, User)
 	 * @property {boolean} [stop=true] If a stop reaction should be included
 	 * @property {boolean} [jump=true] If a jump reaction should be included

--- a/src/lib/util/RichMenu.js
+++ b/src/lib/util/RichMenu.js
@@ -13,7 +13,7 @@ class RichMenu extends RichDisplay {
 	 */
 
 	/**
-	 * @typedef {object} RichMenuEmojisObject
+	 * @typedef {Object} RichMenuEmojisObject
 	 * @property {emoji} first
 	 * @property {emoji} back
 	 * @property {emoji} forward
@@ -35,7 +35,7 @@ class RichMenu extends RichDisplay {
 	 */
 
 	/**
-	 * @typedef {object} MenuOption
+	 * @typedef {Object} MenuOption
 	 * @property {string} name The name of the option
 	 * @property {string} body The description of the option
 	 * @property {boolean} [inline=false] Whether the option should be inline
@@ -43,7 +43,7 @@ class RichMenu extends RichDisplay {
 	 */
 
 	/**
-	 * @typedef {object} RichMenuRunOptions
+	 * @typedef {Object} RichMenuRunOptions
 	 * @property {Function} [filter] A filter function to add to the ReactionHandler (Receives: Reaction, User)
 	 * @property {boolean} [stop=true] If a stop reaction should be included
 	 * @property {string} [prompt=msg.language.get('REACTIONHANDLER_PROMPT')] The prompt to be used when awaiting user input on a page to jump to

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -503,7 +503,7 @@ declare module 'klasa' {
 		public isValid(): boolean;
 		public debug(): string;
 
-		public run(msg: KlasaMessage, min: number): permissionLevelResponse;
+		public run(msg: KlasaMessage, min: number): PermissionLevelsData;
 	}
 
 	// Usage
@@ -603,9 +603,9 @@ declare module 'klasa' {
 	}
 
 	export class Gateway extends GatewayStorage {
-		public constructor(store: GatewayDriver, type: string, validateFunction: Function, schema: object, options: GatewayOptions);
+		public constructor(store: GatewayDriver, type: string, validateFunction: Function, schema: object, options: GatewayDriverAddOptions);
 		public store: GatewayDriver;
-		public options: GatewayOptions;
+		public options: GatewayDriverAddOptions;
 		public validate: Function;
 		public defaultSchema: object;
 		public readonly cache: Provider;
@@ -616,7 +616,7 @@ declare module 'klasa' {
 		public insertEntry(id: string, data?: object): Configuration;
 		public deleteEntry(input: string): Promise<boolean>;
 		public sync(input?: object | string, download?: boolean): Promise<any>;
-		public getPath(key?: string, options?: ConfigurationPathOptions): ConfigurationPathResult;
+		public getPath(key?: string, options?: GatewayGetPathOptions): GatewayGetPathResult;
 
 		private init(download?: boolean): Promise<void>;
 		private _ready(): Promise<Array<Collection<string, Configuration>>>;
@@ -651,7 +651,7 @@ declare module 'klasa' {
 		public users: Gateway;
 		public clientStorage: Gateway;
 
-		public add(name: string, validateFunction: Function, schema?: object, options?: SettingsOptions, download?: boolean): Promise<Gateway>;
+		public add(name: string, validateFunction: Function, schema?: object, options?: GatewayDriverAddOptions, download?: boolean): Promise<Gateway>;
 		private _ready(): Promise<Array<Array<Collection<string, Configuration>>>>;
 		private _checkProvider(engine: string): string;
 	}
@@ -678,7 +678,7 @@ declare module 'klasa' {
 		public addFolder(key: string, object?: object, force?: boolean): Promise<SchemaFolder>;
 		public removeFolder(key: string, force?: boolean): Promise<SchemaFolder>;
 		public hasKey(key: string): boolean;
-		public addKey(key: string, options: AddOptions, force?: boolean): Promise<SchemaFolder>;
+		public addKey(key: string, options: SchemaFolderAddOptions, force?: boolean): Promise<SchemaFolder>;
 		public removeKey(key: string, force?: boolean): Promise<SchemaFolder>;
 		public force(action: 'add' | 'edit' | 'delete', key: string, piece: SchemaFolder | SchemaPiece): Promise<any>;
 		public getList(msg: KlasaMessage): string;
@@ -688,7 +688,7 @@ declare module 'klasa' {
 		public getValues(array?: SchemaPiece[]): SchemaPiece[];
 		public resolveString(): string;
 
-		private _addKey(key: string, options: AddOptions, type: typeof Schema | typeof SchemaFolder): void;
+		private _addKey(key: string, options: SchemaFolderAddOptions, type: typeof Schema | typeof SchemaFolder): void;
 		private _removeKey(key: string): void;
 		private _init(options: object): true;
 
@@ -697,7 +697,7 @@ declare module 'klasa' {
 	}
 
 	export class SchemaPiece extends Schema {
-		public constructor(client: KlasaClient, gateway: Gateway, options: AddOptions, parent: SchemaFolder, key: string);
+		public constructor(client: KlasaClient, gateway: Gateway, options: SchemaFolderAddOptions, parent: SchemaFolder, key: string);
 		public type: string;
 		public array: boolean;
 		public default: any;
@@ -708,15 +708,15 @@ declare module 'klasa' {
 
 		public parse(value: any, guild: KlasaGuild): Promise<any>;
 		public resolveString(msg: KlasaMessage): string;
-		public modify(options: ModifyOptions): Promise<this>;
+		public modify(options: SchemaPieceModifyOptions): Promise<this>;
 
 		private _schemaCheckType(type: string): void;
 		private _schemaCheckArray(array: boolean): void;
-		private _schemaCheckDefault(options: AddOptions): void;
+		private _schemaCheckDefault(options: SchemaFolderAddOptions): void;
 		private _schemaCheckLimits(min: number, max: number): void;
 		private _schemaCheckConfigurable(configurable: boolean): void;
 		private _generateSQLDatatype(sql?: string): string;
-		private _init(options: AddOptions): true;
+		private _init(options: SchemaFolderAddOptions): true;
 
 		public toJSON(): SchemaPieceJSON;
 		public toString(): string;
@@ -730,7 +730,7 @@ declare module 'klasa' {
 		public readonly gateway: Gateway;
 		public readonly type: string;
 		public readonly id: string;
-		public readonly existsInDB: boolean;
+		private _existsInDB: boolean;
 
 		public get(key: string): any;
 		public clone(): Configuration;
@@ -742,14 +742,14 @@ declare module 'klasa' {
 		public update(key: object, guild?: GatewayGuildResolvable): Promise<ConfigurationUpdateManyResult>;
 		public update(key: string, value?: any, options?: ConfigurationUpdateOptions): Promise<ConfigurationUpdateResult>;
 		public update(key: string, value?: any, guild?: GatewayGuildResolvable, options?: ConfigurationUpdateOptions): Promise<ConfigurationUpdateResult>;
-		public updateMany(object: any, guild?: GatewayGuildResolvable): Promise<ConfigurationUpdateManyResult>;
 
+		private _updateMany(object: any, guild?: GatewayGuildResolvable): Promise<ConfigurationUpdateManyResult>;
 		private _reset(key: string, guild: GatewayGuildResolvable, avoidUnconfigurable: boolean): Promise<ConfigurationParseResult>;
-		private _parseReset(key: string, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResult>;
-		private _parseUpdateOne(key: string, value: any, guild: KlasaGuild, options: ConfigurationParseOptions): Promise<ConfigurationParseResult>;
-		private _parseUpdateArray(action: 'add' | 'remove' | 'auto', key: string, value: any, guild: KlasaGuild, arrayPosition: number, options: ConfigurationParseOptions): Promise<ConfigurationParseResultArray>;
-		private _updateSingle(key: string, value: any, guild: KlasaGuild, options: ConfigurationUpdateOptions): Promise<ConfigurationParseResult | ConfigurationParseResultArray>;
-		private _updateMany(cache: any, object: any, schema: SchemaFolder, guild: KlasaGuild, list: ConfigurationUpdateManyResult, updateObject: object): void;
+		private _parseReset(key: string, guild: KlasaGuild, options: ConfigurationPathResult): Promise<ConfigurationParseResult>;
+		private _parseUpdateOne(key: string, value: any, guild: KlasaGuild, options: ConfigurationPathResult): Promise<ConfigurationParseResult>;
+		private _parseUpdateArray(action: 'add' | 'remove' | 'auto', key: string, value: any, guild: KlasaGuild, arrayPosition: number, options: ConfigurationPathResult): Promise<ConfigurationParseResult>;
+		private _parseUpdateMany(cache: any, object: any, schema: SchemaFolder, guild: KlasaGuild, list: ConfigurationUpdateManyResult, updateObject: object): void;
+		private _updateSingle(key: string, value: any, guild: KlasaGuild, options: ConfigurationUpdateOptions): Promise<ConfigurationParseResult>;
 		private _setValue(parsedID: string, path: SchemaPiece, route: string[]): Promise<void>;
 		private _patch(data: any): void;
 
@@ -776,6 +776,9 @@ declare module 'klasa' {
 		public static formatArray([pos1, pos2, pos3]: [number | string, number | string, number | string]): string;
 
 		public format(input: string, type?: ColorsFormatOptions): string;
+		private style(style: string | string[], data?: ColorsFormatData): ColorsFormatData;
+		private background(style: ColorsFormatType, data?: ColorsFormatData): ColorsFormatData;
+		private text(style: ColorsFormatType, data?: ColorsFormatData): ColorsFormatData;
 	}
 
 	class KlasaConsole extends Console {
@@ -785,7 +788,7 @@ declare module 'klasa' {
 		public readonly stderr: NodeJS.WritableStream;
 		public template?: Timestamp;
 		public useColors: boolean;
-		public colors: KlasaConsoleColorsOption;
+		public colors: boolean | KlasaConsoleColorStyles;
 
 		public write(data: any, type?: string): void;
 		public log(...data: any[]): void;
@@ -799,7 +802,7 @@ declare module 'klasa' {
 		public shard(input: string, shard: ColorsFormatOptions): string;
 		public messages(input: string, message: ColorsFormatOptions): string;
 
-		public static flatten(data: any, useColors: boolean): string;
+		private static _flatten(data: any, useColors: boolean): string;
 	}
 
 	export { KlasaConsole as Console };
@@ -1463,12 +1466,6 @@ declare module 'klasa' {
 		quotedStringSupport?: number;
 	};
 
-	export type TextPromptOptions = {
-		promptLimit?: number;
-		promptTime?: number;
-		quotedStringSupport?: number;
-	};
-
 	export type KlasaPieceDefaults = {
 		commands?: CommandOptions;
 		events?: EventOptions;
@@ -1486,9 +1483,9 @@ declare module 'klasa' {
 	};
 
 	export type KlasaGatewaysOptions = {
-		clientStorage?: SettingsOptions;
-		guilds?: SettingsOptions;
-		users?: SettingsOptions;
+		clientStorage?: GatewayDriverAddOptions;
+		guilds?: GatewayDriverAddOptions;
+		users?: GatewayDriverAddOptions;
 		[key: string]: string | object;
 	};
 
@@ -1504,62 +1501,53 @@ declare module 'klasa' {
 		uid?: number;
 	};
 
-	export type KlasaConstantsClient = {
-		clientBaseDir: string;
-		schedule: { interval: 60000 };
-		cmdEditing: false;
-		cmdLogging: false;
-		cmdPrompt: false;
-		commandMessageLifetime: 1800;
-		console: {};
-		consoleEvents: {
-			debug: false;
-			error: true;
-			log: true;
-			verbose: false;
-			warn: true;
-			wtf: true;
-		};
-		ignoreBots: true;
-		ignoreSelf: true;
-		language: 'en-US';
-		pieceDefaults: {
-			commands: CommandOptions,
-			events: EventOptions,
-			extendables: ExtendableOptions,
-			finalizers: FinalizerOptions,
-			inhibitors: InhibitorOptions,
-			languages: LanguageOptions,
-			monitors: MonitorOptions,
-			providers: ProviderOptions
-		};
-		preserveConfigs: true;
-		promptTime: 30000;
-		provider: {};
-		readyMessage: (client: KlasaClient) => string;
-		typing: false;
-		customPromptDefaults: {
-			promptTime: 30000,
-			promptLimit: number,
-			quotedStringSupport: false
-		};
+	// Permissions
+	export type PermissionLevel = {
+		break: boolean;
+		check: (client: KlasaClient, msg: KlasaMessage) => boolean;
 	};
 
-	export type GatewayOptions = {
-		cache?: Provider;
-		nice?: boolean;
-		provider?: Provider;
+	export type PermissionLevelsData = {
+		broke: boolean;
+		permission: boolean;
 	};
 
-	export type ConfigurationUpdateResult = {
+	// Schedule
+	export type ScheduledTaskOptions = {
+		id?: string;
+		data?: any;
+	};
+
+	export type ScheduledTaskJSON = {
+		id: string;
+		taskName: string;
+		time: number;
+		data?: any;
+	};
+
+	export type ScheduledTaskUpdateOptions = {
+		repeat?: string;
+		time?: Date;
+		data?: any;
+	};
+
+	// Settings
+	export type GatewayGetPathOptions = {
+		avoidUnconfigurable?: boolean;
+		piece?: boolean;
+	};
+
+	export type GatewayGetPathResult = {
 		path: SchemaPiece;
-		value: any;
-	};
-
-	export type ConfigurationParseOptions = {
-		path: string;
 		route: string[];
 	};
+
+	export type GuildResolvable = KlasaGuild
+		| KlasaMessage
+		| KlasaTextChannel
+		| KlasaVoiceChannel
+		| GuildMember
+		| Role;
 
 	export type ConfigurationUpdateOptions = {
 		avoidUnconfigurable?: boolean;
@@ -1567,37 +1555,44 @@ declare module 'klasa' {
 		action?: 'add' | 'remove' | 'auto';
 	};
 
-	export type ConfigurationParseResult = {
-		array: null;
+	export type ConfigurationUpdateResult = {
+		path: SchemaPiece;
+		value: any;
+	};
+
+	export type ConfigurationUpdateObjectResult = {
+		updated: ConfigurationUpdateObjectList;
+		errors: Error[];
+	};
+
+	export type ConfigurationUpdateObjectList = {
+		keys: string[];
+		values: any[];
+	};
+
+	type ConfigurationPathResult = {
+		path: string;
+		route: string[];
+	};
+
+	type ConfigurationParseResult = {
+		array?: any[];
 		entryID: string;
 		parsed: any;
 		parsedID: string | number | object;
 		settings: Configuration;
-	} & ConfigurationParseOptions;
+	} & ConfigurationPathResult;
 
-	export type ConfigurationParseResultArray = {
-		array: any[];
-		entryID: string;
-		parsed: any;
-		parsedID: string | number | object;
-		settings: Configuration;
-	} & ConfigurationParseOptions;
-
-	export type ConfigurationUpdateManyList = {
+	type ConfigurationUpdateManyList = {
 		errors: Error[];
 		keys: string[];
 		promises: Array<Promise<any>>;
 		values: any[];
 	};
 
-	export type ConfigurationUpdateManyUpdated = {
-		keys: string[];
-		values: any[];
-	};
-
 	export type ConfigurationUpdateManyResult = {
 		errors: Error[];
-		updated: ConfigurationUpdateManyUpdated;
+		updated: ConfigurationUpdateObjectList;
 	};
 
 	export type ConfigUpdateEntryMany = {
@@ -1623,53 +1618,40 @@ declare module 'klasa' {
 		route: string[];
 	};
 
+	export type GatewayDriverAddOptions = {
+		provider?: string;
+		nice?: boolean;
+	};
+
+	export type SchemaFolderAddOptions = {
+		type: string;
+		default?: any;
+		min?: number;
+		max?: number;
+		array?: boolean;
+		sql?: string;
+		configurable?: boolean;
+	};
+
+	export type SchemaPieceModifyOptions = {
+		default?: any;
+		min?: number;
+		max?: number;
+		configurable?: boolean;
+		sql?: string;
+	};
+
 	export type SchemaPieceJSON = {
 		type: string;
 		array: boolean;
 		default: any;
 		min?: number;
 		max?: number;
-		sql: [string, string];
+		sql: string;
 		configurable: boolean;
 	};
 
-	export type SettingsOptions = {
-		provider?: string;
-		nice?: boolean;
-	};
-
-	export type KlasaConsoleConfig = {
-		colors?: Colors;
-		stderr?: NodeJS.WritableStream;
-		stdout?: NodeJS.WritableStream;
-		timestamps?: boolean | string;
-		useColor?: boolean;
-	};
-
-	export type KlasaConsoleEvents = {
-		debug?: boolean;
-		error?: boolean;
-		log?: boolean;
-		verbose?: boolean;
-		warn?: boolean;
-		wtf?: boolean;
-	};
-
-	export type TimestampObject = {
-		content?: string;
-		type: string;
-	};
-
-	export type PermissionLevel = {
-		break: boolean;
-		check: (client: KlasaClient, msg: KlasaMessage) => boolean;
-	};
-
-	export type permissionLevelResponse = {
-		broke: boolean;
-		permission: boolean;
-	};
-
+	// Structures
 	export type CommandOptions = {
 		aliases?: string[];
 		autoAliases?: boolean;
@@ -1736,108 +1718,14 @@ declare module 'klasa' {
 		name?: string;
 	};
 
-	export type ScheduledTaskOptions = {
-		id?: string;
-		data?: any;
+	// Usage
+	export type TextPromptOptions = {
+		promptLimit?: number;
+		promptTime?: number;
+		quotedStringSupport?: number;
 	};
 
-	export type ScheduledTaskJSON = {
-		id: string;
-		taskName: string;
-		time: number;
-		data?: any;
-	};
-
-	export type ScheduledTaskUpdateOptions = {
-		repeat?: string;
-		time?: Date;
-		data?: any;
-	};
-
-	export type AddOptions = {
-		type: string;
-		default?: any;
-		min?: number;
-		max?: number;
-		array?: boolean;
-		sql?: string;
-		configurable?: boolean;
-	};
-
-	export type ModifyOptions = {
-		default?: any;
-		min?: number;
-		max?: number;
-		configurable?: boolean;
-		sql?: string;
-	};
-
-	export type emoji = string;
-
-	export type RichDisplayEmojisObject = {
-		first: emoji;
-		back: emoji;
-		forward: emoji;
-		last: emoji;
-		jump: emoji;
-		info: emoji;
-		stop: emoji;
-	};
-
-	export type RichMenuEmojisObject = {
-		zero: emoji;
-		one: emoji;
-		two: emoji;
-		three: emoji;
-		four: emoji;
-		five: emoji;
-		six: emoji;
-		seven: emoji;
-		eight: emoji;
-		nine: emoji;
-	} & RichDisplayEmojisObject;
-
-	export type RichDisplayRunOptions = {
-		filter?: Function;
-		firstLast?: boolean;
-		jump?: boolean;
-		max?: number;
-		maxEmojis?: number;
-		maxUsers?: number;
-		prompt?: string;
-		startPage?: number;
-		stop?: boolean;
-		time?: number;
-	};
-
-	export type MenuOption = {
-		name: string;
-		body: string;
-		inline?: boolean;
-	};
-
-	export type RichMenuRunOptions = {
-		filter?: Function;
-		max?: number;
-		maxEmojis?: number;
-		maxUsers?: number;
-		prompt?: string;
-		startPage?: number;
-		stop?: boolean;
-		time?: number;
-	};
-
-	export type ReactionHandlerOptions = {
-		filter?: Function;
-		max?: number;
-		maxEmojis?: number;
-		maxUsers?: number;
-		prompt?: string;
-		startPage?: number;
-		stop?: boolean;
-		time?: number;
-	};
-
+	// Util
 	export type ColorsClose = {
 		normal: 0;
 		bold: 22;
@@ -1910,9 +1798,31 @@ declare module 'klasa' {
 		text: string | number | string[]
 	};
 
-	export type KlasaConsoleColorsOption = boolean | StringMappedType<KlasaConsoleColorObjects> | KlasaConsoleColors;
+	export type ColorsFormatType = string | number | [string, string, string] | [number, number, number];
 
-	export type KlasaConsoleColors = {
+	type ColorsFormatData = {
+		opening: string[];
+		closing: string[];
+	};
+
+	export type KlasaConsoleConfig = {
+		colors?: KlasaConsoleColorStyles;
+		stderr?: NodeJS.WritableStream;
+		stdout?: NodeJS.WritableStream;
+		timestamps?: boolean | string;
+		useColor?: boolean;
+	};
+
+	export type KlasaConsoleEvents = {
+		debug?: boolean;
+		error?: boolean;
+		log?: boolean;
+		verbose?: boolean;
+		warn?: boolean;
+		wtf?: boolean;
+	};
+
+	export type KlasaConsoleColorStyles = {
 		debug: KlasaConsoleColorObjects;
 		error: KlasaConsoleColorObjects;
 		log: KlasaConsoleColorObjects;
@@ -1928,22 +1838,157 @@ declare module 'klasa' {
 	};
 
 	export type KlasaConsoleMessageObject = {
-		background?: BackgroundColorTypes;
-		style?: StyleTypes;
-		text?: TextColorTypes;
+		background?: KlasaConsoleBackgroundColorTypes;
+		style?: KlasaConsoleStyleTypes;
+		text?: KlasaConsoleTextColorTypes;
 	};
 
 	export type KlasaConsoleTimeObject = {
-		background?: BackgroundColorTypes;
-		style?: StyleTypes;
-		text?: TextColorTypes;
+		background?: KlasaConsoleBackgroundColorTypes;
+		style?: KlasaConsoleStyleTypes;
+		text?: KlasaConsoleTextColorTypes;
 	};
 
-	export type TextColorTypes = 'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'gray' | 'grey' | 'lightgray' | 'lightgrey' | 'lightred' | 'lightgreen' | 'lightyellow' | 'lightblue' | 'lightmagenta' | 'lightcyan' | 'white' | number[] | string[];
+	export type KlasaConsoleColorTypes = 'black'
+		| 'blue'
+		| 'cyan'
+		| 'gray'
+		| 'green'
+		| 'grey'
+		| 'lightblue'
+		| 'lightcyan'
+		| 'lightgray'
+		| 'lightgreen'
+		| 'lightgrey'
+		| 'lightmagenta'
+		| 'lightred'
+		| 'lightyellow'
+		| 'magenta'
+		| 'red'
+		| 'white'
+		| number[]
+		| string[];
 
-	export type BackgroundColorTypes = 'black' | 'red' | 'green' | 'blue' | 'magenta' | 'cyan' | 'gray' | 'grey' | 'lightgray' | 'lightgrey' | 'lightred' | 'lightgreen' | 'lightyellow' | 'lightblue' | 'lightmagenta' | 'lightcyan' | 'white' | number[] | string[];
+	export type KlasaConsoleStyleTypes = 'normal'
+		| 'bold'
+		| 'dim'
+		| 'italic'
+		| 'underline'
+		| 'inverse'
+		| 'hidden'
+		| 'strikethrough';
 
-	export type StyleTypes = 'normal' | 'bold' | 'dim' | 'italic' | 'underline' | 'inverse' | 'hidden' | 'strikethrough';
+	export type KlasaConstantsClient = {
+		clientBaseDir: string;
+		schedule: { interval: 60000 };
+		cmdEditing: false;
+		cmdLogging: false;
+		cmdPrompt: false;
+		commandMessageLifetime: 1800;
+		console: {};
+		consoleEvents: {
+			debug: false;
+			error: true;
+			log: true;
+			verbose: false;
+			warn: true;
+			wtf: true;
+		};
+		ignoreBots: true;
+		ignoreSelf: true;
+		language: 'en-US';
+		pieceDefaults: {
+			commands: CommandOptions,
+			events: EventOptions,
+			extendables: ExtendableOptions,
+			finalizers: FinalizerOptions,
+			inhibitors: InhibitorOptions,
+			languages: LanguageOptions,
+			monitors: MonitorOptions,
+			providers: ProviderOptions
+		};
+		preserveConfigs: true;
+		promptTime: 30000;
+		provider: {};
+		readyMessage: (client: KlasaClient) => string;
+		typing: false;
+		customPromptDefaults: {
+			promptTime: 30000,
+			promptLimit: number,
+			quotedStringSupport: false
+		};
+	};
+
+	export type ReactionHandlerOptions = {
+		filter?: Function;
+		max?: number;
+		maxEmojis?: number;
+		maxUsers?: number;
+		prompt?: string;
+		startPage?: number;
+		stop?: boolean;
+		time?: number;
+	};
+
+	export type TimestampObject = {
+		content?: string;
+		type: string;
+	};
+
+	export type RichDisplayRunOptions = {
+		filter?: ((reaction: MessageReaction, user: KlasaUser) => boolean);
+		firstLast?: boolean;
+		jump?: boolean;
+		max?: number;
+		maxEmojis?: number;
+		maxUsers?: number;
+		prompt?: string;
+		startPage?: number;
+		stop?: boolean;
+		time?: number;
+	};
+
+	export type emoji = string;
+
+	export type RichDisplayEmojisObject = {
+		first: emoji;
+		back: emoji;
+		forward: emoji;
+		last: emoji;
+		jump: emoji;
+		info: emoji;
+		stop: emoji;
+	};
+
+	export type RichMenuEmojisObject = {
+		zero: emoji;
+		one: emoji;
+		two: emoji;
+		three: emoji;
+		four: emoji;
+		five: emoji;
+		six: emoji;
+		seven: emoji;
+		eight: emoji;
+		nine: emoji;
+	} & RichDisplayEmojisObject;
+
+	export type MenuOption = {
+		name: string;
+		body: string;
+		inline?: boolean;
+	};
+
+	export type RichMenuRunOptions = {
+		filter?: Function;
+		max?: number;
+		maxEmojis?: number;
+		maxUsers?: number;
+		prompt?: string;
+		startPage?: number;
+		stop?: boolean;
+		time?: number;
+	};
 
 	type StringMappedType<T> = { [key: string]: T };
 


### PR DESCRIPTION
### Description of the PR

Some of the JSDocs were either outdated, duplicated, or with confusing names. This PR fixes the types in both JSDocs (typedefs) and TypeScript (typings) to have a more consistent name. This PR also makes some of the types **private** (types that are only used in Klasa's private ecosystem).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Changed**:

- Refactored typings and JSDoc types.
- Updated dependencies.

**Removed**:

- `Configuration#updateMany` is now under `Configuration#update`, in favor of a much less confusing naming.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
