### PR TITLE
Fixed critical bugs in SettingGateway

### DIFF
--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -109,7 +109,7 @@ class Gateway extends GatewayStorage {
 				// Silently create a new entry. The new data does not matter as Configuration default all the keys.
 				this.provider.create(this.type, input)
 					.then(() => {
-						configs.existsInDB = true;
+						configs._existsInDB = true;
 						if (this.client.listenerCount('configCreateEntry')) this.client.emit('configCreateEntry', configs);
 					})
 					.catch(error => this.client.emit('error', error));
@@ -130,10 +130,10 @@ class Gateway extends GatewayStorage {
 		const target = getIdentifier(input);
 		if (!target) throw new TypeError('The selected target could not be resolved to a string.');
 		const cache = this.cache.get(target);
-		if (cache && cache.existsInDB) return cache;
+		if (cache && cache._existsInDB) return cache;
 		await this.provider.create(this.type, target);
 		const configs = cache || new this.Configuration(this, { id: target });
-		configs.existsInDB = true;
+		configs._existsInDB = true;
 		if (!cache) this.cache.set(target, configs);
 		if (this.client.listenerCount('configCreateEntry')) this.client.emit('configCreateEntry', configs);
 		return configs;
@@ -181,11 +181,11 @@ class Gateway extends GatewayStorage {
 			for (const entry of entries) {
 				const cache = this.cache.get(entry);
 				if (cache) {
-					if (!cache.existsInDB) cache.existsInDB = true;
+					if (!cache._existsInDB) cache._existsInDB = true;
 					cache._patch(entry);
 				} else {
 					const newEntry = new this.Configuration(this, entry);
-					newEntry.existsInDB = true;
+					newEntry._existsInDB = true;
 					this.cache.set(entry.id, newEntry);
 				}
 			}


### PR DESCRIPTION
### Description of the PR

[Configuration#_existsInDB](https://klasa.js.org/#/docs/main/master/class/Configuration?scrollTo=_existsInDB) (private property) used to be called `Configuration#existsInDB`, but an underscore was added to specify it's private (as it's only used by Configuration and the end-user does not need to know that in the majority of cases).

However, the patch was not applied correctly. This PR fixes this issue.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed a critical bug with sync status in Configuration instances.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
