### PR TITLE
Fixed SettingResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#203](https://github.com/dirigeants/klasa/pull/203)] Fixed `SettingResolver#integer` and `SettingResolver#float` not accepting `0` as input. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `Util.deepClone` not cloning full objects. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `SchemaFolder#_shardSyncSchema` not passing the action as string. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `null` values in *updateMany*'s pattern not updating nested keys plus individual queries. (kyranet)

--- a/src/lib/parsers/SettingResolver.js
+++ b/src/lib/parsers/SettingResolver.js
@@ -148,7 +148,7 @@ class SettingResolver extends Resolver {
 	 */
 	async integer(data, guild, name, { min, max } = {}) {
 		const result = await super.integer(data);
-		if (!result) throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_INT', name);
+		if (result === null) throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_INT', name);
 		if (SettingResolver.maxOrMin(this.client, guild, result, min, max, name)) return result;
 		return null;
 	}
@@ -166,7 +166,7 @@ class SettingResolver extends Resolver {
 	 */
 	async float(data, guild, name, { min, max } = {}) {
 		const result = await super.float(data);
-		if (!result) throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_FLOAT', name);
+		if (result === null) throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_FLOAT', name);
 		if (SettingResolver.maxOrMin(this.client, guild, result, min, max, name)) return result;
 		return null;
 	}


### PR DESCRIPTION
### Description of the PR

SettingResolver wasn't accepting `0` due for it being falsy. This PR fixes that issue.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed `SettingResolver#integer` and `SettingResolver#float` not accepting `0` as input.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
