### PR TITLE
Fixed `Util.getIdentifier` nullifying numbers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#204](https://github.com/dirigeants/klasa/pull/204)] Fixed `Util.getIdentifier` nullifying numbers. (kyranet)
 - [[#203](https://github.com/dirigeants/klasa/pull/203)] Fixed `SettingResolver#integer` and `SettingResolver#float` not accepting `0` as input. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `Util.deepClone` not cloning full objects. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `SchemaFolder#_shardSyncSchema` not passing the action as string. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
-- [[#204](https://github.com/dirigeants/klasa/pull/204)] Fixed `Util.getIdentifier` nullifying numbers. (kyranet)
+- [[#204](https://github.com/dirigeants/klasa/pull/204)] Fixed `Util.getIdentifier` nullifying numbers and booleans. (kyranet)
 - [[#203](https://github.com/dirigeants/klasa/pull/203)] Fixed `SettingResolver#integer` and `SettingResolver#float` not accepting `0` as input. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `Util.deepClone` not cloning full objects. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `SchemaFolder#_shardSyncSchema` not passing the action as string. (kyranet)

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -301,7 +301,7 @@ class Util {
 	 * @returns {string}
 	 */
 	static getIdentifier(value) {
-		if (typeof value === 'string') return value;
+		if (['string', 'number'].includes(typeof value)) return value;
 		if (Util.isObject(value)) {
 			if ('id' in value) return value.id;
 			if ('name' in value) return value.name;

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -298,7 +298,7 @@ class Util {
 	 * Get the identifier of a value.
 	 * @since 0.5.0
 	 * @param {*} value The value to get the identifier from
-	 * @returns {string}
+	 * @returns {?(string|number)}
 	 */
 	static getIdentifier(value) {
 		if (['string', 'number', 'boolean'].includes(typeof value)) return value;

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -298,7 +298,7 @@ class Util {
 	 * Get the identifier of a value.
 	 * @since 0.5.0
 	 * @param {*} value The value to get the identifier from
-	 * @returns {?(string|number)}
+	 * @returns {?(string|number|boolean)}
 	 */
 	static getIdentifier(value) {
 		if (['string', 'number', 'boolean'].includes(typeof value)) return value;

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -301,7 +301,7 @@ class Util {
 	 * @returns {string}
 	 */
 	static getIdentifier(value) {
-		if (['string', 'number'].includes(typeof value)) return value;
+		if (['string', 'number', 'boolean'].includes(typeof value)) return value;
 		if (Util.isObject(value)) {
 			if ('id' in value) return value.id;
 			if ('name' in value) return value.name;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1289,7 +1289,7 @@ declare module 'klasa' {
 		public static getDeepTypeName(input: any): string;
 		public static getDeepTypeProxy(input: Proxy<any>): string;
 		public static getDeepTypeSetOrMap(input: Array<any> | Set<any> | WeakSet<any>, basic?: string): string;
-		public static getIdentifier(value: any): string;
+		public static getIdentifier(value: string | number | null | { id?: string | number, name?: string | number }): string | number | null;
 		public static getTypeName(input: any): string;
 		public static isClass(input: Function): boolean;
 		public static isFunction(input: Function): boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1289,7 +1289,7 @@ declare module 'klasa' {
 		public static getDeepTypeName(input: any): string;
 		public static getDeepTypeProxy(input: Proxy<any>): string;
 		public static getDeepTypeSetOrMap(input: Array<any> | Set<any> | WeakSet<any>, basic?: string): string;
-		public static getIdentifier(value: string | number | null | { id?: string | number, name?: string | number }): string | number | null;
+		public static getIdentifier(value: PrimitiveType | { id?: PrimitiveType, name?: PrimitiveType }): PrimitiveType | null;
 		public static getTypeName(input: any): string;
 		public static isClass(input: Function): boolean;
 		public static isFunction(input: Function): boolean;
@@ -1925,6 +1925,8 @@ declare module 'klasa' {
 		get(): T;
 		set(value: T): void;
 	};
+
+	export type PrimitiveType = string | number | boolean;
 
 	export type TitleCaseVariants = {
 		textchannel: 'TextChannel';


### PR DESCRIPTION
### Description of the PR

`Util.getIdentifier` is used to normalize objects into primitives following our code pattern, however, it was nullifying numbers. This PR fixes this bug.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed `Util.getIdentifier` nullifying numbers.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
