### PR TITLE
Fixed `Configuration#_parseSingle` not returning the modified array but the updated element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#207](https://github.com/dirigeants/klasa/pull/207)] Fixed `Configuration#_parseSingle` not returning the modified array but the updated element. (kyranet)
 - [[#204](https://github.com/dirigeants/klasa/pull/204)] Fixed `Util.getIdentifier` nullifying numbers and booleans. (kyranet)
 - [[#203](https://github.com/dirigeants/klasa/pull/203)] Fixed `SettingResolver#integer` and `SettingResolver#float` not accepting `0` as input. (kyranet)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Fixed `Util.deepClone` not cloning full objects. (kyranet)

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -210,7 +210,7 @@ class Configuration {
 	 * Configuration#update(['prefix', 'language'], ['k!', 'es-ES']);
 	 */
 	async update(key, value, guild, options) {
-		if (typeof options === 'undefined' && isObject(guild)) {
+		if (typeof options === 'undefined' && guild && guild.prototype.name === 'Object') {
 			options = guild;
 			guild = undefined;
 		}

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -423,7 +423,7 @@ class Configuration {
 					array.splice(index, 1);
 				}
 			}
-			list.updated.push({ data: [piece.path, parsedID], piece: piece });
+			list.updated.push({ data: [piece.path, array], piece: piece });
 		} else {
 			const { updated } = this._setValueByPath(piece, parsedID);
 			if (updated) list.updated.push({ data: [piece.path, parsedID], piece: piece });


### PR DESCRIPTION
### Description of the PR

Fixes a critical bug where `update` (using the non-object overload) would write the last updated element to the array instead of the modified array.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed `Configuration#_parseSingle` not returning the modified array but the updated element.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
