### PR TITLE
One off custom resolvers / One off custom responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#162](https://github.com/dirigeants/klasa/pull/162)] Added subcommand support. (bdistin)
 - [[#162](https://github.com/dirigeants/klasa/pull/162)] Added per-command custom resolvers and per-command and per-argument custom responses (with i18n support). (bdistin)
 - [[`692e485d2b`](https://github.com/dirigeants/klasa/commit/692e485d2b7af5bf2b1d29c9e2dc4871f2e04f06)] Implemented the wildcards `?`, `H`, and the scheduling definition `@annually`. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added `time`, `duration`, `date` and `task` types to `ArgResolver`. (bdistin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#162](https://github.com/dirigeants/klasa/pull/162)] Added per-command custom resolvers and per-command and per-argument custom responses (with i18n support). (bdistin)
 - [[`692e485d2b`](https://github.com/dirigeants/klasa/commit/692e485d2b7af5bf2b1d29c9e2dc4871f2e04f06)] Implemented the wildcards `?`, `H`, and the scheduling definition `@annually`. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added `time`, `duration`, `date` and `task` types to `ArgResolver`. (bdistin)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Added `Duration`, a class helper to resolve human duration input into milliseconds. (bdistin)
@@ -74,6 +75,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#162](https://github.com/dirigeants/klasa/pull/162)] Modified the built-in conf command to use `dependant arguments`-like arguments using custom arguments and messages. (bdistin)
+- [[#162](https://github.com/dirigeants/klasa/pull/162)] **[BREAKING]** Refactored ArgResolver. Now they take `arg`, `possible` and `msg` as parameters instead of `arg`, `currentUsage`, `possible`, `repeat` and `msg`. Repeating handling is now done in the backends. (bdistin)
 - [[#158](https://github.com/dirigeants/klasa/pull/158)] Refactored typings and JSDoc types. (kyranet)
 - [[#156](https://github.com/dirigeants/klasa/pull/156)] Tweaked `Configuration#update` to accept the overload `(key: string, value: any, options:ConfigurationUpdateOptions)` as opposed of passing `undefined` in the `guild` field between `value` and `options`. (kyranet)
 - [[#155](https://github.com/dirigeants/klasa/pull/155)] Complexity reductions for `SchemaFolder#addKey` and `Colors`. (bdistin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#162](https://github.com/dirigeants/klasa/pull/162)] Added better dependent arguments support. (bdistin)
 - [[#162](https://github.com/dirigeants/klasa/pull/162)] Added subcommand support. (bdistin)
 - [[#162](https://github.com/dirigeants/klasa/pull/162)] Added per-command custom resolvers and per-command and per-argument custom responses (with i18n support). (bdistin)
 - [[#159](https://github.com/dirigeants/klasa/pull/159)] Added `Configuration#_syncStatus`. (kyranet)

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -13,10 +13,10 @@ module.exports = class extends Command {
 		});
 
 		this.createCustomResolver('key', (arg, possible, msg, [action]) => {
-			if (action !== 'list') return arg;
+			if (action === 'list' || arg) return arg;
 			throw msg.language.get('COMMAND_CONF_NOKEY');
 		}).createCustomResolver('value', (arg, possible, msg, [action]) => {
-			if (!['set', 'remove'].includes(action)) return arg;
+			if (!['set', 'remove'].includes(action) || arg) return arg;
 			throw msg.language.get('COMMAND_CONF_NOVALUE');
 		});
 	}

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -8,14 +8,20 @@ module.exports = class extends Command {
 			permLevel: 6,
 			guarded: true,
 			description: (msg) => msg.language.get('COMMAND_CONF_SERVER_DESCRIPTION'),
-			usage: '<get|set|remove|reset|list> [key:string] [value:string] [...]',
+			usage: '<get|set|remove|reset|list> <key:key> <value:value> [...]',
 			usageDelim: ' '
+		});
+
+		this.createCustomArgument('key', (arg, possible, msg, [action]) => {
+			if (action !== 'list') return arg;
+			throw msg.language.get('COMMAND_CONF_NOKEY');
+		}).createCustomArgument('value', (arg, possible, msg, [action]) => {
+			if (!['set', 'remove'].includes(action)) return arg;
+			throw msg.language.get('COMMAND_CONF_NOVALUE');
 		});
 	}
 
 	async run(msg, [action, key, ...value]) {
-		if (action !== 'list' && !key) throw msg.language.get('COMMAND_CONF_NOKEY');
-		if (['set', 'remove'].includes(action) && value.length === 0) throw msg.language.get('COMMAND_CONF_NOVALUE');
 		if (action === 'set' && key === 'disabledCommands') {
 			const command = this.client.commands.get(value.join(' '));
 			if (command && command.guarded) throw msg.language.get('COMMAND_CONF_GUARDED', command.name);

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -26,27 +26,27 @@ module.exports = class extends Command {
 			.customizeResponse('value', msg => msg.language.get('COMMAND_CONF_NOVALUE'));
 	}
 
-	get(msg, key) {
+	get(msg, [key]) {
 		const { path } = this.client.gateways.guilds.getPath(key, { avoidUnconfigurable: true, piece: true });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_GET', path.path, path.resolveString(msg)));
 	}
 
-	async set(msg, key, valueToSet) {
+	async set(msg, [key, ...valueToSet]) {
 		const { path } = await msg.guild.configs.update(key, valueToSet.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'add' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 
-	async remove(msg, key, valueToRemove) {
+	async remove(msg, [key, ...valueToRemove]) {
 		const { path } = await msg.guild.configs.update(key, valueToRemove.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'remove' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 
-	async reset(msg, key) {
+	async reset(msg, [key]) {
 		const { path } = await msg.guild.configs.reset(key, true);
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_RESET', path.path, path.resolveString(msg)));
 	}
 
-	list(msg, key) {
+	list(msg, [key]) {
 		const { path } = this.client.gateways.guilds.getPath(key, { avoidUnconfigurable: true, piece: false });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_SERVER', key ? `: ${key.split('.').map(toTitleCase).join('/')}` : '', codeBlock('asciidoc', path.getList(msg))));
 	}

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -9,21 +9,19 @@ module.exports = class extends Command {
 			guarded: true,
 			subcommands: true,
 			description: (msg) => msg.language.get('COMMAND_CONF_SERVER_DESCRIPTION'),
-			usage: '<get|set|remove|reset|list> <key:key> <value:value> [...]',
+			usage: '<get|set|remove|reset|list> {key:key} {value:value} [...]',
 			usageDelim: ' '
 		});
 
 		this
 			.createCustomResolver('key', (arg, possible, msg, [action]) => {
 				if (action === 'list' || arg) return arg;
-				throw undefined;
+				throw msg.language.get('COMMAND_CONF_NOKEY');
 			})
 			.createCustomResolver('value', (arg, possible, msg, [action]) => {
 				if (!['set', 'remove'].includes(action) || arg) return arg;
-				throw undefined;
-			})
-			.customizeResponse('key', msg => msg.language.get('COMMAND_CONF_NOKEY'))
-			.customizeResponse('value', msg => msg.language.get('COMMAND_CONF_NOVALUE'));
+				throw msg.language.get('COMMAND_CONF_NOVALUE');
+			});
 	}
 
 	get(msg, [key]) {

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -12,10 +12,10 @@ module.exports = class extends Command {
 			usageDelim: ' '
 		});
 
-		this.createCustomArgument('key', (arg, possible, msg, [action]) => {
+		this.createCustomResolver('key', (arg, possible, msg, [action]) => {
 			if (action !== 'list') return arg;
 			throw msg.language.get('COMMAND_CONF_NOKEY');
-		}).createCustomArgument('value', (arg, possible, msg, [action]) => {
+		}).createCustomResolver('value', (arg, possible, msg, [action]) => {
 			if (!['set', 'remove'].includes(action)) return arg;
 			throw msg.language.get('COMMAND_CONF_NOVALUE');
 		});

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -12,13 +12,17 @@ module.exports = class extends Command {
 			usageDelim: ' '
 		});
 
-		this.createCustomResolver('key', (arg, possible, msg, [action]) => {
-			if (action === 'list' || arg) return arg;
-			throw msg.language.get('COMMAND_CONF_NOKEY');
-		}).createCustomResolver('value', (arg, possible, msg, [action]) => {
-			if (!['set', 'remove'].includes(action) || arg) return arg;
-			throw msg.language.get('COMMAND_CONF_NOVALUE');
-		});
+		this
+			.createCustomResolver('key', (arg, possible, msg, [action]) => {
+				if (action === 'list' || arg) return arg;
+				throw undefined;
+			})
+			.createCustomResolver('value', (arg, possible, msg, [action]) => {
+				if (!['set', 'remove'].includes(action) || arg) return arg;
+				throw undefined;
+			})
+			.customizeResponse('key', msg => msg.language.get('COMMAND_CONF_NOKEY'))
+			.customizeResponse('value', msg => msg.language.get('COMMAND_CONF_NOVALUE'));
 	}
 
 	async run(msg, [action, key, ...value]) {

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -9,7 +9,7 @@ module.exports = class extends Command {
 			guarded: true,
 			subcommands: true,
 			description: (msg) => msg.language.get('COMMAND_CONF_SERVER_DESCRIPTION'),
-			usage: '<get|set|remove|reset|list> {key:key} {value:value} [...]',
+			usage: '<get|set|remove|reset|list> (key:key) (value:value) [...]',
 			usageDelim: ' '
 		});
 

--- a/src/commands/General/User Configs/userconf.js
+++ b/src/commands/General/User Configs/userconf.js
@@ -7,21 +7,19 @@ module.exports = class extends Command {
 			guarded: true,
 			description: (msg) => msg.language.get('COMMAND_CONF_USER_DESCRIPTION'),
 			subcommands: true,
-			usage: '<get|set|remove|reset|list> <key:key> <value:value> [...]',
+			usage: '<get|set|remove|reset|list> {key:key} {value:value} [...]',
 			usageDelim: ' '
 		});
 
 		this
 			.createCustomResolver('key', (arg, possible, msg, [action]) => {
 				if (action === 'list' || arg) return arg;
-				throw undefined;
+				throw msg.language.get('COMMAND_CONF_NOKEY');
 			})
 			.createCustomResolver('value', (arg, possible, msg, [action]) => {
 				if (!['set', 'remove'].includes(action) || arg) return arg;
-				throw undefined;
-			})
-			.customizeResponse('key', msg => msg.language.get('COMMAND_CONF_NOKEY'))
-			.customizeResponse('value', msg => msg.language.get('COMMAND_CONF_NOVALUE'));
+				throw msg.language.get('COMMAND_CONF_NOVALUE');
+			});
 	}
 
 	get(msg, [key]) {

--- a/src/commands/General/User Configs/userconf.js
+++ b/src/commands/General/User Configs/userconf.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 			guarded: true,
 			description: (msg) => msg.language.get('COMMAND_CONF_USER_DESCRIPTION'),
 			subcommands: true,
-			usage: '<get|set|remove|reset|list> {key:key} {value:value} [...]',
+			usage: '<get|set|remove|reset|list> (key:key) (value:value) [...]',
 			usageDelim: ' '
 		});
 

--- a/src/commands/General/User Configs/userconf.js
+++ b/src/commands/General/User Configs/userconf.js
@@ -6,38 +6,45 @@ module.exports = class extends Command {
 		super(...args, {
 			guarded: true,
 			description: (msg) => msg.language.get('COMMAND_CONF_USER_DESCRIPTION'),
-			usage: '<get|set|remove|reset|list> [key:string] [value:string] [...]',
+			subcommands: true,
+			usage: '<get|set|remove|reset|list> <key:key> <value:value> [...]',
 			usageDelim: ' '
 		});
+
+		this
+			.createCustomResolver('key', (arg, possible, msg, [action]) => {
+				if (action === 'list' || arg) return arg;
+				throw undefined;
+			})
+			.createCustomResolver('value', (arg, possible, msg, [action]) => {
+				if (!['set', 'remove'].includes(action) || arg) return arg;
+				throw undefined;
+			})
+			.customizeResponse('key', msg => msg.language.get('COMMAND_CONF_NOKEY'))
+			.customizeResponse('value', msg => msg.language.get('COMMAND_CONF_NOVALUE'));
 	}
 
-	async run(msg, [action, key, ...value]) {
-		if (action !== 'list' && !key) throw msg.language.get('COMMAND_CONF_NOKEY');
-		if (['set', 'remove'].includes(action) && value.length === 0) throw msg.language.get('COMMAND_CONF_NOVALUE');
-		return this[action](msg, key, value);
-	}
-
-	get(msg, key) {
+	get(msg, [key]) {
 		const { path } = this.client.gateways.users.getPath(key, { avoidUnconfigurable: true, piece: true });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_GET', path.path, path.resolveString(msg)));
 	}
 
-	async set(msg, key, valueToSet) {
+	async set(msg, [key, ...valueToSet]) {
 		const { path } = await msg.author.configs.update(key, valueToSet.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'add' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 
-	async remove(msg, key, valueToRemove) {
+	async remove(msg, [key, ...valueToRemove]) {
 		const { path } = await msg.author.configs.update(key, valueToRemove.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'remove' });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
 	}
 
-	async reset(msg, key) {
+	async reset(msg, [key]) {
 		const { path } = await msg.author.configs.reset(key, true);
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_RESET', path.path, path.resolveString(msg)));
 	}
 
-	list(msg, key) {
+	list(msg, [key]) {
 		const { path } = this.client.gateways.users.getPath(key, { avoidUnconfigurable: true, piece: false });
 		return msg.sendMessage(msg.language.get('COMMAND_CONF_USER', key ? `: ${key.split('.').map(toTitleCase).join('/')}` : '', codeBlock('asciidoc', path.getList(msg))));
 	}

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -14,6 +14,7 @@ module.exports = class extends Language {
 			SETTING_GATEWAY_KEY_NOT_ARRAY: (key) => `The key ${key} is not an Array.`,
 			SETTING_GATEWAY_KEY_NOEXT: (key) => `The key ${key} does not exist in the current data schema.`,
 			SETTING_GATEWAY_INVALID_TYPE: 'The type parameter must be either add or remove.',
+			RESOLVER_INVALID_CUSTOM: (name, type) => `${name} must be a valid ${type}.`,
 			RESOLVER_INVALID_PIECE: (name, piece) => `${name} must be a valid ${piece} name.`,
 			RESOLVER_INVALID_MSG: (name) => `${name} must be a valid message id.`,
 			RESOLVER_INVALID_USER: (name) => `${name} must be a mention or valid user id.`,

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -363,11 +363,10 @@ class KlasaClient extends Discord.Client {
 	 */
 	registerPiece(pieceName, store) {
 		// eslint-disable-next-line func-names
-		ArgResolver.prototype[pieceName] = async function (arg, currentUsage, possible, repeat, msg) {
+		ArgResolver.prototype[pieceName] = async function (arg, possible, msg) {
 			const piece = store.get(arg);
 			if (piece) return piece;
-			if (currentUsage.type === 'optional' && !repeat) return null;
-			throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, pieceName);
+			throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_PIECE', possible.name, pieceName);
 		};
 		return this;
 	}

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -412,7 +412,7 @@ class KlasaClient extends Discord.Client {
 			await this.gateways.guilds.schema.prefix.modify({ default: this.options.prefix });
 		}
 		if (this.gateways.guilds.schema.hasKey('disabledCommands')) {
-			const languageStore = this.client.languages;
+			const languageStore = this.languages;
 			this.gateways.guilds.schema.disabledCommands.setValidator(function (command, guild) { // eslint-disable-line
 				if (command && command.guarded) throw (guild ? guild.language : languageStore.default).language.get('COMMAND_CONF_GUARDED', command.name);
 			});

--- a/src/lib/parsers/ArgResolver.js
+++ b/src/lib/parsers/ArgResolver.js
@@ -11,66 +11,54 @@ class ArgResolver extends Resolver {
 	 * Resolves a one-off custom argument
 	 * @since 0.5.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @param {Function} custom The custom resolver
-	 * @returns {Piece}
+	 * @returns {?any}
 	 */
-	async custom(arg, currentUsage, possible, repeat, msg, custom) {
-		if (!custom) throw (msg ? msg.language : this.language).get('RESOLVER_MISSING_CUSTOM', currentUsage.possibles[possible].name);
-		const resolved = await custom(arg, msg, msg.params);
+	async custom(arg, possible, msg, custom) {
+		const resolved = await custom(arg, possible, msg, msg.params);
 		if (resolved) return resolved;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_CUSTOM', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_CUSTOM', possible.name, possible.type);
 	}
 
 	/**
 	 * Resolves a piece
 	 * @since 0.3.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {Piece}
+	 * @returns {?Piece}
 	 */
-	async piece(arg, currentUsage, possible, repeat, msg) {
+	async piece(arg, possible, msg) {
 		for (const store of this.client.pieceStores.values()) {
 			const piece = store.get(arg);
 			if (piece) return piece;
 		}
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'piece');
+		throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_PIECE', possible.name, 'piece');
 	}
 
 	/**
 	 * Resolves a store
 	 * @since 0.3.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {Store}
+	 * @returns {?Store}
 	 */
-	async store(arg, currentUsage, possible, repeat, msg) {
+	async store(arg, possible, msg) {
 		const store = this.client.pieceStores.get(arg);
 		if (store) return store;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'store');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'store');
 	}
 
 	/**
 	 * Resolves a command
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {Command}
+	 * @returns {?Command}
 	 */
 	async command(...args) {
 		return this.cmd(...args);
@@ -80,162 +68,137 @@ class ArgResolver extends Resolver {
 	 * Resolves a command
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Command}
 	 */
-	async cmd(arg, currentUsage, possible, repeat, msg) {
+	async cmd(arg, possible, msg) {
 		const command = this.client.commands.get(arg);
 		if (command) return command;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'command');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'command');
 	}
 
 	/**
 	 * Resolves an event
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Event}
 	 */
-	async event(arg, currentUsage, possible, repeat, msg) {
+	async event(arg, possible, msg) {
 		const event = this.client.events.get(arg);
 		if (event) return event;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'event');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'event');
 	}
 
 	/**
 	 * Resolves an extendable
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
+
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Extendable}
 	 */
-	async extendable(arg, currentUsage, possible, repeat, msg) {
+	async extendable(arg, possible, msg) {
 		const extendable = this.client.extendables.get(arg);
 		if (extendable) return extendable;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'extendable');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'extendable');
 	}
 
 	/**
 	 * Resolves a finalizer
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
+
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Finalizer}
 	 */
-	async finalizer(arg, currentUsage, possible, repeat, msg) {
+	async finalizer(arg, possible, msg) {
 		const finalizer = this.client.finalizers.get(arg);
 		if (finalizer) return finalizer;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'finalizer');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'finalizer');
 	}
 
 	/**
 	 * Resolves a inhibitor
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Inhibitor}
 	 */
-	async inhibitor(arg, currentUsage, possible, repeat, msg) {
+	async inhibitor(arg, possible, msg) {
 		const inhibitor = this.client.inhibitors.get(arg);
 		if (inhibitor) return inhibitor;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'inhibitor');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'inhibitor');
 	}
 
 	/**
 	 * Resolves a monitor
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Monitor}
 	 */
-	async monitor(arg, currentUsage, possible, repeat, msg) {
+	async monitor(arg, possible, msg) {
 		const monitor = this.client.monitors.get(arg);
 		if (monitor) return monitor;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'monitor');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'monitor');
 	}
 
 	/**
 	 * Resolves a language
 	 * @since 0.2.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
+
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Language}
 	 */
-	async language(arg, currentUsage, possible, repeat, msg) {
+	async language(arg, possible, msg) {
 		const language = this.client.languages.get(arg);
 		if (language) return language;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'language');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'language');
 	}
 
 	/**
 	 * Resolves a provider
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Provider}
 	 */
-	async provider(arg, currentUsage, possible, repeat, msg) {
+	async provider(arg, possible, msg) {
 		const provider = this.client.providers.get(arg);
 		if (provider) return provider;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'provider');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'provider');
 	}
 
 	/**
 	 * Resolves a Task
 	 * @since 0.5.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
+
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Provider}
 	 */
-	async task(arg, currentUsage, possible, repeat, msg) {
+	async task(arg, possible, msg) {
 		const task = this.client.tasks.get(arg);
 		if (task) return task;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', currentUsage.possibles[possible].name, 'provider');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'provider');
 	}
 
 	/**
 	 * Resolves a message
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?KlasaMessage}
 	 */
@@ -247,26 +210,21 @@ class ArgResolver extends Resolver {
 	 * Resolves a message
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?KlasaMessage}
 	 */
-	async msg(arg, currentUsage, possible, repeat, msg) {
+	async msg(arg, possible, msg) {
 		const message = await super.msg(arg, msg.channel);
 		if (message) return message;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_MSG', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_MSG', possible.name);
 	}
 
 	/**
 	 * Resolves a user
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?KlasaUser}
 	 */
@@ -278,127 +236,104 @@ class ArgResolver extends Resolver {
 	 * Resolves a user
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?KlasaUser}
 	 */
-	async user(arg, currentUsage, possible, repeat, msg) {
+	async user(arg, possible, msg) {
 		const user = await super.user(arg);
 		if (user) return user;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_USER', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_USER', possible.name);
 	}
 
 	/**
 	 * Resolves a member
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?external:GuildMember}
 	 */
-	async member(arg, currentUsage, possible, repeat, msg) {
+	async member(arg, possible, msg) {
 		const member = await super.member(arg, msg.guild);
 		if (member) return member;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_MEMBER', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_MEMBER', possible.name);
 	}
 
 	/**
 	 * Resolves a channel
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?external:Channel}
 	 */
-	async channel(arg, currentUsage, possible, repeat, msg) {
+	async channel(arg, possible, msg) {
 		const channel = await super.channel(arg);
 		if (channel) return channel;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_CHANNEL', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_CHANNEL', possible.name);
 	}
 
 	/**
 	 * Resolves an emoji
 	 * @since 0.5.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?external:Emoji}
 	 */
-	async emoji(arg, currentUsage, possible, repeat, msg) {
+	async emoji(arg, possible, msg) {
 		const emoji = await super.emoji(arg);
 		if (emoji) return emoji;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_EMOJI', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_EMOJI', possible.name);
 	}
 
 	/**
 	 * Resolves a guild
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?KlasaGuild}
 	 */
-	async guild(arg, currentUsage, possible, repeat, msg) {
+	async guild(arg, possible, msg) {
 		const guild = await super.guild(arg);
 		if (guild) return guild;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_GUILD', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_GUILD', possible.name);
 	}
 
 	/**
 	 * Resolves a role
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?external:Role}
 	 */
-	async role(arg, currentUsage, possible, repeat, msg) {
+	async role(arg, possible, msg) {
 		const role = await super.role(arg, msg.guild);
 		if (role) return role;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_ROLE', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_ROLE', possible.name);
 	}
 
 	/**
 	 * Resolves a literal
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?string}
 	 */
-	async literal(arg, currentUsage, possible, repeat, msg) {
-		if (arg.toLowerCase() === currentUsage.possibles[possible].name.toLowerCase()) return arg.toLowerCase();
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_LITERAL', currentUsage.possibles[possible].name);
+	async literal(arg, possible, msg) {
+		if (arg.toLowerCase() === possible.name.toLowerCase()) return arg.toLowerCase();
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_LITERAL', possible.name);
 	}
 
 	/**
 	 * Resolves a boolean
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?boolean}
 	 */
@@ -410,26 +345,21 @@ class ArgResolver extends Resolver {
 	 * Resolves a boolean
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?boolean}
 	 */
-	async bool(arg, currentUsage, possible, repeat, msg) {
+	async bool(arg, possible, msg) {
 		const boolean = await super.boolean(arg);
 		if (boolean !== null) return boolean;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_BOOL', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_BOOL', possible.name);
 	}
 
 	/**
 	 * Resolves a string
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?string}
 	 */
@@ -441,15 +371,13 @@ class ArgResolver extends Resolver {
 	 * Resolves a string
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?string}
 	 */
-	async str(arg, currentUsage, possible, repeat, msg) {
-		const { min, max } = currentUsage.possibles[possible];
-		if (this.constructor.minOrMax(this.client, arg.length, min, max, currentUsage, possible, repeat, msg, 'RESOLVER_STRING_SUFFIX')) return arg;
+	async str(arg, possible, msg) {
+		const { min, max } = possible;
+		if (this.constructor.minOrMax(this.client, arg.length, min, max, possible, msg, 'RESOLVER_STRING_SUFFIX')) return arg;
 		return null;
 	}
 
@@ -457,9 +385,7 @@ class ArgResolver extends Resolver {
 	 * Resolves a integer
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?number}
 	 */
@@ -471,20 +397,17 @@ class ArgResolver extends Resolver {
 	 * Resolves a integer
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?number}
 	 */
-	async int(arg, currentUsage, possible, repeat, msg) {
-		const { min, max } = currentUsage.possibles[possible];
+	async int(arg, possible, msg) {
+		const { min, max } = possible;
 		arg = await super.integer(arg);
 		if (arg === null) {
-			if (currentUsage.type === 'optional' && !repeat) return null;
-			throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_INT', currentUsage.possibles[possible].name);
+			throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_INT', possible.name);
 		}
-		if (this.constructor.minOrMax(this.client, arg, min, max, currentUsage, possible, repeat, msg)) return arg;
+		if (this.constructor.minOrMax(this.client, arg, min, max, possible, msg)) return arg;
 		return null;
 	}
 
@@ -492,9 +415,7 @@ class ArgResolver extends Resolver {
 	 * Resolves a number
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?number}
 	 */
@@ -506,9 +427,7 @@ class ArgResolver extends Resolver {
 	 * Resolves a number
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?number}
 	 */
@@ -520,20 +439,17 @@ class ArgResolver extends Resolver {
 	 * Resolves a number
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?number}
 	 */
-	async float(arg, currentUsage, possible, repeat, msg) {
-		const { min, max } = currentUsage.possibles[possible];
+	async float(arg, possible, msg) {
+		const { min, max } = possible;
 		arg = await super.float(arg);
 		if (arg === null) {
-			if (currentUsage.type === 'optional' && !repeat) return null;
-			throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_FLOAT', currentUsage.possibles[possible].name);
+			throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_FLOAT', possible.name);
 		}
-		if (this.constructor.minOrMax(this.client, arg, min, max, currentUsage, possible, repeat, msg)) return arg;
+		if (this.constructor.minOrMax(this.client, arg, min, max, possible, msg)) return arg;
 		return null;
 	}
 
@@ -541,26 +457,21 @@ class ArgResolver extends Resolver {
 	 * Resolves an argument based on a regular expression
 	 * @since 0.3.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?string}
 	 */
-	async reg(arg, currentUsage, possible, repeat, msg) {
-		const results = currentUsage.possibles[possible].regex.exec(arg);
+	async reg(arg, possible, msg) {
+		const results = possible.regex.exec(arg);
 		if (results !== null) return results;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_REGEX_MATCH', currentUsage.possibles[possible].name, currentUsage.possibles[possible].regex.toString());
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_REGEX_MATCH', possible.name, possible.regex.toString());
 	}
 
 	/**
 	 * Resolves an argument based on a regular expression
 	 * @since 0.3.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?string}
 	 */
@@ -572,9 +483,7 @@ class ArgResolver extends Resolver {
 	 * Resolves an argument based on a regular expression
 	 * @since 0.3.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?string}
 	 */
@@ -586,71 +495,59 @@ class ArgResolver extends Resolver {
 	 * Resolves a hyperlink
 	 * @since 0.0.1
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?string}
 	 */
-	async url(arg, currentUsage, possible, repeat, msg) {
+	async url(arg, possible, msg) {
 		const hyperlink = await super.url(arg);
 		if (hyperlink !== null) return hyperlink;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_URL', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_URL', possible.name);
 	}
 
 	/**
 	 * Resolves a Date or Timestamp
 	 * @since 0.5.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Date}
 	 */
-	async date(arg, currentUsage, possible, repeat, msg) {
+	async date(arg, possible, msg) {
 		const date = new Date(arg);
 		if (!isNaN(date.getTime()) && date.getTime() > Date.now()) return date;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_DATE', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_DATE', possible.name);
 	}
 
 	/**
 	 * Resolves a Date from a relative duration
 	 * @since 0.5.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Date}
 	 */
-	async duration(arg, currentUsage, possible, repeat, msg) {
+	async duration(arg, possible, msg) {
 		const date = new Duration(arg).fromNow;
 		if (!isNaN(date.getTime()) && date.getTime() > Date.now()) return date;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_DURATION', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_DURATION', possible.name);
 	}
 
 	/**
 	 * Resolves a Date from a relative duration or timestamp
 	 * @since 0.5.0
 	 * @param {string} arg This arg
-	 * @param {Object} currentUsage This current usage
-	 * @param {number} possible This possible usage id
-	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @returns {?Date}
 	 */
-	async time(arg, currentUsage, possible, repeat, msg) {
+	async time(arg, possible, msg) {
 		const date = await Promise.all([
-			this.date(arg, currentUsage, possible, repeat, msg).catch(() => null),
-			this.duration(arg, currentUsage, possible, repeat, msg).catch(() => null)
+			this.date(arg, possible, msg).catch(() => null),
+			this.duration(arg, possible, msg).catch(() => null)
 		]).then(ret => ret.find(Boolean));
 		if (date && !isNaN(date.getTime()) && date.getTime() > Date.now()) return date;
-		if (currentUsage.type === 'optional' && !repeat) return null;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_TIME', currentUsage.possibles[possible].name);
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_TIME', possible.name);
 	}
 
 	/**
@@ -660,29 +557,24 @@ class ArgResolver extends Resolver {
 	 * @param {number} value The value to check against
 	 * @param {?number} min The minimum value
 	 * @param {?number} max The maximum value
-	 * @param {Object} currentUsage The current usage
 	 * @param {number} possible The id of the current possible usage
-	 * @param {boolean} repeat If it is a looping/repeating arg
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @param {string} suffix An error suffix
 	 * @returns {boolean}
 	 * @private
 	 */
-	static minOrMax(client, value, min, max, currentUsage, possible, repeat, msg, suffix) {
+	static minOrMax(client, value, min, max, possible, msg, suffix) {
 		suffix = suffix ? (msg ? msg.language : client.languages.default).get(suffix) : '';
 		if (min && max) {
 			if (value >= min && value <= max) return true;
-			if (currentUsage.type === 'optional' && !repeat) return false;
-			if (min === max) throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_EXACTLY', currentUsage.possibles[possible].name, min, suffix);
-			throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_BOTH', currentUsage.possibles[possible].name, min, max, suffix);
+			if (min === max) throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_EXACTLY', possible.name, min, suffix);
+			throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_BOTH', possible.name, min, max, suffix);
 		} else if (min) {
 			if (value >= min) return true;
-			if (currentUsage.type === 'optional' && !repeat) return false;
-			throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_MIN', currentUsage.possibles[possible].name, min, suffix);
+			throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_MIN', possible.name, min, suffix);
 		} else if (max) {
 			if (value <= max) return true;
-			if (currentUsage.type === 'optional' && !repeat) return false;
-			throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_MAX', currentUsage.possibles[possible].name, max, suffix);
+			throw (msg ? msg.language : client.languages.default).get('RESOLVER_MINMAX_MAX', possible.name, max, suffix);
 		}
 		return true;
 	}

--- a/src/lib/parsers/ArgResolver.js
+++ b/src/lib/parsers/ArgResolver.js
@@ -325,7 +325,8 @@ class ArgResolver extends Resolver {
 	 * @returns {Promise<string>}
 	 */
 	async literal(arg, possible, msg) {
-		if (arg.toLowerCase() === possible.name.toLowerCase()) return arg.toLowerCase();
+		arg = arg.toLowerCase();
+		if (arg === possible.name.toLowerCase()) return arg;
 		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_LITERAL', possible.name);
 	}
 

--- a/src/lib/parsers/ArgResolver.js
+++ b/src/lib/parsers/ArgResolver.js
@@ -8,6 +8,25 @@ const Duration = require('../util/Duration');
 class ArgResolver extends Resolver {
 
 	/**
+	 * Resolves a one-off custom argument
+	 * @since 0.5.0
+	 * @param {string} arg This arg
+	 * @param {Object} currentUsage This current usage
+	 * @param {number} possible This possible usage id
+	 * @param {boolean} repeat If it is a looping/repeating arg
+	 * @param {KlasaMessage} msg The message that triggered the command
+	 * @param {Function} custom The custom resolver
+	 * @returns {Piece}
+	 */
+	async custom(arg, currentUsage, possible, repeat, msg, custom) {
+		if (!custom) throw (msg ? msg.language : this.language).get('RESOLVER_MISSING_CUSTOM', currentUsage.possibles[possible].name);
+		const resolved = await custom(arg, msg, msg.params);
+		if (resolved) return resolved;
+		if (currentUsage.type === 'optional' && !repeat) return null;
+		throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_CUSTOM', currentUsage.possibles[possible].name);
+	}
+
+	/**
 	 * Resolves a piece
 	 * @since 0.3.0
 	 * @param {string} arg This arg

--- a/src/lib/parsers/ArgResolver.js
+++ b/src/lib/parsers/ArgResolver.js
@@ -14,7 +14,7 @@ class ArgResolver extends Resolver {
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
 	 * @param {Function} custom The custom resolver
-	 * @returns {?any}
+	 * @returns {Promise<any>}
 	 */
 	async custom(arg, possible, msg, custom) {
 		const resolved = await custom(arg, possible, msg, msg.params);
@@ -28,7 +28,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Piece}
+	 * @returns {Promise<Piece>}
 	 */
 	async piece(arg, possible, msg) {
 		for (const store of this.client.pieceStores.values()) {
@@ -44,7 +44,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Store}
+	 * @returns {Promise<Store>}
 	 */
 	async store(arg, possible, msg) {
 		const store = this.client.pieceStores.get(arg);
@@ -58,7 +58,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Command}
+	 * @returns {Promise<Command>}
 	 */
 	async command(...args) {
 		return this.cmd(...args);
@@ -70,7 +70,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Command}
+	 * @returns {Promise<Command>}
 	 */
 	async cmd(arg, possible, msg) {
 		const command = this.client.commands.get(arg);
@@ -84,7 +84,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Event}
+	 * @returns {Promise<Event>}
 	 */
 	async event(arg, possible, msg) {
 		const event = this.client.events.get(arg);
@@ -97,9 +97,8 @@ class ArgResolver extends Resolver {
 	 * @since 0.0.1
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
-
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Extendable}
+	 * @returns {Promise<Extendable>}
 	 */
 	async extendable(arg, possible, msg) {
 		const extendable = this.client.extendables.get(arg);
@@ -112,9 +111,8 @@ class ArgResolver extends Resolver {
 	 * @since 0.0.1
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
-
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Finalizer}
+	 * @returns {Promise<Finalizer>}
 	 */
 	async finalizer(arg, possible, msg) {
 		const finalizer = this.client.finalizers.get(arg);
@@ -128,7 +126,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Inhibitor}
+	 * @returns {Promise<Inhibitor>}
 	 */
 	async inhibitor(arg, possible, msg) {
 		const inhibitor = this.client.inhibitors.get(arg);
@@ -142,7 +140,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Monitor}
+	 * @returns {Promise<Monitor>}
 	 */
 	async monitor(arg, possible, msg) {
 		const monitor = this.client.monitors.get(arg);
@@ -155,9 +153,8 @@ class ArgResolver extends Resolver {
 	 * @since 0.2.1
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
-
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Language}
+	 * @returns {Promise<Language>}
 	 */
 	async language(arg, possible, msg) {
 		const language = this.client.languages.get(arg);
@@ -171,7 +168,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Provider}
+	 * @returns {Promise<Provider>}
 	 */
 	async provider(arg, possible, msg) {
 		const provider = this.client.providers.get(arg);
@@ -184,14 +181,13 @@ class ArgResolver extends Resolver {
 	 * @since 0.5.0
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
-
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Provider}
+	 * @returns {Promise<Task>}
 	 */
 	async task(arg, possible, msg) {
 		const task = this.client.tasks.get(arg);
 		if (task) return task;
-		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'provider');
+		throw (msg ? msg.language : this.client.languages.default).get('RESOLVER_INVALID_PIECE', possible.name, 'task');
 	}
 
 	/**
@@ -200,7 +196,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?KlasaMessage}
+	 * @returns {Promise<KlasaMessage>}
 	 */
 	message(...args) {
 		return this.msg(...args);
@@ -212,7 +208,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?KlasaMessage}
+	 * @returns {Promise<KlasaMessage>}
 	 */
 	async msg(arg, possible, msg) {
 		const message = await super.msg(arg, msg.channel);
@@ -226,7 +222,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?KlasaUser}
+	 * @returns {Promise<KlasaUser>}
 	 */
 	mention(...args) {
 		return this.user(...args);
@@ -238,7 +234,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?KlasaUser}
+	 * @returns {Promise<KlasaUser>}
 	 */
 	async user(arg, possible, msg) {
 		const user = await super.user(arg);
@@ -252,7 +248,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?external:GuildMember}
+	 * @returns {Promise<external:GuildMember>}
 	 */
 	async member(arg, possible, msg) {
 		const member = await super.member(arg, msg.guild);
@@ -266,7 +262,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?external:Channel}
+	 * @returns {Promise<external:Channel>}
 	 */
 	async channel(arg, possible, msg) {
 		const channel = await super.channel(arg);
@@ -280,7 +276,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?external:Emoji}
+	 * @returns {Promise<external:Emoji>}
 	 */
 	async emoji(arg, possible, msg) {
 		const emoji = await super.emoji(arg);
@@ -294,7 +290,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?KlasaGuild}
+	 * @returns {Promise<KlasaGuild>}
 	 */
 	async guild(arg, possible, msg) {
 		const guild = await super.guild(arg);
@@ -308,7 +304,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?external:Role}
+	 * @returns {Promise<external:Role>}
 	 */
 	async role(arg, possible, msg) {
 		const role = await super.role(arg, msg.guild);
@@ -322,7 +318,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?string}
+	 * @returns {Promise<string>}
 	 */
 	async literal(arg, possible, msg) {
 		if (arg.toLowerCase() === possible.name.toLowerCase()) return arg.toLowerCase();
@@ -335,7 +331,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?boolean}
+	 * @returns {Promise<boolean>}
 	 */
 	boolean(...args) {
 		return this.bool(...args);
@@ -347,7 +343,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?boolean}
+	 * @returns {Promise<boolean>}
 	 */
 	async bool(arg, possible, msg) {
 		const boolean = await super.boolean(arg);
@@ -361,7 +357,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?string}
+	 * @returns {Promise<string>}
 	 */
 	string(...args) {
 		return this.str(...args);
@@ -373,7 +369,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?string}
+	 * @returns {Promise<string>}
 	 */
 	async str(arg, possible, msg) {
 		const { min, max } = possible;
@@ -387,7 +383,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?number}
+	 * @returns {Promise<number>}
 	 */
 	integer(...args) {
 		return this.int(...args);
@@ -399,7 +395,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?number}
+	 * @returns {Promise<number>}
 	 */
 	async int(arg, possible, msg) {
 		const { min, max } = possible;
@@ -417,7 +413,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?number}
+	 * @returns {Promise<number>}
 	 */
 	num(...args) {
 		return this.float(...args);
@@ -429,7 +425,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?number}
+	 * @returns {Promise<number>}
 	 */
 	number(...args) {
 		return this.float(...args);
@@ -441,7 +437,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?number}
+	 * @returns {Promise<number>}
 	 */
 	async float(arg, possible, msg) {
 		const { min, max } = possible;
@@ -459,7 +455,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?string}
+	 * @returns {Promise<RegExpExecArray>}
 	 */
 	async reg(arg, possible, msg) {
 		const results = possible.regex.exec(arg);
@@ -473,7 +469,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?string}
+	 * @returns {Promise<RegExpExecArray>}
 	 */
 	regex(...args) {
 		return this.reg(...args);
@@ -485,7 +481,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?string}
+	 * @returns {Promise<RegExpExecArray>}
 	 */
 	regexp(...args) {
 		return this.reg(...args);
@@ -497,7 +493,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?string}
+	 * @returns {Promise<string>}
 	 */
 	async url(arg, possible, msg) {
 		const hyperlink = await super.url(arg);
@@ -511,7 +507,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Date}
+	 * @returns {Promise<Date>}
 	 */
 	async date(arg, possible, msg) {
 		const date = new Date(arg);
@@ -525,7 +521,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Date}
+	 * @returns {Promise<Date>}
 	 */
 	async duration(arg, possible, msg) {
 		const date = new Duration(arg).fromNow;
@@ -539,7 +535,7 @@ class ArgResolver extends Resolver {
 	 * @param {string} arg This arg
 	 * @param {Possible} possible This current usage possible
 	 * @param {KlasaMessage} msg The message that triggered the command
-	 * @returns {?Date}
+	 * @returns {Promise<Date>}
 	 */
 	async time(arg, possible, msg) {
 		const date = await Promise.all([

--- a/src/lib/parsers/ArgResolver.js
+++ b/src/lib/parsers/ArgResolver.js
@@ -17,9 +17,13 @@ class ArgResolver extends Resolver {
 	 * @returns {Promise<any>}
 	 */
 	async custom(arg, possible, msg, custom) {
-		const resolved = await custom(arg, possible, msg, msg.params);
-		if (resolved) return resolved;
-		throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_CUSTOM', possible.name, possible.type);
+		try {
+			const resolved = await custom(arg, possible, msg, msg.params);
+			return resolved;
+		} catch (err) {
+			if (err) throw err;
+			throw (msg ? msg.language : this.language).get('RESOLVER_INVALID_CUSTOM', possible.name, possible.type);
+		}
 	}
 
 	/**

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -267,6 +267,19 @@ class Command {
 	}
 
 	/**
+	 * Customizes the response of an argument if it fails resolution.
+	 * @param {string} name The type of the usage argument
+	 * @param {string|Function} response The custom response or i18n function
+	 * @returns {Command}
+	 * @chainable
+	 * @since 0.5.0
+	 */
+	customizeResponse(name, response) {
+		this.usage.customizeResponse(name, response);
+		return this;
+	}
+
+	/**
 	 * The run method to be overwritten in actual commands
 	 * @since 0.0.1
 	 * @param {KlasaMessage} msg The command message mapped on top of the message used to trigger this command

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -269,7 +269,7 @@ class Command {
 	/**
 	 * Customizes the response of an argument if it fails resolution.
 	 * @param {string} name The name of the usage argument
-	 * @param {string|Function} response The custom response or i18n function
+	 * @param {(string|Function)} response The custom response or i18n function
 	 * @returns {Command}
 	 * @chainable
 	 * @since 0.5.0

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -254,6 +254,19 @@ class Command {
 	}
 
 	/**
+	 * Registers a one-off custom resolver
+	 * @param {string} type The type of the usage argument
+	 * @param {Function} resolver The one-off custom resolver
+	 * @returns {Command}
+	 * @chainable
+	 * @since 0.5.0
+	 */
+	createCustomResolver(type, resolver) {
+		this.usage.createCustomResolver(type, resolver);
+		return this;
+	}
+
+	/**
 	 * The run method to be overwritten in actual commands
 	 * @since 0.0.1
 	 * @param {KlasaMessage} msg The command message mapped on top of the message used to trigger this command

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -193,6 +193,13 @@ class Command {
 		this.quotedStringSupport = options.quotedStringSupport;
 
 		/**
+		 * Whether to enable sub commands or not
+		 * @since 0.5.0
+		 * @type {boolean}
+		 */
+		this.subcommands = options.subcommands;
+
+		/**
 		 * The full category for the command
 		 * @since 0.0.1
 		 * @type {string[]}

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -268,7 +268,7 @@ class Command {
 
 	/**
 	 * Customizes the response of an argument if it fails resolution.
-	 * @param {string} name The type of the usage argument
+	 * @param {string} name The name of the usage argument
 	 * @param {string|Function} response The custom response or i18n function
 	 * @returns {Command}
 	 * @chainable

--- a/src/lib/usage/CommandUsage.js
+++ b/src/lib/usage/CommandUsage.js
@@ -27,7 +27,7 @@ class CommandUsage extends ParsedUsage {
 		 * @since 0.0.1
 		 * @type {string}
 		 */
-		this.commands = this.names.length === 1 ? this.names[0] : `⟨${this.names.join('|')}⟩`;
+		this.commands = this.names.length === 1 ? this.names[0] : `《${this.names.join('|')}》`;
 
 		/**
 		 * The concatenated string of this.commands and this.deliminatedUsage

--- a/src/lib/usage/CommandUsage.js
+++ b/src/lib/usage/CommandUsage.js
@@ -27,7 +27,7 @@ class CommandUsage extends ParsedUsage {
 		 * @since 0.0.1
 		 * @type {string}
 		 */
-		this.commands = this.names.length === 1 ? this.names[0] : `(${this.names.join('|')})`;
+		this.commands = this.names.length === 1 ? this.names[0] : `⟨${this.names.join('|')}⟩`;
 
 		/**
 		 * The concatenated string of this.commands and this.deliminatedUsage

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -49,6 +49,26 @@ class ParsedUsage {
 		 * @type {Tag[]}
 		 */
 		this.parsedUsage = this.constructor.parseUsage(this.usageString);
+
+		/**
+		 * Stores one-off custom resolvers for use with the custom type arg
+		 * @since 0.5.0
+		 * @type {Object}
+		 */
+		this.customResolvers = {};
+	}
+
+	/**
+	 * Registers a one-off custom resolver
+	 * @param {string} type The type of the usage argument
+	 * @param {Function} resolver The one-off custom resolver
+	 * @returns {ParsedUsage}
+	 * @chainable
+	 * @since 0.5.0
+	 */
+	createCustomResolver(type, resolver) {
+		this.customResolvers[type] = resolver;
+		return this;
 	}
 
 	/**

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -56,6 +56,13 @@ class ParsedUsage {
 		 * @type {Object}
 		 */
 		this.customResolvers = {};
+
+		/**
+		 * Stores custom responses
+		 * @since 0.5.0
+		 * @type {Object}
+		 */
+		this.customResponses = {};
 	}
 
 	/**
@@ -68,6 +75,19 @@ class ParsedUsage {
 	 */
 	createCustomResolver(type, resolver) {
 		this.customResolvers[type] = resolver;
+		return this;
+	}
+
+	/**
+	 * Customizes the response of an argument if it fails resolution.
+	 * @param {string} name The type of the usage argument
+	 * @param {string|Function} response The custom response or i18n function
+	 * @returns {ParsedUsage}
+	 * @chainable
+	 * @since 0.5.0
+	 */
+	customizeResponse(name, response) {
+		this.customResponses[name] = response;
 		return this;
 	}
 

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -1,7 +1,7 @@
 const Tag = require('./Tag');
 const TextPrompt = require('./TextPrompt');
-const open = ['[', '{', '<'];
-const close = [']', '}', '>'];
+const open = ['[', '(', '<'];
+const close = [']', ')', '>'];
 
 /**
  * Converts usage strings into objects to compare against later

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -80,7 +80,7 @@ class ParsedUsage {
 
 	/**
 	 * Customizes the response of an argument if it fails resolution.
-	 * @param {string} name The type of the usage argument
+	 * @param {string} name The name of the usage argument
 	 * @param {string|Function} response The custom response or i18n function
 	 * @returns {ParsedUsage}
 	 * @chainable

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -56,13 +56,6 @@ class ParsedUsage {
 		 * @type {Object}
 		 */
 		this.customResolvers = {};
-
-		/**
-		 * Stores custom responses
-		 * @since 0.5.0
-		 * @type {Object}
-		 */
-		this.customResponses = {};
 	}
 
 	/**
@@ -87,7 +80,7 @@ class ParsedUsage {
 	 * @since 0.5.0
 	 */
 	customizeResponse(name, response) {
-		this.customResponses[name] = response;
+		this.parsedUsage.some(tag => tag.register(name, response));
 		return this;
 	}
 

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -74,7 +74,7 @@ class ParsedUsage {
 	/**
 	 * Customizes the response of an argument if it fails resolution.
 	 * @param {string} name The name of the usage argument
-	 * @param {string|Function} response The custom response or i18n function
+	 * @param {(string|Function)} response The custom response or i18n function
 	 * @returns {ParsedUsage}
 	 * @chainable
 	 * @since 0.5.0

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -196,7 +196,7 @@ class ParsedUsage {
 		if (usage.current === '...') {
 			if (usage.openReq) throw `${usage.at}: repeat tag cannot be required`;
 			if (usage.tags.length < 1) throw `${usage.fromTo}: there can't be a repeat at the beginning`;
-			usage.tags.push({ type: 'repeat' });
+			usage.tags[usage.tags.length - 1].repeat = true;
 			usage.last = true;
 		} else {
 			usage.tags.push(new Tag(usage.current, usage.tags.length + 1, required));

--- a/src/lib/usage/ParsedUsage.js
+++ b/src/lib/usage/ParsedUsage.js
@@ -152,8 +152,8 @@ class ParsedUsage {
 				continue;
 			}
 
-			if (['<', '{', '['].includes(char)) usage = ParsedUsage.tagOpen(usage, char);
-			else if (['>', '}', ']'].includes(char)) usage = ParsedUsage.tagClose(usage, char);
+			if (open.includes(char)) usage = ParsedUsage.tagOpen(usage, char);
+			else if (close.includes(char)) usage = ParsedUsage.tagClose(usage, char);
 			else if ([' ', '\n'].includes(char)) usage = ParsedUsage.tagSpace(usage, char);
 			else usage.current += char;
 		}

--- a/src/lib/usage/Tag.js
+++ b/src/lib/usage/Tag.js
@@ -15,7 +15,7 @@ class Tag {
 		/**
 		 * The type of this tag
 		 * @since 0.5.0
-		 * @type {boolean}
+		 * @type {number}
 		 */
 		this.required = required;
 

--- a/src/lib/usage/Tag.js
+++ b/src/lib/usage/Tag.js
@@ -14,10 +14,17 @@ class Tag {
 	constructor(members, count, required) {
 		/**
 		 * The type of this tag
-		 * @since 0.2.1
-		 * @type {string}
+		 * @since 0.5.0
+		 * @type {boolean}
 		 */
-		this.type = required ? 'required' : 'optional';
+		this.required = required;
+
+		/**
+		 * If this tag is repeating
+		 * @since 0.5.0
+		 * @type {boolean}
+		 */
+		this.repeat = false;
 
 		/**
 		 * The possibilities of this tag

--- a/src/lib/usage/Tag.js
+++ b/src/lib/usage/Tag.js
@@ -32,6 +32,30 @@ class Tag {
 		 * @type {Possible[]}
 		 */
 		this.possibles = Tag.parseMembers(members, count);
+
+		/**
+		 * The custom response defined for this possible
+		 * @since 0.5.0
+		 * @type {?(string|Function)}
+		 */
+		this.response = null;
+	}
+
+	/**
+	 * Registers a response
+	 * @since 0.5.0
+	 * @param {string} name The argument name the response is for
+	 * @param {string|Function} response The custom response
+	 * @returns {boolean}
+	 * @private
+	 */
+	register(name, response) {
+		if (this.response) return false;
+		if (this.possibles.some(val => val.name === name)) {
+			this.response = response;
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/src/lib/usage/Tag.js
+++ b/src/lib/usage/Tag.js
@@ -45,7 +45,7 @@ class Tag {
 	 * Registers a response
 	 * @since 0.5.0
 	 * @param {string} name The argument name the response is for
-	 * @param {string|Function} response The custom response
+	 * @param {(string|Function)} response The custom response
 	 * @returns {boolean}
 	 * @private
 	 */

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -250,11 +250,11 @@ class TextPrompt {
 	 */
 	async multiPossibles(index) {
 		if (index >= this._currentUsage.possibles.length) {
-			if (this._required) {
-				return this.handleError(this.message.language.get('COMMANDMESSAGE_NOMATCH', this._currentUsage.possibles.map(poss => poss.name).join(', ')));
+			if (!this._required) {
+				this.args.splice(this.params.length, 0, undefined);
+				return this.pushParam(undefined);
 			}
-			this.args.splice(this.params.length, 0, undefined);
-			return this.pushParam(undefined);
+			return this.handleError(this.message.language.get('COMMANDMESSAGE_NOMATCH', this._currentUsage.possibles.map(poss => poss.name).join(', ')));
 		}
 
 		const possible = this._currentUsage.possibles[index];
@@ -265,7 +265,6 @@ class TextPrompt {
 			this.client.emit('warn', `Unknown Argument Type encountered: ${possible.type}`);
 			return this.multiPossibles(++index);
 		}
-
 
 		try {
 			const res = await this.client.argResolver[custom ? 'custom' : possible.type](this.args[this.params.length], possible, this.message, custom);

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -235,7 +235,7 @@ class TextPrompt {
 				return this.pushParam(undefined);
 			}
 			const { response } = this._currentUsage;
-			const error = typeof response === 'function' ? response(possible, this.message) : response;
+			const error = typeof response === 'function' ? response(this.message, possible) : response;
 			return this.handleError(error || this.args[this.params.length] === undefined ?
 				this.message.language.get('COMMANDMESSAGE_MISSING_REQUIRED', possible.name) :
 				err
@@ -258,7 +258,7 @@ class TextPrompt {
 			}
 			const { response } = this._currentUsage;
 			if (response) {
-				const error = typeof response === 'function' ? response(possible, this.message) : response;
+				const error = typeof response === 'function' ? response(this.message, possible) : response;
 				return this.handleError(error);
 			}
 			return this.handleError(this.message.language.get('COMMANDMESSAGE_NOMATCH', this._currentUsage.possibles.map(poss => poss.name).join(', ')));

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -234,7 +234,7 @@ class TextPrompt {
 				this.args.splice(this.params.length, 0, undefined);
 				return this.pushParam(undefined);
 			}
-			const response = this.usage.customResponses[possible.name];
+			const { response } = this._currentUsage;
 			const error = typeof response === 'function' ? response(possible, this.message) : response;
 			return this.handleError(error || this.args[this.params.length] === undefined ?
 				this.message.language.get('COMMANDMESSAGE_MISSING_REQUIRED', possible.name) :
@@ -256,9 +256,8 @@ class TextPrompt {
 				this.args.splice(this.params.length, 0, undefined);
 				return this.pushParam(undefined);
 			}
-			const possible = this._currentUsage.possibles.find(val => val.name in this.usage.customResponses);
-			if (possible) {
-				const response = this.usage.customResponses[possible.name];
+			const { response } = this._currentUsage;
+			if (response) {
 				const error = typeof response === 'function' ? response(possible, this.message) : response;
 				return this.handleError(error);
 			}

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -236,9 +236,9 @@ class TextPrompt {
 			}
 			const { response } = this._currentUsage;
 			const error = typeof response === 'function' ? response(this.message, possible) : response;
-			return this.handleError(error || this.args[this.params.length] === undefined ?
+			return this.handleError(error || (this.args[this.params.length] === undefined ?
 				this.message.language.get('COMMANDMESSAGE_MISSING_REQUIRED', possible.name) :
-				err
+				err)
 			);
 		}
 	}

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -106,10 +106,10 @@ class TextPrompt {
 		/**
 		 * Whether the current usage is required
 		 * @since 0.0.1
-		 * @type {boolean}
+		 * @type {number}
 		 * @private
 		 */
-		this._required = false;
+		this._required = 0;
 
 		/**
 		 * How many time this class has reprompted
@@ -209,7 +209,7 @@ class TextPrompt {
 			this._currentUsage = this.usage.parsedUsage[this.params.length];
 			this._required = this._currentUsage.required;
 		} else if (this._currentUsage.repeat) {
-			this._required = false;
+			this._required = 0;
 			this._repeat = true;
 		} else {
 			return this.finalize();
@@ -236,6 +236,7 @@ class TextPrompt {
 			}
 			const { response } = this._currentUsage;
 			const error = typeof response === 'function' ? response(this.message, possible) : response;
+			if (this._required === 1) return this.handleError(response || err);
 			return this.handleError(error || (this.args[this.params.length] === undefined ?
 				this.message.language.get('COMMANDMESSAGE_MISSING_REQUIRED', possible.name) :
 				err)

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -210,15 +210,17 @@ class TextPrompt {
 
 		if (this._currentUsage.possibles.length !== 1) return this.multiPossibles(0);
 
-		if (this._currentUsage.possibles[0].name in this.flags) this.args.splice(this.params.length, 0, this.flags[this._currentUsage.possibles[0].name]);
+		const { name, type } = this._currentUsage.possibles[0];
+		const custom = this.usage.customResolvers[name];
 
-		if (!this.client.argResolver[this._currentUsage.possibles[0].type]) {
-			this.client.emit('warn', `Unknown Argument Type encountered: ${this._currentUsage.possibles[0].type}`);
+		if (name in this.flags) this.args.splice(this.params.length, 0, this.flags[name]);
+		if (!this.client.argResolver[type] && !custom) {
+			this.client.emit('warn', `Unknown Argument Type encountered: ${type}`);
 			return this.pushParam(undefined);
 		}
 
 		try {
-			const res = await this.client.argResolver[this._currentUsage.possibles[0].type](this.args[this.params.length], this._currentUsage, 0, this._repeat, this.message);
+			const res = await this.client.argResolver[custom ? 'custom' : type](this.args[this.params.length], this._currentUsage, 0, this._repeat, this.message, custom);
 			if (res !== null) return this.pushParam(res);
 			this.args.splice(this.params.length, 0, undefined);
 			return this.pushParam(undefined);
@@ -228,7 +230,7 @@ class TextPrompt {
 				return this.pushParam(undefined);
 			}
 			return this.handleError(this.args[this.params.length] === undefined ?
-				this.message.language.get('COMMANDMESSAGE_MISSING_REQUIRED', this._currentUsage.possibles[0].name) :
+				this.message.language.get('COMMANDMESSAGE_MISSING_REQUIRED', name) :
 				err
 			);
 		}
@@ -250,15 +252,18 @@ class TextPrompt {
 			return this.pushParam(undefined);
 		}
 
-		if (this._currentUsage.possibles[possible].name in this.flags) this.args.splice(this.params.length, 0, this.flags[this._currentUsage.possibles[possible].name]);
+		const { name, type } = this._currentUsage.possibles[possible];
+		const custom = this.usage.customResolvers[name];
 
-		if (!this.client.argResolver[this._currentUsage.possibles[possible].type]) {
-			this.client.emit('warn', `Unknown Argument Type encountered: ${this._currentUsage.possibles[possible].type}`);
+		if (name in this.flags) this.args.splice(this.params.length, 0, this.flags[name]);
+		if (!this.client.argResolver[type] && !custom) {
+			this.client.emit('warn', `Unknown Argument Type encountered: ${type}`);
 			return this.multiPossibles(++possible);
 		}
 
+
 		try {
-			const res = await this.client.argResolver[this._currentUsage.possibles[possible].type](this.args[this.params.length], this._currentUsage, possible, this._repeat, this.message);
+			const res = await this.client.argResolver[custom ? 'custom' : type](this.args[this.params.length], this._currentUsage, possible, this._repeat, this.message, custom);
 			if (res !== null) return this.pushParam(res);
 			return this.multiPossibles(++possible);
 		} catch (err) {

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -234,7 +234,9 @@ class TextPrompt {
 				this.args.splice(this.params.length, 0, undefined);
 				return this.pushParam(undefined);
 			}
-			return this.handleError(this.args[this.params.length] === undefined ?
+			const response = this.usage.customResponses[possible.name];
+			const error = typeof response === 'function' ? response(possible, this.message) : response;
+			return this.handleError(error || this.args[this.params.length] === undefined ?
 				this.message.language.get('COMMANDMESSAGE_MISSING_REQUIRED', possible.name) :
 				err
 			);
@@ -253,6 +255,12 @@ class TextPrompt {
 			if (!this._required) {
 				this.args.splice(this.params.length, 0, undefined);
 				return this.pushParam(undefined);
+			}
+			const possible = this._currentUsage.possibles.find(val => val.name in this.usage.customResponses);
+			if (possible) {
+				const response = this.usage.customResponses[possible.name];
+				const error = typeof response === 'function' ? response(possible, this.message) : response;
+				return this.handleError(error);
 			}
 			return this.handleError(this.message.language.get('COMMANDMESSAGE_NOMATCH', this._currentUsage.possibles.map(poss => poss.name).join(', ')));
 		}

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -51,6 +51,7 @@ exports.DEFAULTS = {
 				promptTime: 30000,
 				requiredConfigs: [],
 				runIn: ['text', 'dm', 'group'],
+				subcommands: false,
 				usage: '',
 				quotedStringSupport: false,
 				deletable: false

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -85,7 +85,8 @@ module.exports = class extends Monitor {
 			return this.client.emit('commandError', msg, msg.command, msg.params, error);
 		}
 
-		const commandRun = msg.command.run(msg, msg.params);
+		const subcommand = msg.command.subcommands ? msg.params.shift() : undefined;
+		const commandRun = subcommand ? msg.command[subcommand](msg, msg.params) : msg.command.run(msg, msg.params);
 
 		if (this.client.options.typing) msg.channel.stopTyping();
 		timer.stop();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -384,46 +384,47 @@ declare module 'klasa' {
 
 	export class ArgResolver extends Resolver {
 
-		public piece(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Piece>;
-		public store(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Store>;
+		public custom(arg: string, possible: Possible, msg: KlasaMessage, custom: ArgResolverCustomMethod): Promise<any>;
+		public piece(arg: string, possible: Possible, msg: KlasaMessage): Promise<Piece>;
+		public store(arg: string, possible: Possible, msg: KlasaMessage): Promise<Store>;
 
-		public command(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Command>;
-		public cmd(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Command>;
-		public event(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Event>;
-		public extendable(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Extendable>;
-		public finalizer(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Finalizer>;
-		public inhibitor(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Inhibitor>;
-		public monitor(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Monitor>;
-		public language(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Language>;
-		public provider(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Provider>;
-		public task(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Task>;
+		public command(arg: string, possible: Possible, msg: KlasaMessage): Promise<Command>;
+		public cmd(arg: string, possible: Possible, msg: KlasaMessage): Promise<Command>;
+		public event(arg: string, possible: Possible, msg: KlasaMessage): Promise<Event>;
+		public extendable(arg: string, possible: Possible, msg: KlasaMessage): Promise<Extendable>;
+		public finalizer(arg: string, possible: Possible, msg: KlasaMessage): Promise<Finalizer>;
+		public inhibitor(arg: string, possible: Possible, msg: KlasaMessage): Promise<Inhibitor>;
+		public monitor(arg: string, possible: Possible, msg: KlasaMessage): Promise<Monitor>;
+		public language(arg: string, possible: Possible, msg: KlasaMessage): Promise<Language>;
+		public provider(arg: string, possible: Possible, msg: KlasaMessage): Promise<Provider>;
+		public task(arg: string, possible: Possible, msg: KlasaMessage): Promise<Task>;
 
-		public message(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<KlasaMessage>;
-		public msg(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<KlasaMessage>;
-		public mention(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<KlasaUser>;
-		public user(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<KlasaUser>;
-		public member(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<GuildMember>;
-		public channel(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Channel>;
-		public emoji(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Emoji>;
-		public guild(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<KlasaGuild>;
-		public role(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Role>;
-		public literal(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<string>;
-		public boolean(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<boolean>;
-		public bool(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<boolean>;
-		public string(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<string>;
-		public str(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<string>;
-		public integer(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<number>;
-		public int(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<number>;
-		public num(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<number>;
-		public number(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<number>;
-		public float(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<number>;
-		public reg(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<string>;
-		public regex(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<string>;
-		public regexp(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<string>;
-		public url(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<string>;
-		public date(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Date>;
-		public duration(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Date>;
-		public time(arg: string, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage): Promise<Date>;
+		public message(arg: string, possible: Possible, msg: KlasaMessage): Promise<KlasaMessage>;
+		public msg(arg: string, possible: Possible, msg: KlasaMessage): Promise<KlasaMessage>;
+		public mention(arg: string, possible: Possible, msg: KlasaMessage): Promise<KlasaUser>;
+		public user(arg: string, possible: Possible, msg: KlasaMessage): Promise<KlasaUser>;
+		public member(arg: string, possible: Possible, msg: KlasaMessage): Promise<GuildMember>;
+		public channel(arg: string, possible: Possible, msg: KlasaMessage): Promise<Channel>;
+		public emoji(arg: string, possible: Possible, msg: KlasaMessage): Promise<Emoji>;
+		public guild(arg: string, possible: Possible, msg: KlasaMessage): Promise<KlasaGuild>;
+		public role(arg: string, possible: Possible, msg: KlasaMessage): Promise<Role>;
+		public literal(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public boolean(arg: string, possible: Possible, msg: KlasaMessage): Promise<boolean>;
+		public bool(arg: string, possible: Possible, msg: KlasaMessage): Promise<boolean>;
+		public string(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public str(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public integer(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
+		public int(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
+		public num(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
+		public number(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
+		public float(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
+		public reg(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public regex(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public regexp(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public url(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public date(arg: string, possible: Possible, msg: KlasaMessage): Promise<Date>;
+		public duration(arg: string, possible: Possible, msg: KlasaMessage): Promise<Date>;
+		public time(arg: string, possible: Possible, msg: KlasaMessage): Promise<Date>;
 
 		// Overloads for TS retrocompatibility
 		public message(input: string | KlasaMessage, channel: Channel): Promise<KlasaMessage>;
@@ -445,7 +446,7 @@ declare module 'klasa' {
 		public float(input: string | number): Promise<number>;
 		public url(input: string): Promise<string>;
 
-		private static minOrMax(value: number, min: number, max: number, currentUsage: object, possible: number, repeat: boolean, msg: KlasaMessage, suffix: string): Promise<boolean>;
+		private static minOrMax(client: KlasaClient, value: number, min: number, max: number, possible: Possible, msg: KlasaMessage, suffix: string): boolean;
 	}
 
 	export class SettingResolver extends Resolver {
@@ -514,7 +515,10 @@ declare module 'klasa' {
 		public usageString: string;
 		public usageDelim: string;
 		public parsedUsage: Tag[];
+		public customResolvers: { [K: string]: ArgResolverCustomMethod };
 
+		public createCustomResolver(type: string, resolver: ArgResolverCustomMethod): this;
+		public customizeResponse(name: string, response: ((msg: KlasaMessage) => string)): this;
 		public createPrompt(msg: KlasaMessage, options?: TextPromptOptions): TextPrompt;
 		public toJSON(): Tag[];
 		public toString(): string;
@@ -538,9 +542,11 @@ declare module 'klasa' {
 
 	export class Tag {
 		public constructor(members: string, count: number, required: boolean);
-		public type: string;
+		public required: boolean;
 		public possibles: Possible[];
+		public response: string | ((msg: KlasaMessage) => string);
 
+		private register(name: string, response: ArgResolverCustomMethod): boolean;
 		private static parseMembers(members: string, count: number): Possible[];
 		private static parseTrueMembers(members: string): string[];
 	}
@@ -558,6 +564,7 @@ declare module 'klasa' {
 		public promptLimit: number;
 		public quotedStringSupport: boolean;
 		private _repeat: boolean;
+		private _required: boolean;
 		private _prompted: number;
 		private _currentUsage: Tag;
 
@@ -565,7 +572,7 @@ declare module 'klasa' {
 		private reprompt(prompt: string): Promise<any[]>;
 		private repeatingPrompt(): Promise<any[]>;
 		private validateArgs(): Promise<any[]>;
-		private multiPossibles(possible: number): Promise<any[]>;
+		private multiPossibles(index: number): Promise<any[]>;
 		private pushParam(param: any): any[];
 		private handleError(err: string): Promise<any[]>;
 		private finalize(): any[];
@@ -957,6 +964,8 @@ declare module 'klasa' {
 		private fullCategory: string[];
 
 		public definePrompt(usageString: string, usageDelim: string): ParsedUsage;
+		public createCustomResolver(type: string, resolver: ArgResolverCustomMethod): this;
+		public customizeResponse(name: string, response: string | ((msg: KlasaMessage) => string)): this;
 
 		public abstract run(msg: KlasaMessage, params: any[]): Promise<KlasaMessage | KlasaMessage[]>;
 		public init(): Promise<void>;
@@ -1338,11 +1347,11 @@ declare module 'klasa' {
 		public init(): Promise<void>;
 		public execute(): Promise<void>;
 		public next(): ScheduledTask;
-		public create(taskName: string, time: Date | number | string, options: ScheduledTaskOptions);
+		public create(taskName: string, time: Date | number | string, options: ScheduledTaskOptions): Promise<ScheduledTask>;
 		public delete(id: string): Promise<this>;
 		public clear(): Promise<void>;
 
-		private _add(taskName: string, time: Date | number | string, options: ScheduledTaskOptions);
+		private _add(taskName: string, time: Date | number | string, options: ScheduledTaskOptions): ScheduledTask;
 		private _insert(task: ScheduledTask): ScheduledTask;
 		private _clearInterval(): void;
 		private _checkInterval(): void;
@@ -1365,7 +1374,7 @@ declare module 'klasa' {
 		public toJSON(): ScheduledTaskJSON;
 
 		private static _resolveTime(time: Date | number | Cron | string): [Date, Cron];
-		private static _generateID(client: KlasaCLient, time: Date | number): string;
+		private static _generateID(client: KlasaClient, time: Date | number): string;
 		private static _validate(st: ScheduledTask): void;
 	}
 
@@ -1501,6 +1510,9 @@ declare module 'klasa' {
 		uid?: number;
 	};
 
+	// Parsers
+	type ArgResolverCustomMethod = (arg: string, possible: Possible, msg: KlasaMessage, params: string[]) => Promise<any>;
+
 	// Permissions
 	export type PermissionLevel = {
 		break: boolean;
@@ -1568,11 +1580,6 @@ declare module 'klasa' {
 	export type ConfigurationUpdateObjectList = {
 		keys: string[];
 		values: any[];
-	};
-
-	type ConfigurationPathResult = {
-		path: string;
-		route: string[];
 	};
 
 	type ConfigurationParseResult = {
@@ -1838,15 +1845,15 @@ declare module 'klasa' {
 	};
 
 	export type KlasaConsoleMessageObject = {
-		background?: KlasaConsoleBackgroundColorTypes;
+		background?: KlasaConsoleColorTypes;
 		style?: KlasaConsoleStyleTypes;
-		text?: KlasaConsoleTextColorTypes;
+		text?: KlasaConsoleColorTypes;
 	};
 
 	export type KlasaConsoleTimeObject = {
-		background?: KlasaConsoleBackgroundColorTypes;
+		background?: KlasaConsoleColorTypes;
 		style?: KlasaConsoleStyleTypes;
-		text?: KlasaConsoleTextColorTypes;
+		text?: KlasaConsoleColorTypes;
 	};
 
 	export type KlasaConsoleColorTypes = 'black'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1674,7 +1674,7 @@ declare module 'klasa' {
 		name?: string;
 		permLevel?: number;
 		quotedStringSupport?: boolean;
-		subcommands: boolean;
+		subcommands?: boolean;
 		requiredConfigs?: string[];
 		runIn?: string[];
 		usage?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -954,6 +954,7 @@ declare module 'klasa' {
 		public promptLimit: number;
 		public promptTime: number;
 		public quotedStringSupport: boolean;
+		public subcommands: boolean;
 		public requiredConfigs: string[];
 		public runIn: string[];
 		public subCategory: string;
@@ -1673,6 +1674,7 @@ declare module 'klasa' {
 		name?: string;
 		permLevel?: number;
 		quotedStringSupport?: boolean;
+		subcommands: boolean;
 		requiredConfigs?: string[];
 		runIn?: string[];
 		usage?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -418,9 +418,9 @@ declare module 'klasa' {
 		public num(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
 		public number(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
 		public float(arg: string, possible: Possible, msg: KlasaMessage): Promise<number>;
-		public reg(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
-		public regex(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
-		public regexp(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
+		public reg(arg: string, possible: Possible, msg: KlasaMessage): Promise<RegExpExecArray>;
+		public regex(arg: string, possible: Possible, msg: KlasaMessage): Promise<RegExpExecArray>;
+		public regexp(arg: string, possible: Possible, msg: KlasaMessage): Promise<RegExpExecArray>;
 		public url(arg: string, possible: Possible, msg: KlasaMessage): Promise<string>;
 		public date(arg: string, possible: Possible, msg: KlasaMessage): Promise<Date>;
 		public duration(arg: string, possible: Possible, msg: KlasaMessage): Promise<Date>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -542,7 +542,7 @@ declare module 'klasa' {
 
 	export class Tag {
 		public constructor(members: string, count: number, required: boolean);
-		public required: boolean;
+		public required: number;
 		public possibles: Possible[];
 		public response: string | ((msg: KlasaMessage) => string);
 
@@ -564,7 +564,7 @@ declare module 'klasa' {
 		public promptLimit: number;
 		public quotedStringSupport: boolean;
 		private _repeat: boolean;
-		private _required: boolean;
+		private _required: number;
 		private _prompted: number;
 		private _currentUsage: Tag;
 


### PR DESCRIPTION
### Description of the PR

- Adds one-off custom resolvers
- Adds one-off custom responses (with i18n)
- Refactors argument resolvers
- Refactors argument validation

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- Added per-command custom resolvers and per-command and per-argument custom responses (with i18n support).

**Changed**:

- Modified the built-in conf command to use `dependant arguments`-like arguments using custom arguments and messages.
- **[BREAKING]** Refactored ArgResolver. Now they take `arg`, `possible` and `msg` as parameters instead of `arg`, `currentUsage`, `possible`, `repeat` and `msg`. Repeating handling is now done in the backends.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
