### PR TITLE
Command string-return sending

### DIFF
--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -26,27 +26,27 @@ module.exports = class extends Command {
 
 	get(msg, [key]) {
 		const { path } = this.client.gateways.guilds.getPath(key, { avoidUnconfigurable: true, piece: true });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_GET', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_GET', path.path, path.resolveString(msg));
 	}
 
 	async set(msg, [key, ...valueToSet]) {
 		const { path } = await msg.guild.configs.update(key, valueToSet.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'add' });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg));
 	}
 
 	async remove(msg, [key, ...valueToRemove]) {
 		const { path } = await msg.guild.configs.update(key, valueToRemove.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'remove' });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg));
 	}
 
 	async reset(msg, [key]) {
 		const { path } = await msg.guild.configs.reset(key, true);
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_RESET', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_RESET', path.path, path.resolveString(msg));
 	}
 
 	list(msg, [key]) {
 		const { path } = this.client.gateways.guilds.getPath(key, { avoidUnconfigurable: true, piece: false });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_SERVER', key ? `: ${key.split('.').map(toTitleCase).join('/')}` : '', codeBlock('asciidoc', path.getList(msg))));
+		return msg.language.get('COMMAND_CONF_SERVER', key ? `: ${key.split('.').map(toTitleCase).join('/')}` : '', codeBlock('asciidoc', path.getList(msg)));
 	}
 
 };

--- a/src/commands/General/Chat Bot Info/info.js
+++ b/src/commands/General/Chat Bot Info/info.js
@@ -11,7 +11,7 @@ module.exports = class extends Command {
 	}
 
 	async run(msg) {
-		return msg.sendMessage(msg.language.get('COMMAND_INFO'));
+		return msg.language.get('COMMAND_INFO');
 	}
 
 };

--- a/src/commands/General/Chat Bot Info/invite.js
+++ b/src/commands/General/Chat Bot Info/invite.js
@@ -13,7 +13,7 @@ module.exports = class extends Command {
 	async run(msg) {
 		if (!this.client.user.bot) return msg.reply(msg.language.get('COMMAND_INVITE_SELFBOT'));
 
-		return msg.sendMessage(msg.language.get('COMMAND_INVITE', this.client));
+		return msg.language.get('COMMAND_INVITE', this.client);
 	}
 
 };

--- a/src/commands/General/Chat Bot Info/ping.js
+++ b/src/commands/General/Chat Bot Info/ping.js
@@ -11,9 +11,7 @@ module.exports = class extends Command {
 
 	async run(msg) {
 		const message = await msg.sendMessage(msg.language.get('COMMAND_PING'));
-		return msg.sendMessage(
-			msg.language.get('COMMAND_PINGPONG', (message.editedTimestamp || message.createdTimestamp) - (msg.editedTimestamp || msg.createdTimestamp), Math.round(this.client.ping))
-		);
+		return msg.language.get('COMMAND_PINGPONG', (message.editedTimestamp || message.createdTimestamp) - (msg.editedTimestamp || msg.createdTimestamp), Math.round(this.client.ping));
 	}
 
 };

--- a/src/commands/General/User Configs/userconf.js
+++ b/src/commands/General/User Configs/userconf.js
@@ -24,27 +24,27 @@ module.exports = class extends Command {
 
 	get(msg, [key]) {
 		const { path } = this.client.gateways.users.getPath(key, { avoidUnconfigurable: true, piece: true });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_GET', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_GET', path.path, path.resolveString(msg));
 	}
 
 	async set(msg, [key, ...valueToSet]) {
 		const { path } = await msg.author.configs.update(key, valueToSet.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'add' });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg));
 	}
 
 	async remove(msg, [key, ...valueToRemove]) {
 		const { path } = await msg.author.configs.update(key, valueToRemove.join(' '), msg.guild, { avoidUnconfigurable: true, action: 'remove' });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_UPDATED', path.path, path.resolveString(msg));
 	}
 
 	async reset(msg, [key]) {
 		const { path } = await msg.author.configs.reset(key, true);
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_RESET', path.path, path.resolveString(msg)));
+		return msg.language.get('COMMAND_CONF_RESET', path.path, path.resolveString(msg));
 	}
 
 	list(msg, [key]) {
 		const { path } = this.client.gateways.users.getPath(key, { avoidUnconfigurable: true, piece: false });
-		return msg.sendMessage(msg.language.get('COMMAND_CONF_USER', key ? `: ${key.split('.').map(toTitleCase).join('/')}` : '', codeBlock('asciidoc', path.getList(msg))));
+		return msg.language.get('COMMAND_CONF_USER', key ? `: ${key.split('.').map(toTitleCase).join('/')}` : '', codeBlock('asciidoc', path.getList(msg)));
 	}
 
 };

--- a/src/finalizers/commandSendReturn.js
+++ b/src/finalizers/commandSendReturn.js
@@ -1,9 +1,14 @@
 const { Finalizer } = require('klasa');
 
-module.exports = class extends Finalizer {
+module.exports = class SendCmdReturn extends Finalizer {
 
 	run(msg, mes) {
-		if (typeof mes === 'string') msg.sendMessage(mes);
+		if (
+			(typeof mes === 'string') ||
+			(Array.isArray(mes) && mes.every(SendCmdReturn.isString))
+		) msg.sendMessage(mes);
 	}
+
+	static isString(value) { return typeof value === 'string'; }
 
 };

--- a/src/finalizers/commandSendReturn.js
+++ b/src/finalizers/commandSendReturn.js
@@ -1,0 +1,9 @@
+const { Finalizer } = require('klasa');
+
+module.exports = class extends Finalizer {
+
+	run(msg, mes) {
+		if (typeof mes === 'string') msg.sendMessage(mes);
+	}
+
+};

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -92,7 +92,8 @@ module.exports = class extends Monitor {
 		timer.stop();
 
 		try {
-			const mes = await commandRun;
+			let mes = await commandRun;
+			if (typeof mes === 'string') mes = msg.sendMessage(mes);
 			await this.client.finalizers.run(msg, mes, timer);
 			return this.client.emit('commandSuccess', msg, msg.command, msg.params, mes);
 		} catch (error) {

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -92,8 +92,7 @@ module.exports = class extends Monitor {
 		timer.stop();
 
 		try {
-			let mes = await commandRun;
-			if (typeof mes === 'string') mes = msg.sendMessage(mes);
+			const mes = await commandRun;
 			await this.client.finalizers.run(msg, mes, timer);
 			return this.client.emit('commandSuccess', msg, msg.command, msg.params, mes);
 		} catch (error) {


### PR DESCRIPTION
### Description of the PR
Most commands send a message at the end. This PR allows you to return a string (or a string[]) from a command to send it to the relevant channel (or edit the previous message in that channel, if `cmdEditing` is turned on). This works with subcommands, as well.

I changed a few core commands to take advantage of this new feature. However, it may be better to leave the core commands using msg.sendMessage explicitly, so they'd still work if the user disables command string-return sending.

Originally, I modified commandHandler.js directly, but then I decided that making it a finalizer might be better. Users can then easily disable this feature by transferring the finalizer and setting `enabled: false`.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- A new finalizer, commandSendReturn.js, which sends the return value from commands, if it's a string or array of strings
- (Possibly) a rewrite of the core commands to take advantage of this feature

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
