### PR TITLE
Convert object instance to Symbol and add PermissionLevels#remove()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#213](https://github.com/dirigeants/klasa/pull/213)] Added `PermissionLevels#remove()`. (bdistin)
 - [[#210](https://github.com/dirigeants/klasa/pull/210)] Added `PermissionLevelsOptions.fetch` to autofetch uncached members. (bdistin)
 - [[#196](https://github.com/dirigeants/klasa/pull/196)] Added property of `ignoreEdits` in monitors for whether a monitor should run in edited messages. (bdistin)
 - [[#196](https://github.com/dirigeants/klasa/pull/196)] Added property of `catchUp` in `ScheduledTask`, making the scheduled task not execute if the bot was offline when it was supposed to run, if this option is set to false. (bdistin)
@@ -97,6 +98,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#213](https://github.com/dirigeants/klasa/pull/213)] Converted the not-set empty object instance to a Symbol for checking empty entries in PermissionLevels. (bdistin)
 - [[#210](https://github.com/dirigeants/klasa/pull/210)] **[BREAKING]** Changed the level adding to a more consistent format with the rest of the library: replaced `addLevel` to `add` and moved the `break` boolean to `PermissionLevelOptions.break`, which is taken as third parameter. (bdistin)
 - [[#196](https://github.com/dirigeants/klasa/pull/196)] **[BREAKING]** Moved the array for the argument `appliesTo` in extendables to be an option in `ExtendableOptions`. (bdistin)
 - [[#179](https://github.com/dirigeants/klasa/pull/179)] Refactored Configuration's internals for maximum consistency and reduced code duplication. (kyranet)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -451,9 +451,10 @@ declare module 'klasa' {
 		public constructor(levels?: number);
 
 		public add(level: number, check: (client: KlasaClient, msg: KlasaMessage) => boolean, options?: PermissionLevelOptions): this;
-		public set(level: number, obj: PermissionLevelOptions): this;
-		public isValid(): boolean;
 		public debug(): string;
+		public isValid(): boolean;
+		public remove(level: number): this;
+		public set(level: number, obj: PermissionLevelOptions | symbol): this;
 
 		public run(msg: KlasaMessage, min: number): PermissionLevelsData;
 	}


### PR DESCRIPTION
### Description of the PR


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Adds PermissionLevels#remove()
- Converts an instance check of an empty object to a symbol check (safety)
- Brings some old docs style up to date with the new style

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
