### PR TITLE
Fix _parseValue to correctly make usage of makeStringLiteral function

### DIFF
--- a/src/lib/settings/QueryBuilder.js
+++ b/src/lib/settings/QueryBuilder.js
@@ -98,12 +98,13 @@ class QueryBuilder {
 	 * Parse a value.
 	 * @since 0.5.0
 	 * @param {*} value The value to parse
+	 * @param {*} type The type of the Query
 	 * @returns {string}
 	 * @private
 	 */
-	_parseValue(value) { // eslint-disable-line complexity
+	_parseValue(value, type) { // eslint-disable-line complexity
 		const type = typeof value;
-		switch (this.type) {
+		switch (type) {
 			case 'BOOLEAN':
 				if (type === 'boolean') return this.types.BOOLEAN.default[Number(value)];
 				if (type === 'string') return this.types.BOOLEAN.default[Number(value === 'true')];

--- a/src/lib/settings/QueryBuilder.js
+++ b/src/lib/settings/QueryBuilder.js
@@ -103,18 +103,18 @@ class QueryBuilder {
 	 * @private
 	 */
 	_parseValue(value, type) { // eslint-disable-line complexity
-		const type = typeof value;
+		const valueType = typeof value;
 		switch (type) {
 			case 'BOOLEAN':
-				if (type === 'boolean') return this.types.BOOLEAN.default[Number(value)];
-				if (type === 'string') return this.types.BOOLEAN.default[Number(value === 'true')];
-				if (type === 'number') return this.types.BOOLEAN.default[Number(value !== 0)];
+				if (valueType === 'boolean') return this.types.BOOLEAN.default[Number(value)];
+				if (valueType === 'string') return this.types.BOOLEAN.default[Number(value === 'true')];
+				if (valueType === 'number') return this.types.BOOLEAN.default[Number(value !== 0)];
 				return this.types.BOOLEAN.default[0];
 			case 'SMALLINT':
 			case 'INTEGER':
 			case 'BIGINT':
-				if (type === 'number') return Number.isInteger(value) ? value : Math.floor(value);
-				if (type === 'string') return Number(value) || 0;
+				if (valueType === 'number') return Number.isInteger(value) ? value : Math.floor(value);
+				if (valueType === 'string') return Number(value) || 0;
 				return 0;
 			case 'REAL':
 			case 'FLOAT':
@@ -123,11 +123,11 @@ class QueryBuilder {
 				return this.makeStringLiteral(isObject(value) ? JSON.stringify(value) : '{}');
 			case 'TEXT':
 			case 'VARCHAR':
-				if (type === 'string') return this.makeStringLiteral(value);
-				if (type === 'object') return this.makeStringLiteral(JSON.stringify(value));
+				if (valueType === 'string') return this.makeStringLiteral(value);
+				if (valueType === 'object') return this.makeStringLiteral(JSON.stringify(value));
 				return this.makeStringLiteral(String(value));
 			default: {
-				const customResolver = this.customResolvers.get(this.type);
+				const customResolver = this.customResolvers.get(type);
 				return customResolver ? customResolver(this, value) : value;
 			}
 		}

--- a/src/lib/settings/QueryBuilder.js
+++ b/src/lib/settings/QueryBuilder.js
@@ -98,8 +98,8 @@ class QueryBuilder {
 	 * Parse a value.
 	 * @since 0.5.0
 	 * @param {*} value The value to parse
-	 * @param {*} type The type of the Query
-	 * @returns {string}
+	 * @param {string} type The type of the Query
+	 * @returns {*}
 	 * @private
 	 */
 	_parseValue(value, type) { // eslint-disable-line complexity

--- a/src/lib/settings/QueryType.js
+++ b/src/lib/settings/QueryType.js
@@ -135,7 +135,7 @@ class QueryType {
 			(this.size !== null ? `(${this.size}) ` : ' ') +
 			(this.notNull ? 'NOT NULL ' : '') +
 			(this.unique ? 'UNIQUE ' : '') +
-			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue.bind(this)(this.default)}` : '');
+			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue(this.default, this.type)}` : '');
 	}
 
 }

--- a/src/lib/settings/QueryType.js
+++ b/src/lib/settings/QueryType.js
@@ -135,7 +135,7 @@ class QueryType {
 			(this.size !== null ? `(${this.size}) ` : ' ') +
 			(this.notNull ? 'NOT NULL ' : '') +
 			(this.unique ? 'UNIQUE ' : '') +
-			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue(this.default).bind(this)}` : '');
+			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue.bind(this)(this.default)}` : '');
 	}
 
 }

--- a/src/lib/settings/QueryType.js
+++ b/src/lib/settings/QueryType.js
@@ -135,7 +135,7 @@ class QueryType {
 			(this.size !== null ? `(${this.size}) ` : ' ') +
 			(this.notNull ? 'NOT NULL ' : '') +
 			(this.unique ? 'UNIQUE ' : '') +
-			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue(this.default)}` : '');
+			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue(this.default).bind(this)}` : '');
 	}
 
 }

--- a/src/lib/settings/QueryType.js
+++ b/src/lib/settings/QueryType.js
@@ -135,7 +135,7 @@ class QueryType {
 			(this.size !== null ? `(${this.size}) ` : ' ') +
 			(this.notNull ? 'NOT NULL ' : '') +
 			(this.unique ? 'UNIQUE ' : '') +
-			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue(this.default, this.type)}` : '');
+			(this.default !== null && !this.notNull ? `DEFAULT ${this.queryBuilder._parseValue(this.default, this.type.name)}` : '');
 	}
 
 }


### PR DESCRIPTION
### Description of the PR
This PR fixes the usage of the makeStringLiteral function you can pass to the QueryBuilder constructor

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- edited _parseValue method on QueryBuilder.js
- edit QueryType.js to pass value pass type

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
