### PR TITLE
Settings Queued and Initialized Before Login

### DIFF
--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -10,7 +10,6 @@ module.exports = class extends Event {
 	}
 
 	async run() {
-		await this.client.gateways._ready();
 		if (this.client.user.bot) this.client.application = await this.client.fetchApplication();
 		if (!this.client.options.ownerID) this.client.options.ownerID = this.client.user.bot ? this.client.application.owner.id : this.client.user.id;
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -257,6 +257,11 @@ class KlasaClient extends Discord.Client {
 		 */
 		this.gateways = new GatewayDriver(this);
 
+		// Register default gateways
+		this.gateways.register('guilds', this.gateways.guildsSchema, this.options.gateways.guilds, false);
+		this.gateways.register('users', undefined, this.options.gateways.users, false);
+		this.gateways.register('clientStorage', this.gateways.clientStorageSchema, this.options.gateways.clientStorage, false);
+
 		/**
 		 * The Configuration instance that handles this client's configuration
 		 * @since 0.5.0
@@ -403,13 +408,7 @@ class KlasaClient extends Discord.Client {
 
 		// Providers must be init before configs, and those before all other stores.
 		await this.providers.init();
-
-		// Add the gateways
-		await Promise.all([
-			this.gateways.add('guilds', this.gateways.guildsSchema, this.options.gateways.guilds, false),
-			this.gateways.add('users', undefined, this.options.gateways.users, false),
-			this.gateways.add('clientStorage', this.gateways.clientStorageSchema, this.options.gateways.clientStorage, false)
-		]);
+		await this.gateways._ready();
 
 		// Automatic Prefix editing detection.
 		if (typeof this.options.prefix === 'string' && this.options.prefix !== this.gateways.guilds.schema.prefix.default) {

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -206,37 +206,6 @@ class GatewayDriver {
 	}
 
 	/**
-	 * Registers a new Gateway and inits it.
-	 * @since 0.3.0
-	 * @param {string} name The name for the new instance
-	 * @param {Object} [schema={}] The schema
-	 * @param {GatewayDriverAddOptions} [options={}] A provider to use. If not specified it'll use the one in the client
-	 * @param {boolean} [download=true] Whether this Gateway should download the data from the database at init
-	 * @returns {Gateway}
-	 * @example
-	 * // Add a new SettingGateway instance, called 'channels', that stores
-	 * // disabled commands and a command throttle for custom ratelimits.
-	 * this.client.gateways.add('channels', {
-	 *     disabledCommands: {
-	 *         type: 'Command',
-	 *         default: []
-	 *     },
-	 *     commandThrottle: {
-	 *         type: 'Integer',
-	 *         default: 5,
-	 *         min: 0,
-	 *         max: 60
-	 *     }
-	 * });
-	 */
-	async add(name, schema = {}, options = {}, download = true) {
-		const gateway = this._register(name, schema, options);
-		await gateway.init(download);
-
-		return gateway;
-	}
-
-	/**
 	 * Readies up all Gateways and Configuration instances
 	 * @since 0.5.0
 	 * @returns {Array<Array<external:Collection<string, Configuration>>>}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -601,7 +601,6 @@ declare module 'klasa' {
 		public clientStorage: Gateway;
 
 		public register(name: string, schema?: object, options?: GatewayDriverAddOptions): this;
-		public add(name: string, schema?: object, options?: GatewayDriverAddOptions, download?: boolean): Promise<Gateway>;
 		private _register(name: string, schema?: object, options?: GatewayDriverAddOptions): Gateway;
 		private _ready(): Promise<Array<Array<Collection<string, Configuration>>>>;
 		private _checkProvider(engine: string): string;


### PR DESCRIPTION
### Description of the PR
Should (hopefully) fix the issue of gateways not being ready by the time an extended class needs it to be. Also removes GatewayDriver#add for GatewayDriver#register

Caveat: Users will have to initialize the gateway on their own end if they create custom ones after the client has completed login and been determined to be ready.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Remove GatewayDriver#add
- Change Gateways to be initialized before the login phase.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
