### PR TITLE
Make the default ready message be correct

### DIFF
--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -21,7 +21,7 @@ exports.DEFAULTS = {
 		language: 'en-US',
 		prefix: '!',
 		preserveConfigs: true,
-		readyMessage: (client) => `Successfully initialized. Ready to serve ${client.guilds.size} guilds.`,
+		readyMessage: (client) => `Successfully initialized. Ready to serve ${client.guilds.size} guild${client.guilds.size === 1 ? '' : 's'}.`,
 		typing: false,
 		customPromptDefaults: {
 			promptTime: 30000,


### PR DESCRIPTION
### Description of the PR
It triggered me, so I made it to where if you have just 1 guild it says one `guild` not `guilds`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
