### PR TITLE
Added Configuration#_syncStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#159](https://github.com/dirigeants/klasa/pull/159)] Made `'id'` a `PRIMARY KEY` in the SQL schema generator. (kyranet)
 - [[#158](https://github.com/dirigeants/klasa/pull/158)] Refactored typings and JSDoc types. (kyranet)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Tweaked `Configuration#update` to accept the overload `(key: string, value: any, options:ConfigurationUpdateOptions)` as opposed of passing `undefined` in the `guild` field between `value` and `options`. (kyranet)
 - [[#155](https://github.com/dirigeants/klasa/pull/155)] Complexity reductions for `SchemaFolder#addKey` and `Colors`. (bdistin)
@@ -123,6 +124,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#159](https://github.com/dirigeants/klasa/pull/159)] Removed deprecated property `GatewayOptions.cache` to be locked to `'collection'`. (kyranet)
 - [[#158](https://github.com/dirigeants/klasa/pull/158)] `Configuration#updateMany` is now under `Configuration#update`, in favor of a much less confusing naming. (kyranet)
 - [[`5b0c468362`](https://github.com/dirigeants/klasa/commit/5b0c46836200a57577bbd4aaa5cd463089a3bff0)] Removed `KlasaClient.sharded` as `Client.shard` is now fixed. (bdistin)
 - [[#136](https://github.com/dirigeants/klasa/pull/136)] Removed `util.newError`. (bdistin)
@@ -143,6 +145,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#159](https://github.com/dirigeants/klasa/pull/159)] Fixed Timestamp's `'MM'` token not padding with zeroes in the start. (kyranet)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Fixed a bug in Configuration not cloning objects correctly. (kyranet)
 - [[`35c42296fe`](https://github.com/dirigeants/klasa/commit/35c42296fe2738361dc48e3eee7716cfa73041b9)] Fixed GatewayStorage getting the wrong value. (bdistin)
 - [[`ab1f7c9ecf`](https://github.com/dirigeants/klasa/commit/ab1f7c9ecfa64e0b25c910ebe03d4f79eb29c8c0)] Fixed a bug where GatewayDriver wasn't checking if the provider was a CacheProvider correctly. (bdistin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#159](https://github.com/dirigeants/klasa/pull/159)] Added `Configuration#_syncStatus`. (kyranet)
 - [[`692e485d2b`](https://github.com/dirigeants/klasa/commit/692e485d2b7af5bf2b1d29c9e2dc4871f2e04f06)] Implemented the wildcards `?`, `H`, and the scheduling definition `@annually`. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added `time`, `duration`, `date` and `task` types to `ArgResolver`. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added `Duration`, a class helper to resolve human duration input into milliseconds. (bdistin)

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -115,6 +115,15 @@ class Configuration {
 		 */
 		Object.defineProperty(this, '_existsInDB', { value: false, writable: true });
 
+		/**
+		 * The sync status for this Configuration instance.
+		 * @since 0.5.0
+		 * @type {boolean}
+		 * @name Configuration#_syncStatus
+		 * @private
+		 */
+		Object.defineProperty(this, '_syncStatus', { value: null, writable: true });
+
 		const { schema } = this.gateway;
 		for (let i = 0; i < schema.keyArray.length; i++) {
 			const key = schema.keyArray[i];
@@ -169,7 +178,9 @@ class Configuration {
 	 * @returns {Promise<Configuration>}
 	 */
 	async sync() {
-		const data = await this.gateway.provider.get(this.gateway.type, this.id);
+		this._syncStatus = this.gateway.provider.get(this.gateway.type, this.id);
+		this._syncStatus.then(() => { this._syncStatus = null; });
+		const data = await this._syncStatus;
 		if (data) {
 			if (!this._existsInDB) this._existsInDB = true;
 			this._patch(data);

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -180,7 +180,7 @@ class Configuration {
 	async sync() {
 		this._syncStatus = this.gateway.provider.get(this.gateway.type, this.id);
 		this._syncStatus.then(() => { this._syncStatus = null; });
-		const data = await this._syncStatus;
+		const data = await this._syncStatus.catch(() => null);
 		if (data) {
 			if (!this._existsInDB) this._existsInDB = true;
 			this._patch(data);

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -91,7 +91,7 @@ class Gateway extends GatewayStorage {
 	 * @readonly
 	 */
 	get cache() {
-		return this.client.providers.get(this.options.cache);
+		return this.client.providers.get('collection');
 	}
 
 	/**

--- a/src/lib/settings/GatewayStorage.js
+++ b/src/lib/settings/GatewayStorage.js
@@ -86,7 +86,7 @@ class GatewayStorage {
 	 * @readonly
 	 */
 	get sqlSchema() {
-		const schema = [['id', 'VARCHAR(19) NOT NULL UNIQUE']];
+		const schema = [['id', 'VARCHAR(19) NOT NULL UNIQUE PRIMARY KEY']];
 		this.schema.getSQL(schema);
 		return schema;
 	}

--- a/src/lib/util/Colors.js
+++ b/src/lib/util/Colors.js
@@ -12,12 +12,14 @@ class Colors {
 
 	/**
 	 * @typedef {(string|number|string[]|number[])} ColorsFormatType
+	 * @memberof Colors
 	 */
 
 	/**
 	 * @typedef {Object} ColorsFormatData
 	 * @property {string[]} opening
 	 * @property {string[]} closing
+	 * @memberof Colors
 	 * @private
 	 */
 

--- a/src/lib/util/Console.js
+++ b/src/lib/util/Console.js
@@ -17,6 +17,7 @@ class KlasaConsole extends Console {
 	 * @property {NodeJS.WritableStream} [stderr]
 	 * @property {(boolean|string)} [timestamps]
 	 * @property {boolean} [useColor]
+	 * @memberof KlasaConsole
 	 */
 
 	/**

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -179,8 +179,8 @@ class Timestamp {
 			case 'YYY':
 			case 'YYYY': return String(time.getFullYear());
 			case 'Q': return String((time.getMonth() + 1) / 3);
-			case 'M':
-			case 'MM': return String(time.getMonth() + 1);
+			case 'M': return String(time.getMonth() + 1);
+			case 'MM': return String(time.getMonth() + 1).padStart(2, '0');
 			case 'MMM':
 			case 'MMMM': return months[time.getMonth()];
 			case 'D': return String(time.getDate());

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -731,6 +731,7 @@ declare module 'klasa' {
 		public readonly type: string;
 		public readonly id: string;
 		private _existsInDB: boolean;
+		private _syncStatus?: Promise<object>;
 
 		public get(key: string): any;
 		public clone(): Configuration;
@@ -753,7 +754,7 @@ declare module 'klasa' {
 		private _setValue(parsedID: string, path: SchemaPiece, route: string[]): Promise<void>;
 		private _patch(data: any): void;
 
-		public toJSON(): any;
+		public toJSON(): object;
 		public toString(): string;
 
 		private static _merge(data: any, folder: SchemaFolder | SchemaPiece): any;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1339,11 +1339,11 @@ declare module 'klasa' {
 		public init(): Promise<void>;
 		public execute(): Promise<void>;
 		public next(): ScheduledTask;
-		public create(taskName: string, time: Date | number | string, options: ScheduledTaskOptions);
+		public create(taskName: string, time: Date | number | string, options: ScheduledTaskOptions): Promise<ScheduledTask>;
 		public delete(id: string): Promise<this>;
 		public clear(): Promise<void>;
 
-		private _add(taskName: string, time: Date | number | string, options: ScheduledTaskOptions);
+		private _add(taskName: string, time: Date | number | string, options: ScheduledTaskOptions): ScheduledTask;
 		private _insert(task: ScheduledTask): ScheduledTask;
 		private _clearInterval(): void;
 		private _checkInterval(): void;
@@ -1366,7 +1366,7 @@ declare module 'klasa' {
 		public toJSON(): ScheduledTaskJSON;
 
 		private static _resolveTime(time: Date | number | Cron | string): [Date, Cron];
-		private static _generateID(client: KlasaCLient, time: Date | number): string;
+		private static _generateID(client: KlasaClient, time: Date | number): string;
 		private static _validate(st: ScheduledTask): void;
 	}
 


### PR DESCRIPTION
### Description of the PR

This PR adds `Configuration#_syncStatus`, very handful to handle some potential issues in autofetch. As described below:

*Let's consider a bot that handles per-user profiles. Imagine the case where an uncached user talks and discord.js fetches it, that'd create a User instance and therefore it'll create a configuration instance + sync it, but then the message gets sent to the message event rapidly.*

*That fires Klasa's monitors, and the `Configuration#sync` hasn't potentially resolved yet
So I hit a **racecondition** where I'd get the user with all the defaults, increment the points and try to write to the db (if it's not synchronized yet, _existsInDB is false, so it **writes/inserts instead of update**)
Then if the user has 140.000 points, as the data didn't resolve yet, they'd get overwritten to the points the bot gave.*

This PR also fixes two documentation issues where the lack of `@memberof` made them show as global types.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- Added `Configuration#_syncStatus`.

**Changed**:

- Made `'id'` a `PRIMARY KEY` in the SQL schema generator.

**Removed**:

- Removed deprecated property `GatewayOptions.cache` to be locked to `'collection'`.

**Fixed**:

- Fixed Timestamp's `'MM'` token not padding with zeroes in the start.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
