### PR TITLE
Fixed overloading for Configuration#update

### DIFF
--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -209,18 +209,25 @@ class Configuration {
 	 * // Updating multiple keys (with arrays):
 	 * Configuration#update(['prefix', 'language'], ['k!', 'es-ES']);
 	 */
-	async update(key, value, guild, options) {
-		if (typeof options === 'undefined' && guild && guild.constructor.name === 'Object') {
-			options = guild;
-			guild = undefined;
+	async update(key, ...args) {
+		if (isObject(key)) {
+			// Overload update(object, GuildResolvable);
+			return this._updateMany(key, args[0] ? this.gateway._resolveGuild(args[0]) : null);
 		}
-		if (guild) guild = this.gateway._resolveGuild(guild);
+
+		// Overload update(string|string[], any|any[], ...any[]);
+		let value = args[0];
 		if (typeof key === 'string') {
 			key = [key];
 			value = [value];
-		} else if (isObject(key)) {
-			return this._updateMany(key, guild);
 		}
+
+		// Overload update(string|string[], any|any[], ConfigurationUpdateOptions);
+		// Overload update(string|string[], any|any[], GuildResolvable, ConfigurationUpdateOptions);
+		// If the third argument is undefined and the second is an object literal, swap the variables.
+		const [guild, options] = typeof args[2] === 'undefined' && args[1] && args[1].constructor.name === 'Object' ?
+			[undefined, args[1]] :
+			[args[1] ? this.gateway._resolveGuild(args[1]) : null, args[2]];
 
 		if (Array.isArray(key)) {
 			if (!Array.isArray(value) || key.length !== value.length) throw new Error(`Expected an array of ${key.length} entries. Got: ${value.length}.`);


### PR DESCRIPTION
### Description of the PR

Unlike the docs were saying, `Configuration#update(object, GuildResolvable);` was unsupported, as the guild was being resolved as the third parameter instead of the second (since this overload has 2 arguments vs 4, and doesn't accept options). So instead, you had to do `Configuration#udpate(object, undefined, GuildResolvable);` to fix the issue.

Thanks @Tylertron1998 for reporting this issue.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed overload `Configuration#update(object, GuildResolvable);`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
