### PR TITLE
misc: Improve util.toTitleCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#201](https://github.com/dirigeants/klasa/pull/201)] Improve `util.toTitleCase`. (KingDGrizzle)
 - [[#186](https://github.com/dirigeants/klasa/pull/186)] Added a **load** command. (kyranet)
 - [[#176](https://github.com/dirigeants/klasa/pull/176)] Added `categorychannel` type to `ArgResolver`. (kyranet)
 - [[#166](https://github.com/dirigeants/klasa/pull/166)] Added support for TypeScript's `export default` in the loader. (kyranet)

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -374,9 +374,14 @@ Util.sleep = promisify(setTimeout);
 /**
  * Object with certain title case variants for words
  * @since 0.5.0
- * @type {Object<string, string>}
+ * @type {Object}
  * @static
  */
-Util.titleCaseVariants = { textchannel: 'TextChannel' };
+Util.titleCaseVariants = {
+	textchannel: 'TextChannel',
+	voicechannel: 'VoiceChannel',
+	categorychannel: 'CategoryChannel',
+	guildmember: 'GuildMember',
+};
 
 module.exports = Util;

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -62,7 +62,7 @@ class Util {
 	 * @returns {string}
 	 */
 	static toTitleCase(str) {
-		return str.replace(/[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+		return str.replace(/[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g, (txt) => Util.titleCaseVariants[txt] || txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 	}
 
 	/**
@@ -370,5 +370,13 @@ Util.exec = promisify(exec);
  * @static
  */
 Util.sleep = promisify(setTimeout);
+
+/**
+ * Object with certain title case variants for words
+ * @since 0.5.0
+ * @type {Object<string, string>}
+ * @static
+ */
+Util.titleCaseVariants = { textchannel: 'TextChannel' };
 
 module.exports = Util;

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -381,7 +381,7 @@ Util.titleCaseVariants = {
 	textchannel: 'TextChannel',
 	voicechannel: 'VoiceChannel',
 	categorychannel: 'CategoryChannel',
-	guildmember: 'GuildMember',
+	guildmember: 'GuildMember'
 };
 
 module.exports = Util;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1921,11 +1921,11 @@ declare module 'klasa' {
 	};
 
 	export type TitleCaseVariants = {
-		[key: string]: string;
 		textchannel: 'TextChannel';
 		voicechannel: 'VoiceChannel';
 		categorychannel: 'CategoryChannel';
 		guildmember: 'GuildMember';
+		[key: string]: string;
 	};
 
 //#endregion

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1297,6 +1297,8 @@ declare module 'klasa' {
 		public static toTitleCase(str: string): string;
 		public static tryParse(value: string): object;
 		private static initClean(client: KlasaClient): void;
+
+		public static titleCaseVariants: TitleCaseVariants;
 	}
 
 	export { Util as util };
@@ -1916,6 +1918,14 @@ declare module 'klasa' {
 	export type Proxy<T> = {
 		get(): T;
 		set(value: T): void;
+	};
+
+	export type TitleCaseVariants = {
+		[key: string]: string;
+		textchannel: 'TextChannel';
+		voicechannel: 'VoiceChannel';
+		categorychannel: 'CategoryChannel';
+		guildmember: 'GuildMember';
 	};
 
 //#endregion


### PR DESCRIPTION
### Description of the PR
This PR allows defining custom strings for `util.toTitleCase`, for certain strings that would look better as `MyWord` and not `Myword` (for instance `TextChannel` vs `Textchannel`)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Add an object with key-value pairs that define custom returns of toTitleCase
- Allow toTitleCase to replace words based on that object

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
