### PR TITLE
fix ._save still using createEntry instead get(id, true)

### DIFF
--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -349,7 +349,7 @@ class Configuration {
 	async _save({ updated }) {
 		if (!updated.length) return;
 		if (!this._existsInDB) {
-			await this.gateway.createEntry(this.id);
+			await this.gateway.get(this.id, true);
 			if (this.client.listenerCount('configCreateEntry')) this.client.emit('configCreateEntry', this);
 		}
 		const oldClone = this.client.listenerCount('configUpdateEntry') ? this.clone() : null;


### PR DESCRIPTION
### Description of the PR
fixes a small bug

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- fixed Configuration method _save still using createEntry instead get(id, true)

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
