### PR TITLE
Fixed typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -811,7 +811,7 @@ declare module 'klasa' {
 		public abstract getKeys(table: string): Promise<string[]>;
 		public abstract get<T>(table: string, entry: string): Promise<T>;
 		public abstract has(table: string, entry: string): Promise<boolean>;
-		public abstract updateValue(table: string, path: string, path: string, newValue: any): Promise<any>;
+		public abstract updateValue(table: string, path: string, newValue: any): Promise<any>;
 		public abstract removeValue(table: string, path: string): Promise<any>;
 		public abstract create(table: string, entry: string, data: any): Promise<any>;
 		public abstract update(table: string, entry: string, data: any): Promise<any>;
@@ -1157,10 +1157,10 @@ declare module 'klasa' {
 		public groupCollapsed(groupTitle?: string, ...optionalParameters: any[]): void;
 		public groupEnd(): void;
 		public info(message?: string, ...optionalParameters: any[]): void;
-		public msIsIndependentlyComposed(element: Element): boolean;
+		public msIsIndependentlyComposed(element: any): boolean;
 		public profile(reportName?: string): void;
 		public profileEnd(): void;
-		public select(element: Element): void;
+		public select(element: any): void;
 		public table(...data: any[]): void;
 		public time(timerName?: string): void;
 		public timeEnd(timerName?: string): void;
@@ -1352,15 +1352,13 @@ declare module 'klasa' {
 
 	export type KlasaProvidersOptions = {
 		default?: string;
-		[key: string]: string | object;
-	};
+	} & object;
 
 	export type KlasaGatewaysOptions = {
 		clientStorage?: GatewayDriverAddOptions;
 		guilds?: GatewayDriverAddOptions;
 		users?: GatewayDriverAddOptions;
-		[key: string]: string | object;
-	};
+	} & object;
 
 	export type ExecOptions = {
 		cwd?: string;


### PR DESCRIPTION
### Description of the PR

As always, TSLint is very often cool with some mistakes and errors, however, the compiler is always stricter than a linter as it goes *deeper* when it comes to the used namespace in a specific version of TypeScript/JavaScript, and sometimes, VSCode suggests interfaces (such as `Element`) that are shown in IntelliSense but that don't exist for the TypeScript compiler.

So I ran it and found these bugs, now fixed. Thanks Pinecode for reaching us with that issue.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed typings.

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
