### PR TITLE
Change initTable method to pass raw sql Schema to provider

### DIFF
--- a/src/lib/settings/GatewayStorage.js
+++ b/src/lib/settings/GatewayStorage.js
@@ -132,7 +132,7 @@ class GatewayStorage {
 	 */
 	async initTable() {
 		const hasTable = await this.provider.hasTable(this.type);
-		if (!hasTable) await this.provider.createTable(this.type, this.sql ? this.sqlSchema.map(([k, v]) => `${k} ${v}`).join(', ') : undefined);
+		if (!hasTable) await this.provider.createTable(this.type, this.sql ? this.sqlSchema : undefined);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR
This is a breaking change to providers what allows the Postgresql provider to add double quotes around each colum while creation so it will not be lowercase in the end and break internal SG methods. After this PR is merged SQL provider needs to map the iterable of key, value by themself instead just passing a string in the query. 

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Updated initTable method in GateawayStorage

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
