### PR TITLE
fix Rich Menu Example

### DIFF
--- a/guides/Other Subjects/RichMenu.md
+++ b/guides/Other Subjects/RichMenu.md
@@ -20,14 +20,14 @@ module.exports = class extends Command {
 	}
 
 	async run(msg) {
-		const collector = await menu.run(await msg.send('Loading commands...'));
+		const collector = await this.menu.run(await msg.send('Loading commands...'));
 
 		const choice = await collector.selection;
 		if (choice === null) {
 			return collector.message.delete();
 		}
 
-		const command = this.client.commands.get(menu.options[choice].name);
+		const command = this.client.commands.get(this.menu.options[choice].name);
 		const info = new this.client.methods.Embed()
 			.setTitle(`Command \`${msg.guild.configs.prefix}${command.name}\``)
 			.setDescription(typeof command.description === 'function' ? command.description(msg) : command.description)


### PR DESCRIPTION
menu is now not undefined anymore \o/

### Description of the PR
I dont think menu should be `undefined` here since its not available in that scope

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- edited RichMenu.md

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
