### PR TITLE
[WIP] [RFC] SGv2.1.1

### DIFF
--- a/src/events/guildDelete.js
+++ b/src/events/guildDelete.js
@@ -3,7 +3,7 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(guild) {
-		if (guild.available && !this.client.configs.preserveConfigs) this.client.gateways.guilds.deleteEntry(guild.id).catch(() => null);
+		if (guild.available && !this.client.configs.preserveConfigs) guild.configs.destroy().catch(() => null);
 	}
 
 };

--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -14,7 +14,7 @@ module.exports = class extends Event {
 		if (!this.client.options.ownerID) this.client.options.ownerID = this.client.user.bot ? this.client.application.owner.id : this.client.user.id;
 
 		// Client-wide settings
-		this.client.configs = this.client.gateways.clientStorage.cache.get(this.client.user.id) || this.client.gateways.clientStorage.insertEntry(this.client.user.id);
+		this.client.configs = this.client.gateways.clientStorage.get(this.client.user.id, true);
 		await this.client.configs.sync();
 
 		// Init all the pieces

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -72,9 +72,9 @@ class KlasaClient extends Discord.Client {
 
 	/**
 	 * @typedef {Object} KlasaGatewaysOptions
-	 * @property {GatewayDriverAddOptions} [clientStorage] The options for clientStorage's gateway
-	 * @property {GatewayDriverAddOptions} [guilds] The options for guilds' gateway
-	 * @property {GatewayDriverAddOptions} [users] The options for users' gateway
+	 * @property {GatewayDriverRegisterOptions} [clientStorage] The options for clientStorage's gateway
+	 * @property {GatewayDriverRegisterOptions} [guilds] The options for guilds' gateway
+	 * @property {GatewayDriverRegisterOptions} [users] The options for users' gateway
 	 */
 
 	/**
@@ -258,9 +258,9 @@ class KlasaClient extends Discord.Client {
 		this.gateways = new GatewayDriver(this);
 
 		// Register default gateways
-		this.gateways.register('guilds', this.gateways.guildsSchema, this.options.gateways.guilds, false);
-		this.gateways.register('users', undefined, this.options.gateways.users, false);
-		this.gateways.register('clientStorage', this.gateways.clientStorageSchema, this.options.gateways.clientStorage, false);
+		this.gateways.register('guilds', this.gateways.guildsSchema, { download: false, ...this.options.gateways.guilds });
+		this.gateways.register('users', {}, { download: false, ...this.options.gateways.users });
+		this.gateways.register('clientStorage', this.gateways.clientStorageSchema, { download: false, ...this.options.gateways.clientStorage });
 
 		/**
 		 * The Configuration instance that handles this client's configuration
@@ -603,15 +603,14 @@ KlasaClient.defaultPermissionLevels = new PermissionLevels()
  */
 
 /**
- * Emitted when {@link Gateway#deleteEntry} is run.
+ * Emitted when {@link Configuration#destroy} is run.
  * @event KlasaClient#configDeleteEntry
  * @since 0.5.0
  * @param {Configuration} entry The entry which got deleted
  */
 
 /**
- * Emitted when {@link Gateway#createEntry} is run, when {@link Gateway#getEntry}
- * with the create parameter set to true creates the entry, or an entry with no persistence gets updated.
+ * Emitted when a new entry in the database has been created upon update.
  * @event KlasaClient#configCreateEntry
  * @since 0.5.0
  * @param {Configuration} entry The entry which got created

--- a/src/lib/extensions/KlasaGuild.js
+++ b/src/lib/extensions/KlasaGuild.js
@@ -18,7 +18,7 @@ module.exports = Structures.extend('Guild', Guild => {
 			 * @since 0.5.0
 			 * @type {Configuration}
 			 */
-			this.configs = this.client.gateways.guilds.cache.get(this.id) || this.client.gateways.guilds.insertEntry(this.id);
+			this.configs = this.client.gateways.guilds.get(this.id, true);
 		}
 
 		/**

--- a/src/lib/extensions/KlasaUser.js
+++ b/src/lib/extensions/KlasaUser.js
@@ -18,7 +18,7 @@ module.exports = Structures.extend('User', User => {
 			 * @since 0.5.0
 			 * @type {Configuration}
 			 */
-			this.configs = this.client.gateways.users.cache.get(this.id) || this.client.gateways.users.insertEntry(this.id);
+			this.configs = this.client.gateways.users.get(this.id, true);
 		}
 
 	}

--- a/src/lib/parsers/SettingResolver.js
+++ b/src/lib/parsers/SettingResolver.js
@@ -12,11 +12,11 @@ class SettingResolver extends Resolver {
 	 * @param {*} data The data to resolve
 	 * @param {KlasaGuild} guild The guild to resolve for
 	 * @param {string} name The name of the key being resolved
-	 * @returns {KlasaUser}
+	 * @returns {string}
 	 */
 	async user(data, guild, name) {
 		const result = await super.user(data);
-		if (result) return result;
+		if (result) return result.id;
 		throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_USER', name);
 	}
 
@@ -26,11 +26,11 @@ class SettingResolver extends Resolver {
 	 * @param {*} data The data to resolve
 	 * @param {KlasaGuild} guild The guild to resolve for
 	 * @param {string} name The name of the key being resolved
-	 * @returns {external:Channel}
+	 * @returns {string}
 	 */
 	async channel(data, guild, name) {
 		const result = await super.channel(data);
-		if (result) return result;
+		if (result) return result.id;
 		throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_CHANNEL', name);
 	}
 
@@ -40,11 +40,11 @@ class SettingResolver extends Resolver {
 	 * @param {*} data The data to resolve
 	 * @param {KlasaGuild} guild The guild to resolve for
 	 * @param {string} name The name of the key being resolved
-	 * @returns {external:TextChannel}
+	 * @returns {string}
 	 */
 	async textchannel(data, guild, name) {
 		const result = await super.channel(data);
-		if (result && result.type === 'text') return result;
+		if (result && result.type === 'text') return result.id;
 		throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_CHANNEL', name);
 	}
 
@@ -54,11 +54,11 @@ class SettingResolver extends Resolver {
 	 * @param {*} data The data to resolve
 	 * @param {KlasaGuild} guild The guild to resolve for
 	 * @param {string} name The name of the key being resolved
-	 * @returns {external:VoiceChannel}
+	 * @returns {string}
 	 */
 	async voicechannel(data, guild, name) {
 		const result = await super.channel(data);
-		if (result && result.type === 'voice') return result;
+		if (result && result.type === 'voice') return result.id;
 		throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_CHANNEL', name);
 	}
 
@@ -68,11 +68,11 @@ class SettingResolver extends Resolver {
 	 * @param {*} data The data to resolve
 	 * @param {KlasaGuild} guild The guild to resolve for
 	 * @param {string} name The name of the key being resolved
-	 * @returns {external:CategoryChannel}
+	 * @returns {string}
 	 */
 	async categorychannel(data, guild, name) {
 		const result = await super.channel(data);
-		if (result && result.type === 'category') return result;
+		if (result && result.type === 'category') return result.id;
 		throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_CHANNEL', name);
 	}
 
@@ -82,11 +82,11 @@ class SettingResolver extends Resolver {
 	 * @param {*} data The data to resolve
 	 * @param {KlasaGuild} guild The guild to resolve for
 	 * @param {string} name The name of the key being resolved
-	 * @returns {KlasaGuild}
+	 * @returns {string}
 	 */
 	async guild(data, guild, name) {
 		const result = await super.guild(data);
-		if (result) return result;
+		if (result) return result.id;
 		throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_GUILD', name);
 	}
 
@@ -96,11 +96,11 @@ class SettingResolver extends Resolver {
 	 * @param {*} data The data to resolve
 	 * @param {KlasaGuild} guild The guild to resolve for
 	 * @param {string} name The name of the key being resolved
-	 * @returns {external:Role}
+	 * @returns {string}
 	 */
 	async role(data, guild, name) {
 		const result = await super.role(data, guild) || (guild ? guild.roles.find('name', data) : null);
-		if (result) return result;
+		if (result) return result.id;
 		throw (guild ? guild.language : this.client.languages.default).get('RESOLVER_INVALID_ROLE', name);
 	}
 

--- a/src/lib/schedule/Schedule.js
+++ b/src/lib/schedule/Schedule.js
@@ -71,8 +71,7 @@ class Schedule {
 				min: null,
 				max: null,
 				array: true,
-				configurable: false,
-				sql: 'TEXT'
+				configurable: false
 			});
 		}
 

--- a/src/lib/schedule/ScheduledTask.js
+++ b/src/lib/schedule/ScheduledTask.js
@@ -1,4 +1,5 @@
 const Cron = require('../util/Cron');
+const { isObject } = require('../util/util');
 
 /**
  * The structure for future tasks to be run
@@ -90,7 +91,7 @@ class ScheduledTask {
 		 * @since 0.5.0
 		 * @type {*}
 		 */
-		this.data = 'data' in options ? options.data : null;
+		this.data = 'data' in options && isObject(options.data) ? options.data : {};
 
 		this.constructor._validate(this);
 	}
@@ -125,7 +126,7 @@ class ScheduledTask {
 		if (!this.task || !this.task.enabled) return this;
 		try {
 			this.task.disable();
-			await this.task.run({ id: this.id, ...(this.data || {}) });
+			await this.task.run({ id: this.id, ...this.data });
 			this.task.enable();
 		} catch (err) {
 			this.client.emit('taskError', this, this.task, err);

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -1,4 +1,4 @@
-const { isObject, makeObject, deepClone, tryParse, getIdentifier, toTitleCase, arraysEqual, mergeObjects, getDeepTypeName } = require('../util/util');
+const { isObject, makeObject, deepClone, tryParse, toTitleCase, arraysEqual, mergeObjects, getDeepTypeName, objectToTuples } = require('../util/util');
 const SchemaFolder = require('./SchemaFolder');
 const SchemaPiece = require('./SchemaPiece');
 
@@ -109,14 +109,8 @@ class Configuration {
 	 * @returns {this}
 	 */
 	async sync() {
-		this._syncStatus = this.gateway.provider.get(this.gateway.type, this.id);
-		this._syncStatus.then(() => { this._syncStatus = null; });
-		const data = await this._syncStatus.catch(() => null);
-		if (data) {
-			if (!this._existsInDB) this._existsInDB = true;
-			this._patch(data);
-		}
-		return this;
+		if (!this._syncStatus) this._syncStatus = this._sync();
+		return this._syncStatus;
 	}
 
 	/**
@@ -140,6 +134,7 @@ class Configuration {
 	 * @param {KlasaGuild} [guild] A KlasaGuild instance for multilingual support
 	 * @param {boolean} [avoidUnconfigurable] Whether the Gateway should avoid configuring the selected key
 	 * @returns {ConfigurationUpdateResult}
+	 * @example
 	 * // Reset all keys for this instance
 	 * Configuration#reset();
 	 *
@@ -173,8 +168,7 @@ class Configuration {
 					continue;
 				}
 				const newValue = value === null ? deepClone(path.piece.default) : value;
-				const { updated } = this._setValueByPath(path.piece, newValue);
-				if (updated) result.updated.push({ data: [path.piece.path, newValue], piece: path.piece });
+				if (this._setValueByPath(path.piece, newValue).updated) result.updated.push({ data: [path.piece.path, newValue], piece: path.piece });
 			}
 			if (result.updated.length) await this._save(result);
 			return result;
@@ -185,9 +179,9 @@ class Configuration {
 	/**
 	 * Update a value from an entry.
 	 * @since 0.5.0
-	 * @param {(string|Object)} key The key to modify
-	 * @param {*} [value] The value to parse and save
-	 * @param {GuildResolvable} [guild] A guild resolvable
+	 * @param {(string|Object)} keys The key to modify
+	 * @param {*} [values] The value to parse and save
+	 * @param {GuildResolvable} [guild=null] A guild resolvable
 	 * @param {ConfigurationUpdateOptions} [options={}] The options for the update
 	 * @returns {ConfigurationUpdateResult}
 	 * @example
@@ -209,40 +203,35 @@ class Configuration {
 	 * // Updating multiple keys (with arrays):
 	 * Configuration#update(['prefix', 'language'], ['k!', 'es-ES']);
 	 */
-	async update(key, ...args) {
-		if (isObject(key)) {
-			// Overload update(object, GuildResolvable);
-			return this._updateMany(key, args[0] ? this.gateway._resolveGuild(args[0]) : null);
-		}
-
-		// Overload update(string|string[], any|any[], ...any[]);
-		let value = args[0];
-		if (typeof key === 'string') {
-			key = [key];
-			value = [value];
+	update(keys, values, guild, options) {
+		// Overload update(object, GuildResolvable);
+		if (isObject(keys)) {
+			[keys, values] = objectToTuples(keys);
+			[guild, options] = [values, guild];
+		} else if (typeof keys === 'string') {
+			// Overload update(string|string[], any|any[], ...any[]);
+			keys = [keys];
+			values = [values];
+		} else if (!Array.isArray(keys)) {
+			throw new TypeError(`Invalid value. Expected object, string or Array<string>. Got: ${getDeepTypeName(keys)}`);
 		}
 
 		// Overload update(string|string[], any|any[], ConfigurationUpdateOptions);
 		// Overload update(string|string[], any|any[], GuildResolvable, ConfigurationUpdateOptions);
 		// If the third argument is undefined and the second is an object literal, swap the variables.
-		const [guild, options] = typeof args[2] === 'undefined' && args[1] && args[1].constructor.name === 'Object' ?
-			[undefined, args[1]] :
-			[args[1] ? this.gateway._resolveGuild(args[1]) : null, args[2]];
+		if (typeof options === 'undefined' && guild && guild.constructor.name === 'Object') [guild, options] = [null, guild];
+		if (guild) guild = this.gateway._resolveGuild(guild);
+		if (!options) options = {};
 
-		if (Array.isArray(key)) {
-			if (!Array.isArray(value) || key.length !== value.length) throw new Error(`Expected an array of ${key.length} entries. Got: ${value.length}.`);
+		// Do a length check on both keys and values before trying to update
+		if (keys.length !== values.length) throw new Error(`Expected an array of ${keys.length} entries. Got: ${values.length}.`);
 
-			// Create the result with all the promises to resolve
-			const result = { errors: [], updated: [] };
-			const mps = new Array(key.length);
-			for (let i = 0; i < key.length; i++) mps[i] = this._parseSingle(key[i], value[i], guild, options, result);
-			await Promise.all(mps);
-
-			// If at least one key updated, save it to the database
-			if (result.updated.length) await this._save(result);
-			return result;
-		}
-		throw new TypeError(`Invalid value. Expected object, string or Array<string>. Got: ${getDeepTypeName(key)}`);
+		const updateOptions = {
+			avoidUnconfigurable: 'avoidUnconfigurable' in options ? options.avoidUnconfigurable : false,
+			action: 'action' in options ? options.action : 'auto',
+			arrayPosition: 'arrayPosition' in options ? options.arrayPosition : null
+		};
+		return this._update(keys, values, guild, updateOptions);
 	}
 
 	/**
@@ -321,6 +310,22 @@ class Configuration {
 	}
 
 	/**
+	 * Sync the entry with the database
+	 * @since 0.5.0
+	 * @returns {this}
+	 */
+	async _sync() {
+		const data = await this.gateway.provider.get(this.gateway.type, this.id);
+		if (data) {
+			if (!this._existsInDB) this._existsInDB = true;
+			this._patch(data);
+		}
+
+		this._syncStatus = null;
+		return this;
+	}
+
+	/**
 	 * Get a value from the cache.
 	 * @since 0.5.0
 	 * @param {(string|string[])} route The route to get
@@ -338,6 +343,67 @@ class Configuration {
 		}
 
 		return piece && refSchema.type !== 'Folder' ? refCache : undefined;
+	}
+
+	/**
+	 * Update this Configuration instance
+	 * @since 0.5.0
+	 * @param {string[]} keys The keys to update
+	 * @param {Array<*>} values The values to update
+	 * @param {?KlasaGuild} guild The KlasaGuild for context in SchemaPiece#parse
+	 * @param {ConfigurationUpdateOptions} options The parse options
+	 * @returns {ConfigurationUpdateResult}
+	 * @private
+	 */
+	async _update(keys, values, guild, options) {
+		const result = { errors: [], updated: [] };
+		const pathOptions = { piece: true, avoidUnconfigurable: options.avoidUnconfigurable, errors: false };
+		const promises = [];
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i], value = values[i];
+			const path = this.gateway.getPath(key, pathOptions);
+			if (!path) {
+				result.errors.push(guild && guild.language ?
+					guild.language.get('COMMAND_CONF_GET_NOEXT', key) :
+					`The path ${key} does not exist in the current schema, or does not correspond to a piece.`);
+				continue;
+			}
+			if (!path.piece.array && Array.isArray(value)) {
+				result.errors.push(guild && guild.language ?
+					guild.language.get('SETTING_GATEWAY_KEY_NOT_ARRAY', key) :
+					`The path ${key} does not store multiple values.`);
+				continue;
+			}
+			promises.push(this._parse(value, guild, options, result, path));
+		}
+		if (promises.length) {
+			await Promise.all(promises);
+			await this._save(result);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Parse a value
+	 * @since 0.5.0
+	 * @param {*} value The value to parse
+	 * @param {?KlasaGuild} guild The KlasaGuild for context in SchemaPiece#parse
+	 * @param {ConfigurationUpdateOptions} options The parse options
+	 * @param {ConfigurationUpdateResult} result The updated result
+	 * @param {GatewayGetPathResult} path The path result
+	 * @private
+	 */
+	async _parse(value, guild, options, result, { piece, route }) {
+		const parsedID = value !== null ?
+			await (Array.isArray(value) ? this._parseAll(piece, value, guild, result.errors) : piece.parse(value, guild)) :
+			deepClone(piece.default);
+
+		if (piece.array && !Array.isArray(value)) {
+			this._parseArraySingle(piece, route, parsedID, options, result);
+		} else if (this._setValueByPath(piece, parsedID).updated) {
+			result.updated.push({ data: [piece.path, parsedID], piece: piece });
+		}
 	}
 
 	/**
@@ -368,113 +434,52 @@ class Configuration {
 	}
 
 	/**
-	 * Update multiple keys given a JSON object.
+	 * Parse a single value for an array
 	 * @since 0.5.0
-	 * @param {Object} object A JSON object to iterate and parse
-	 * @param {GuildResolvable} [guild] A guild resolvable
-	 * @returns {ConfigurationUpdateResult}
+	 * @param {SchemaPiece} piece The SchemaPiece pointer that parses this entry
+	 * @param {string[]} route The path bits for property accessment
+	 * @param {*} parsedID The parsed value
+	 * @param {ConfigurationUpdateOptions} options The parse options
+	 * @param {ConfigurationUpdateResult} result The updated result
 	 * @private
 	 */
-	async _updateMany(object, guild) {
-		const result = { errors: [], updated: [], promises: [] };
-
-		this._parseUpdateMany(this, object, this.gateway.schema, guild, result);
-		await Promise.all(result.promises);
-		delete result.promises;
-
-		// If at least one key updated, save it to the database
-		if (result.updated.length) await this._save(result);
-		return result;
+	_parseArraySingle(piece, route, parsedID, { action, arrayPosition }, { updated, errors }) {
+		const lengthErrors = errors.length;
+		const array = this._get(route, true);
+		if (typeof arrayPosition === 'number') {
+			if (arrayPosition >= array.length) throw new Error(`The option arrayPosition should be a number between 0 and ${array.length - 1}`);
+			array[arrayPosition] = parsedID;
+		} else {
+			if (action === 'auto') action = array.includes(parsedID) ? 'remove' : 'add';
+			if (action === 'add') {
+				if (array.includes(parsedID)) errors.push(new Error(`The value ${parsedID} for the key ${piece.path} already exists.`));
+				else array.push(parsedID);
+			} else {
+				const index = array.indexOf(parsedID);
+				if (index === -1) errors.push(new Error(`The value ${parsedID} for the key ${piece.path} does not exist.`));
+				else array.splice(index, 1);
+			}
+		}
+		if (errors.length === lengthErrors) updated.push({ data: [piece.path, array], piece: piece });
 	}
 
 	/**
-	 * Parse a single value
+	 * Parse all values from an array
 	 * @since 0.5.0
-	 * @param {string} key The key to update
-	 * @param {*} value The new value for the key
-	 * @param {?KlasaGuild} guild The Guild instance for key resolving
-	 * @param {ConfigurationUpdateOptions} options The options for parsing this value
-	 * @param {ConfigurationUpdateResult} list The list to update
+	 * @param {SchemaPiece} piece The SchemaPiece pointer that parses this entry
+	 * @param {Array<*>} values The values to parse
+	 * @param {?KlasaGuild} guild The KlasaGuild for context in SchemaPiece#parse
+	 * @param {Error[]} errors The Errors array
+	 * @returns {Array<number|string>}
 	 * @private
 	 */
-	async _parseSingle(key, value, guild, { avoidUnconfigurable = false, action = 'auto', arrayPosition = null } = {}, list) {
-		const path = this.gateway.getPath(key, { piece: true, avoidUnconfigurable, errors: false });
-		if (!path) {
-			list.errors.push(guild && guild.language ?
-				guild.language.get('COMMAND_CONF_GET_NOEXT', key) :
-				`The path ${key} does not exist in the current schema, or does not correspond to a piece.`);
-			return;
-		}
-		const { piece, route } = path;
-		let parsed, parsedID;
-		if (value === null) {
-			parsed = parsedID = deepClone(piece.default);
-		} else {
-			parsed = await piece.parse(value, guild);
-			parsedID = piece.type === 'any' ? parsed : getIdentifier(parsed);
-		}
+	async _parseAll(piece, values, guild, errors) {
+		const output = [];
+		await Promise.all(values.map(value => piece.parse(value, guild)
+			.then(parsed => output.push(parsed))
+			.catch(error => errors.push(error))));
 
-		if (piece.array) {
-			const array = this._get(route, true);
-			if (typeof arrayPosition === 'number') {
-				if (arrayPosition >= array.length) throw new Error(`The option arrayPosition should be a number between 0 and ${array.length - 1}`);
-				array[arrayPosition] = parsedID;
-			} else {
-				if (action === 'auto') action = array.includes(parsedID) ? 'remove' : 'add';
-				if (action === 'add') {
-					if (array.includes(parsedID)) throw `The value ${parsedID} for the key ${piece.path} already exists.`;
-					array.push(parsedID);
-				} else {
-					const index = array.indexOf(parsedID);
-					if (index === -1) throw `The value ${parsedID} for the key ${piece.path} does not exist.`;
-					array.splice(index, 1);
-				}
-			}
-			list.updated.push({ data: [piece.path, array], piece: piece });
-		} else {
-			const { updated } = this._setValueByPath(piece, parsedID);
-			if (updated) list.updated.push({ data: [piece.path, parsedID], piece: piece });
-		}
-	}
-
-	/**
-	 * Update many keys in a single query.
-	 * @since 0.5.0
-	 * @param {Object} cache The key target
-	 * @param {Object} object The key to edit
-	 * @param {SchemaFolder} schema The new value
-	 * @param {GuildResolvable} guild The guild to take
-	 * @param {ConfigurationUpdateResult} result The options
-	 * @private
-	 */
-	_parseUpdateMany(cache, object, schema, guild, result) {
-		for (const key of Object.keys(object)) {
-			if (!schema.has(key)) continue;
-			if (schema[key].type === 'Folder') {
-				// Check if it's a folder, and recursively iterate over it
-				this._parseUpdateMany(cache[key], object[key], schema[key], guild, result);
-			} else if (object[key] === null) {
-				// If the value is null, reset it
-				const defaultValue = deepClone(schema[key].default);
-				if (this._setValueByPath(schema[key], defaultValue).updated) {
-					result.updated.push({ data: [schema[key].path, defaultValue], piece: schema[key] });
-				}
-				// Throw an error if it's not array (nor type any) but an array was given
-			} else if (schema[key].array !== Array.isArray(object[key])) {
-				result.errors.push(new TypeError(schema[key].array ?
-					`${schema[key].path} expects an array as value.` :
-					`${schema[key].path} does not expect an array as value.`));
-			} else {
-				const getID = schema[key].type !== 'any' ? getIdentifier : entry => entry;
-				result.promises.push((schema[key].array ?
-					Promise.all(object[key].map(entry => schema[key].parse(entry, guild).then(getID))) :
-					schema[key].parse(object[key], guild)).then(parsed => {
-					if (this._setValueByPath(schema[key], parsed).updated) {
-						result.updated.push({ data: [schema[key].path, parsed], piece: schema[key] });
-					}
-				}).catch(error => { result.errors.push(error); }));
-			}
-		}
+		return output;
 	}
 
 	/**
@@ -588,10 +593,10 @@ class Configuration {
 	 * @private
 	 */
 	static _patch(inst, data, schema) {
-		for (const key of schema.keys()) {
+		for (const [key, piece] of schema) {
 			if (typeof data[key] === 'undefined') continue;
-			inst[key] = schema[key].type === 'Folder' ?
-				Configuration._patch(inst[key], data[key], schema[key]) :
+			inst[key] = piece.type === 'Folder' ?
+				Configuration._patch(inst[key], data[key], piece) :
 				data[key];
 		}
 

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -415,7 +415,7 @@ class Configuration {
 	async _save({ updated }) {
 		if (!updated.length) return;
 		if (!this._existsInDB) {
-			await this.gateway.createEntry(this.id);
+			await this.gateway.provider.create(this.gateway.type, this.id);
 			if (this.client.listenerCount('configCreateEntry')) this.client.emit('configCreateEntry', this);
 		}
 		const oldClone = this.client.listenerCount('configUpdateEntry') ? this.clone() : null;

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -594,10 +594,9 @@ class Configuration {
 	 */
 	static _patch(inst, data, schema) {
 		for (const [key, piece] of schema) {
-			if (typeof data[key] === 'undefined') continue;
-			inst[key] = piece.type === 'Folder' ?
-				Configuration._patch(inst[key], data[key], piece) :
-				data[key];
+			const value = data[key];
+			if (value === undefined || value === null) continue;
+			inst[key] = piece.type === 'Folder' ? Configuration._patch(inst[key], value, piece) : value;
 		}
 
 		return inst;

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -512,12 +512,10 @@ class Configuration {
 	_patch(data) {
 		if (this.gateway.sql) data = this.gateway.parseEntry(data);
 		const { schema } = this.gateway;
-		for (let i = 0; i < schema.keyArray.length; i++) {
-			const key = schema.keyArray[i];
-			if (typeof data[key] === 'undefined') continue;
-			this[key] = schema[key].type === 'Folder' ?
-				Configuration._patch(this[key], data[key], schema[key]) :
-				data[key];
+		for (const [key, piece] of schema) {
+			const value = data[key];
+			if (value === undefined || value === null) continue;
+			this[key] = piece.type === 'Folder' ? Configuration._patch(this[key], value, piece) : value;
 		}
 	}
 

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -206,8 +206,8 @@ class Configuration {
 	update(keys, values, guild, options) {
 		// Overload update(object, GuildResolvable);
 		if (isObject(keys)) {
-			[keys, values] = objectToTuples(keys);
 			[guild, options] = [values, guild];
+			[keys, values] = objectToTuples(keys);
 		} else if (typeof keys === 'string') {
 			// Overload update(string|string[], any|any[], ...any[]);
 			keys = [keys];

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -32,7 +32,7 @@ class Gateway extends GatewayStorage {
 	/**
 	 * @typedef {Object} GatewayJSON
 	 * @property {string} type The name of this gateway
-	 * @property {GatewayDriverAddOptions} options The options for this gateway
+	 * @property {GatewayDriverRegisterOptions} options The options for this gateway
 	 * @property {Object} schema The current schema
 	 */
 
@@ -40,29 +40,16 @@ class Gateway extends GatewayStorage {
 	 * @since 0.0.1
 	 * @param {GatewayDriver} store The GatewayDriver instance which initiated this instance
 	 * @param {string} type The name of this Gateway
-	 * @param {Object} schema The initial schema for this instance
-	 * @param {GatewayDriverAddOptions} options The options for this schema
+	 * @param {GatewayDriverRegisterOptions} options The options for this schema
 	 */
-	constructor(store, type, schema, options) {
-		super(store.client, type, options.provider);
+	constructor(store, type, { provider }) {
+		super(store.client, type, provider);
 
 		/**
 		 * @since 0.0.1
 		 * @type {GatewayDriver}
 		 */
 		this.store = store;
-
-		/**
-		 * @since 0.5.0
-		 * @type {GatewayDriverAddOptions}
-		 */
-		this.options = options;
-
-		/**
-		 * @since 0.3.0
-		 * @type {Object}
-		 */
-		this.defaultSchema = schema;
 
 		/**
 		 * @since 0.0.1
@@ -95,76 +82,20 @@ class Gateway extends GatewayStorage {
 	/**
 	 * Get an entry from the cache.
 	 * @since 0.5.0
-	 * @param {string} input The key to get from the cache
-	 * @param {boolean} [create=false] Whether SG should create a new instance of Configuration in the background
-	 * @returns {(Configuration|Object)}
+	 * @param {string} id The key to get from the cache
+	 * @param {boolean} [create = false] Whether SG should create a new instance of Configuration in the background
+	 * @returns {?Configuration}
 	 */
-	getEntry(input, create = false) {
-		if (input === 'default') return this.defaults;
+	get(id, create = false) {
+		const entry = this.cache.get(id);
+		if (entry) return entry;
 		if (create) {
-			const entry = this.cache.get(input);
-			if (!entry) {
-				const configs = new this.Configuration(this, { id: input });
-				this.cache.set(input, configs);
-				// Silently create a new entry. The new data does not matter as Configuration default all the keys.
-				this.provider.create(this.type, input)
-					.then(() => {
-						configs._existsInDB = true;
-						if (this.client.listenerCount('configCreateEntry')) this.client.emit('configCreateEntry', configs);
-					})
-					.catch(error => this.client.emit('error', error));
-				return configs;
-			}
-			return entry;
+			const configs = new this.Configuration(this, { id });
+			this.cache.set(id, configs);
+			if (this.ready && this.schema.keyArray.length) configs.sync().catch(err => this.client.emit('error', err));
+			return configs;
 		}
-		return this.cache.get(input) || this.defaults;
-	}
-
-	/**
-	 * Create a new entry into the database with an optional content (defaults to this Gateway's defaults).
-	 * @since 0.5.0
-	 * @param {string} input The name of the key to create
-	 * @returns {Configuration}
-	 */
-	async createEntry(input) {
-		const target = getIdentifier(input);
-		if (!target) throw new TypeError('The selected target could not be resolved to a string.');
-		const cache = this.cache.get(target);
-		if (cache && cache._existsInDB) return cache;
-		await this.provider.create(this.type, target);
-		const configs = cache || new this.Configuration(this, { id: target });
-		configs._existsInDB = true;
-		if (!cache) this.cache.set(target, configs);
-		if (this.client.listenerCount('configCreateEntry')) this.client.emit('configCreateEntry', configs);
-		return configs;
-	}
-
-	/**
-	 * Generate a new entry and add it to the cache.
-	 * @since 0.5.0
-	 * @param {string} id The ID of the entry
-	 * @param {*} data The data to insert
-	 * @returns {Configuration}
-	 */
-	insertEntry(id, data = {}) {
-		const configs = new this.Configuration(this, { ...data, id });
-		this.cache.set(id, configs);
-		if (this.ready && this.schema.keyArray.length) configs.sync().catch(err => this.client.emit('error', err));
-		return configs;
-	}
-
-	/**
-	 * Delete an entry from the database and cache.
-	 * @since 0.5.0
-	 * @param {string} input The name of the key to fetch and delete
-	 * @returns {boolean}
-	 */
-	async deleteEntry(input) {
-		const configs = this.cache.get(input);
-		if (!configs) return false;
-
-		await configs.destroy();
-		return true;
+		return null;
 	}
 
 	/**
@@ -176,19 +107,8 @@ class Gateway extends GatewayStorage {
 	 */
 	async sync(input, download) {
 		if (typeof input === 'undefined') {
-			if (!download) return Promise.all(this.cache.map(entry => entry.sync()));
-			const entries = await this.provider.getAll(this.type);
-			for (const entry of entries) {
-				const cache = this.cache.get(entry);
-				if (cache) {
-					if (!cache._existsInDB) cache._existsInDB = true;
-					cache._patch(entry);
-				} else {
-					const newEntry = new this.Configuration(this, entry);
-					newEntry._existsInDB = true;
-					this.cache.set(entry.id, newEntry);
-				}
-			}
+			if (download) await this._download();
+			else await Promise.all(this.cache.map(entry => entry.sync()));
 			return null;
 		}
 		const target = getIdentifier(input);
@@ -250,14 +170,30 @@ class Gateway extends GatewayStorage {
 	 * @param {boolean} [download=true] Whether this Gateway should download the data from the database
 	 * @private
 	 */
-	async init(download = true) {
-		if (this.ready) throw new Error(`[INIT] ${this} has already initialized.`);
+	async init({ download = true, defaultSchema = {} } = {}) {
+		await super.init(defaultSchema);
+		if (download) await this._download();
+		await this._ready();
+	}
 
-		await this.initSchema();
-		await this.initTable();
-
-		if (download) await this.sync();
-		this.ready = true;
+	/**
+	 * Download all entries for this database
+	 * @since 0.5.0
+	 * @private
+	 */
+	async _download() {
+		const entries = await this.provider.getAll(this.type);
+		for (const entry of entries) {
+			const cache = this.cache.get(entry);
+			if (cache) {
+				if (!cache._existsInDB) cache._existsInDB = true;
+				cache._patch(entry);
+			} else {
+				const configs = new this.Configuration(this, entry);
+				configs._existsInDB = true;
+				this.cache.set(entry.id, configs);
+			}
+		}
 	}
 
 	/**
@@ -270,8 +206,9 @@ class Gateway extends GatewayStorage {
 		if (!this.schema.keyArray.length || typeof this.client[this.type] === 'undefined') return null;
 		const promises = [];
 		const keys = await this.provider.getKeys(this.type);
+		const store = this.client[this.type];
 		for (let i = 0; i < keys.length; i++) {
-			const structure = this.client[this.type].get(keys[i]);
+			const structure = store.get(keys[i]);
 			if (structure) promises.push(structure.configs.sync().then(() => this.cache.set(keys[i], structure.configs)));
 		}
 		const results = await Promise.all(promises);
@@ -305,10 +242,9 @@ class Gateway extends GatewayStorage {
 	 * @param {string[]} path The key's path
 	 * @param {Object} data The data to insert
 	 * @param {('add'|'delete'|'update')} action Whether the piece got added or removed
-	 * @param {boolean} force Whether the key got added with force or not
 	 * @private
 	 */
-	async _shardSync(path, data, action, force) {
+	async _shardSync(path, data, action) {
 		if (!this.client.shard) return;
 		const parsed = typeof data === 'string' ? JSON.parse(data) : data;
 		let route = this.schema;
@@ -316,15 +252,14 @@ class Gateway extends GatewayStorage {
 		for (const pt of path) route = route[pt];
 		let piece;
 		if (action === 'add') {
-			if (parsed.type === 'Folder') piece = route[key] = new SchemaFolder(this.client, this, parsed, route, key);
-			else piece = route[key] = new SchemaPiece(this.client, this, parsed, route, key);
+			piece = route._add(key, parsed, parsed.type === 'Folder' ? SchemaFolder : SchemaPiece);
 		} else if (action === 'delete') {
 			piece = route[key];
 			delete route[key];
 		} else {
 			route[key]._patch(parsed);
 		}
-		if (force) await route.force(action, key, piece);
+		await route.force(action, piece);
 	}
 
 	/**
@@ -335,7 +270,7 @@ class Gateway extends GatewayStorage {
 	toJSON() {
 		return {
 			type: this.type,
-			options: this.options,
+			options: { provider: this.providerName },
 			schema: this.schema.toJSON()
 		};
 	}

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -8,9 +8,9 @@ const Gateway = require('./Gateway');
 class GatewayDriver {
 
 	/**
-	 * @typedef {Object} GatewayDriverAddOptions
+	 * @typedef {Object} GatewayDriverRegisterOptions
 	 * @property {string} [provider] The name of the provider to use
-	 * @property {boolean} [nice=false] Whether the JSON provider should use sequential or burst mode
+	 * @property {boolean} [download=true] Whether the Gateway should download all entries or not
 	 */
 
 	/**
@@ -62,9 +62,9 @@ class GatewayDriver {
 
 		/**
 		 * All the types accepted for the Gateway.
-		 * @type {Set<string>}
+		 * @type {?Set<string>}
 		 */
-		this.types = new Set(Object.getOwnPropertyNames(SettingResolver.prototype).slice(1));
+		this.types = null;
 
 		/**
 		 * All the gateways added
@@ -110,9 +110,8 @@ class GatewayDriver {
 				default: this.client.options.prefix,
 				min: null,
 				max: 10,
-				array: this.client.options.prefix.constructor.name === 'Array',
-				configurable: true,
-				sql: `VARCHAR(10) NOT NULL DEFAULT '${this.client.options.prefix.constructor.name === 'Array' ? JSON.stringify(this.client.options.prefix) : this.client.options.prefix}'`
+				array: Array.isArray(this.client.options.prefix),
+				configurable: true
 			},
 			language: {
 				type: 'language',
@@ -120,8 +119,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: false,
-				configurable: true,
-				sql: `VARCHAR(5) NOT NULL DEFAULT '${this.client.options.language}'`
+				configurable: true
 			},
 			disableNaturalPrefix: {
 				type: 'boolean',
@@ -129,8 +127,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: false,
-				configurable: Boolean(this.client.options.regexPrefix),
-				sql: `BIT(1) NOT NULL DEFAULT 0`
+				configurable: Boolean(this.client.options.regexPrefix)
 			},
 			disabledCommands: {
 				type: 'command',
@@ -138,8 +135,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: true,
-				configurable: true,
-				sql: 'TEXT'
+				configurable: true
 			}
 		};
 	}
@@ -158,8 +154,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: true,
-				configurable: true,
-				sql: 'TEXT'
+				configurable: true
 			},
 			guildBlacklist: {
 				type: 'string',
@@ -167,8 +162,7 @@ class GatewayDriver {
 				min: 17,
 				max: 19,
 				array: true,
-				configurable: true,
-				sql: 'TEXT'
+				configurable: true
 			},
 			schedules: {
 				type: 'any',
@@ -176,8 +170,7 @@ class GatewayDriver {
 				min: null,
 				max: null,
 				array: true,
-				configurable: false,
-				sql: 'TEXT'
+				configurable: false
 			}
 		};
 	}
@@ -186,20 +179,23 @@ class GatewayDriver {
 	 * Registers a new Gateway.
 	 * @since 0.5.0
 	 * @param {string} name The name for the new gateway
-	 * @param {Object} [schema={}] The schema for use in this gateway
-	 * @param {GatewayDriverAddOptions} [options={}] The options for the new gateway
-	 * @chainable
+	 * @param {Object} [defaultSchema = {}] The schema for use in this gateway
+	 * @param {GatewayDriverRegisterOptions} [options = {}] The options for the new gateway
 	 * @returns {this}
+	 * @chainable
 	 */
-	register(name, schema = {}, options = {}) {
+	register(name, defaultSchema = {}, { download = true, provider = this.client.options.providers.default } = {}) {
+		if (typeof name !== 'string') throw new TypeError('You must pass a name for your new gateway and it must be a string.');
+		if (!this.client.methods.util.isObject(defaultSchema)) throw new TypeError('Schema must be a valid object or left undefined for an empty object.');
+		if (this.name !== undefined && this.name !== null) throw new Error(`The key '${name}' is either taken by another Gateway or reserved for GatewayDriver's functionality.`);
 		if (!this.ready) {
-			if (this._queue.has(name)) throw new Error(`There is already a Gateway with the name '${name}'.`);
-			this._queue.set(name, () => {
-				this._register(name, schema, options);
+			if (this._queue.has(name)) throw new Error(`There is already a Gateway with the name '${name}' in the queue.`);
+			this._queue.set(name, async () => {
+				await this._register(name, { provider }).init({ download, defaultSchema });
 				this._queue.delete(name);
 			});
 		} else {
-			this._register(name, schema, options);
+			this._register(name, { provider });
 		}
 
 		return this;
@@ -212,54 +208,26 @@ class GatewayDriver {
 	 * @private
 	 */
 	async _ready() {
-		if (this.ready) throw new Error('Configuration has already run the ready method.');
+		if (this.ready) throw new Error('The GatewayDriver has already been inited.');
+		this.types = new Set(Object.getOwnPropertyNames(SettingResolver.prototype).slice(1));
 		this.ready = true;
-		const promises = [];
-		for (const register of this._queue.values()) register();
-		for (const key of this.keys) {
-			// If the gateway did not init yet, init it now
-			if (!this[key].ready) await this[key].init();
-			promises.push(this[key]._ready());
-		}
-		return Promise.all(promises);
+		return Promise.all([...this._queue.values()].map(register => register()));
 	}
 
 	/**
 	 * Registers a new Gateway
 	 * @since 0.5.0
 	 * @param {string} name The name for the new gateway
-	 * @param {Object} schema The schema for use in this gateway
-	 * @param {GatewayDriverAddOptions} options The options for the new gateway
+	 * @param {GatewayDriverRegisterOptions} options The options for the new gateway
 	 * @returns {Gateway}
 	 * @private
 	 */
-	_register(name, schema, options) {
-		if (typeof name !== 'string') throw new Error('You must pass a name for your new gateway and it must be a string.');
+	_register(name, options) {
+		if (!this.client.providers.has(options.provider)) throw new Error(`This provider (${options.provider}) does not exist in your system.`);
 
-		if (this[name] !== undefined && this[name] !== null) throw new Error(`There is already a Gateway with the name '${name}'.`);
-		if (!this.client.methods.util.isObject(schema)) throw new Error('Schema must be a valid object or left undefined for an empty object.');
-
-		options.provider = this._checkProvider(options.provider || this.client.options.providers.default);
-		const provider = this.client.providers.get(options.provider);
-		if (provider.cache) throw new Error(`The provider ${provider.name} is designed for caching, not persistent data. Please try again with another.`);
-
-		const gateway = new Gateway(this, name, schema, options);
 		this.keys.add(name);
-		this[name] = gateway;
-
-		return gateway;
-	}
-
-	/**
-	 * Check if a provider exists.
-	 * @since 0.5.0
-	 * @param {string} engine Check if a provider exists
-	 * @returns {string}
-	 * @private
-	 */
-	_checkProvider(engine) {
-		if (this.client.providers.has(engine)) return engine;
-		throw new Error(`This provider (${engine}) does not exist in your system.`);
+		this[name] = new Gateway(this, name, options);
+		return this[name];
 	}
 
 	/**

--- a/src/lib/settings/SchemaFolder.js
+++ b/src/lib/settings/SchemaFolder.js
@@ -192,7 +192,7 @@ class SchemaFolder extends Schema {
 				for (let j = 0; j < path.length - 1; j++) value = value[path[j]];
 				value[path[path.length - 1]] = deepClone(defValue);
 			}
-			return this.gateway.provider.updateValue(this.gateway.type, piece.path, defValue, this.gateway.options.nice);
+			return this.gateway.provider.updateValue(this.gateway.type, piece.path, defValue);
 		}
 
 		if (action === 'delete') {
@@ -200,7 +200,7 @@ class SchemaFolder extends Schema {
 				for (let j = 0; j < path.length - 1; j++) value = value[path[j]];
 				delete value[path[path.length - 1]];
 			}
-			return this.gateway.provider.removeValue(this.gateway.type, piece.path, this.gateway.options.nice);
+			return this.gateway.provider.removeValue(this.gateway.type, piece.path);
 		}
 
 		throw new TypeError(`Action must be either 'add' or 'delete'. Got: ${action}`);

--- a/src/lib/settings/SchemaFolder.js
+++ b/src/lib/settings/SchemaFolder.js
@@ -119,7 +119,7 @@ class SchemaFolder extends Schema {
 		if (this.gateway.sql) {
 			if (piece.type !== 'Folder' || piece.keyArray.length) {
 				await this.gateway.provider.addColumn(this.gateway.type, piece.type === 'Folder' ?
-					piece.getSQL() : [piece.sql]);
+					piece.sqlSchema : [piece.path, piece.sql]);
 			}
 		} else if (force || (this.gateway.type === 'clientStorage' && this.client.shard)) {
 			await this.force('add', key, piece);
@@ -148,7 +148,7 @@ class SchemaFolder extends Schema {
 		if (this.gateway.sql) {
 			if (piece.type !== 'Folder' || (piece.type === 'Folder' && piece.keyArray.length)) {
 				await this.gateway.provider.removeColumn(this.gateway.type, piece.type === 'Folder' ?
-					[...piece.keys(true)] : key);
+					[...piece.keys(true)] : [key]);
 			}
 		} else if (force || (this.gateway.type === 'clientStorage' && this.client.shard)) {
 			// If force, or if the gateway is clientStorage, it should update all entries
@@ -222,17 +222,15 @@ class SchemaFolder extends Schema {
 	}
 
 	/**
-	 * Get all the SQL schemas from this schema's children.
+	 * Get all SQL datatypes from this SchemaFolder's children.
 	 * @since 0.5.0
-	 * @param {string[]} [array=[]] The array to push.
-	 * @returns {string[]}
+	 * @type {Array<Array<string>>}
+	 * @readonly
 	 */
-	getSQL(array = []) {
-		for (const key of this.keyArray) {
-			if (this[key].type === 'Folder') this[key].getSQL(array);
-			else array.push(this[key].sql);
-		}
-		return array;
+	get sqlSchema() {
+		const schema = [];
+		for (const piece of this.schema.values(true)) schema.push([piece.path, piece.sql]);
+		return schema;
 	}
 
 	/**

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -44,7 +44,6 @@ class SchemaPiece extends Schema {
 		 * The type of this key.
 		 * @since 0.5.0
 		 * @type {string}
-		 * @name SchemaPiece#type
 		 */
 		this.type = options.type.toLowerCase();
 
@@ -52,7 +51,6 @@ class SchemaPiece extends Schema {
 		 * Whether this key should store multiple or a single value.
 		 * @since 0.5.0
 		 * @type {boolean}
-		 * @name SchemaPiece#array
 		 */
 		this.array = 'array' in options ? options.array : Array.isArray(options.default);
 
@@ -60,7 +58,6 @@ class SchemaPiece extends Schema {
 		 * What this key should provide by default.
 		 * @since 0.5.0
 		 * @type {*}
-		 * @name SchemaPiece#default
 		 */
 		this.default = 'default' in options ? options.default : this._generateDefault();
 
@@ -68,7 +65,6 @@ class SchemaPiece extends Schema {
 		 * The minimum value for this key.
 		 * @since 0.5.0
 		 * @type {?number}
-		 * @name SchemaPiece#min
 		 */
 		this.min = 'min' in options ? options.min : null;
 
@@ -76,23 +72,20 @@ class SchemaPiece extends Schema {
 		 * The maximum value for this key.
 		 * @since 0.5.0
 		 * @type {?number}
-		 * @name SchemaPiece#max
 		 */
 		this.max = 'max' in options ? options.max : null;
 
 		/**
 		 * A tuple of strings containing the path and the datatype.
 		 * @since 0.5.0
-		 * @type {string[]}
-		 * @name SchemaPiece#sql
+		 * @type {string}
 		 */
-		this.sql = [this.path, null];
+		this.sql = null;
 
 		/**
 		 * Whether this key should be configurable by the config command. When type is any, this key defaults to false.
 		 * @since 0.5.0
 		 * @type {boolean}
-		 * @name SchemaPiece#configurable
 		 */
 		this.configurable = 'configurable' in options ? options.configurable : this.type !== 'any';
 
@@ -144,15 +137,15 @@ class SchemaPiece extends Schema {
 		if (!isObject(options)) throw new TypeError(`SchemaPiece#edit expected an object as a parameter. Got: ${typeof options}`);
 
 		const edited = new Set();
-		if (typeof options.sql === 'string' && this.sql[1] !== options.sql) {
-			this.sql[1] = options.sql;
+		if (typeof options.sql === 'string' && this.sql !== options.sql) {
+			this.sql = options.sql;
 			edited.add('SQL');
 			if (this.gateway.sql) await this.gateway.provider.updateColumn(this.gateway.type, this.path, options.sql);
 		}
 		if (typeof options.default !== 'undefined' && this.default !== options.default) {
 			this._schemaCheckDefault({ ...this.toJSON(), ...options });
 			this.default = options.default;
-			if (!edited.has('SQL')) this.sql[1] = this._generateSQLDatatype(options.sql);
+			if (!edited.has('SQL')) this.sql = this._generateSQLDatatype(options.sql);
 			edited.add('DEFAULT');
 		}
 		if (typeof options.min !== 'undefined' && this.min !== options.min) {
@@ -172,7 +165,7 @@ class SchemaPiece extends Schema {
 		}
 		if (edited.size > 0) {
 			await fs.outputJSONAtomic(this.gateway.filePath, this.gateway.schema.toJSON());
-			if (this.gateway.sql && this.gateway.provider.updateColumn === 'function') {
+			if (this.gateway.sql && typeof this.gateway.provider.updateColumn === 'function') {
 				this.gateway.provider.updateColumn(this.gateway.type, this.key, this._generateSQLDatatype(options.sql));
 			}
 			await this.parent._shardSyncSchema(this, 'update', false);
@@ -282,7 +275,7 @@ class SchemaPiece extends Schema {
 		if (typeof object.default !== 'undefined') this.default = object.default;
 		if (typeof object.min === 'number') this.min = object.min;
 		if (typeof object.max === 'number') this.max = object.max;
-		if (typeof object.sql === 'string') this.sql[1] = object.sql;
+		if (typeof object.sql === 'string') this.sql = object.sql;
 		if (typeof object.configurable === 'boolean') this.configurable = object.configurable;
 	}
 
@@ -300,7 +293,7 @@ class SchemaPiece extends Schema {
 
 		// Check if the 'options' parameter is an object.
 		if (!isObject(options)) throw new TypeError(`SchemaPiece#init expected an object as a parameter. Got: ${typeof options}`);
-		this.sql[1] = this._generateSQLDatatype(options.sql);
+		this.sql = this._generateSQLDatatype(options.sql);
 
 		return true;
 	}
@@ -317,7 +310,7 @@ class SchemaPiece extends Schema {
 			default: this.default,
 			min: this.min,
 			max: this.max,
-			sql: this.sql[1],
+			sql: this.sql,
 			configurable: this.configurable
 		};
 	}

--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -36,7 +36,7 @@ class Type {
 		/**
 		 * The child keys of this Type
 		 * @since 0.5.0
-		 * @type {Map}
+		 * @type {Map<string, Type>}
 		 * @private
 		 */
 		this.childKeys = new Map();
@@ -44,7 +44,7 @@ class Type {
 		/**
 		 * The child values of this Type
 		 * @since 0.5.0
-		 * @type {Map}
+		 * @type {Map<string, Type>}
 		 * @private
 		 */
 		this.childValues = new Map();
@@ -154,7 +154,7 @@ class Type {
 	/**
 	 * Joins the list of child types.
 	 * @since 0.5.0
-	 * @param {Map} values The values to list
+	 * @param {Map<string, Type>} values The values to list
 	 * @returns {string}
 	 * @private
 	 */

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -244,14 +244,15 @@ class Util {
 	 * @since 0.5.0
 	 * @param {Object<string, *>} object The object to convert
 	 * @param {{ keys: string[], values: any[] }} [entries={}] The initial entries
+	 * @param {string} [prefix=''] The prefix for the key
 	 * @returns {Array<Array<*>>}
 	 */
-	static objectToTuples(object, { keys = [], values = [] } = {}) {
+	static objectToTuples(object, { keys = [], values = [] } = {}, prefix = '') {
 		for (const key of Object.keys(object)) {
 			if (Util.isObject(object[key])) {
-				Util.objectToTuples(object[key], { keys, values });
+				Util.objectToTuples(object[key], { keys, values }, `${prefix}${key}.`);
 			} else {
-				keys.push(key);
+				keys.push(`${prefix}${key}`);
 				values.push(object[key]);
 			}
 		}

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -232,6 +232,18 @@ class Util {
 		return object;
 	}
 
+	static objectToTuples(object, { keys = [], values = [] } = {}) {
+		for (const key of Object.keys(object)) {
+			if (Util.isObject(object[key])) {
+				Util.objectToTuples(object[key], { keys, values });
+			} else {
+				keys.push(key);
+				values.push(object[key]);
+			}
+		}
+		return [keys, values];
+	}
+
 	/**
 	 * Compare if both arrays are equal
 	 * @param {any[]} arr1 The first array to compare

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -3,6 +3,8 @@ const { exec } = require('child_process');
 const zws = String.fromCharCode(8203);
 const has = (ob, ke) => Object.prototype.hasOwnProperty.call(ob, ke);
 let sensitivePattern;
+const TOTITLECASE = /[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g;
+const REGEXPESC = /[-/\\^$*+?.()|[\]{}]/g;
 
 /**
  * Contains static methods to be used throughout klasa
@@ -62,7 +64,7 @@ class Util {
 	 * @returns {string}
 	 */
 	static toTitleCase(str) {
-		return str.replace(/[A-Za-zÀ-ÖØ-öø-ÿ]\S*/g, (txt) => Util.titleCaseVariants[txt] || txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+		return str.replace(TOTITLECASE, (txt) => Util.titleCaseVariants[txt] || txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 	}
 
 	/**
@@ -72,7 +74,7 @@ class Util {
 	 * @returns {string}
 	 */
 	static regExpEsc(str) {
-		return str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+		return str.replace(REGEXPESC, '\\$&');
 	}
 
 	/**
@@ -106,12 +108,12 @@ class Util {
 			for (const key in source) output[key] = Util.deepClone(source[key]);
 			return output;
 		}
-		if (source instanceof Map || source instanceof WeakMap) {
+		if (source instanceof Map) {
 			const output = new source.constructor();
 			for (const [key, value] of source.entries()) output.set(key, Util.deepClone(value));
 			return output;
 		}
-		if (source instanceof Set || source instanceof WeakSet) {
+		if (source instanceof Set) {
 			const output = new source.constructor();
 			for (const value of source.values()) output.add(Util.deepClone(value));
 			return output;
@@ -150,9 +152,8 @@ class Util {
 	 */
 	static isClass(input) {
 		return typeof input === 'function' &&
-			typeof input.constructor !== 'undefined' &&
-			typeof input.constructor.constructor.toString === 'function' &&
-			input.prototype.constructor.toString().substring(0, 5) === 'class';
+			typeof input.prototype === 'object' &&
+			input.toString().substring(0, 5) === 'class';
 	}
 
 	/**
@@ -162,7 +163,7 @@ class Util {
 	 * @returns {boolean}
 	 */
 	static isObject(input) {
-		return Object.prototype.toString.call(input) === '[object Object]';
+		return input && input.constructor === Object;
 	}
 
 	/**
@@ -219,19 +220,32 @@ class Util {
 	 * @since 0.5.0
 	 * @param {string} path The dotted path
 	 * @param {*} value The value
+	 * @param {Object<string, *>} [obj = {}] The object to edit
 	 * @returns {*}
 	 */
-	static makeObject(path, value) {
-		if (path.indexOf('.') === -1) return { [path]: value };
-		const object = {};
-		const route = path.split('.');
-		const lastKey = route.pop();
-		let reference = object;
-		for (const key of route) reference = reference[key] = {};
-		reference[lastKey] = value;
-		return object;
+	static makeObject(path, value, obj = {}) {
+		if (path.indexOf('.') === -1) {
+			obj[path] = value;
+		} else {
+			const route = path.split('.');
+			const lastKey = route.pop();
+			let reference = obj;
+			for (const key of route) {
+				if (!(key in reference)) reference[key] = {};
+				reference = reference[key];
+			}
+			reference[lastKey] = value;
+		}
+		return obj;
 	}
 
+	/**
+	 * Convert an object to a tuple
+	 * @since 0.5.0
+	 * @param {Object<string, *>} object The object to convert
+	 * @param {{ keys: string[], values: any[] }} [entries={}] The initial entries
+	 * @returns {Array<Array<*>>}
+	 */
 	static objectToTuples(object, { keys = [], values = [] } = {}) {
 		for (const key of Object.keys(object)) {
 			if (Util.isObject(object[key])) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1305,7 +1305,7 @@ declare module 'klasa' {
 		public static isNumber(input: number): boolean;
 		public static isObject(input: object): boolean;
 		public static isThenable(input: Promise<any>): boolean;
-		public static objectToTuples(obj: ObjectLiteral<any>, entries?: { keys: string[], values: any[] }): [string[], any[]]
+		public static objectToTuples(obj: ObjectLiteral<any>, entries?: { keys: string[], values: any[] }): [string[], any[]];
 		public static makeObject(path: string, value: any, obj?: object): object;
 		public static arrayFromObject<T = any>(obj: ObjectLiteral<T>, prefix?: string): Array<string, T>;
 		public static arraysEqual(arr1: any[], arr2: any[], clone?: boolean): boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1268,14 +1268,14 @@ declare module 'klasa' {
 	}
 
 	export class Type {
-		public constructor(value: any, parent: ?type);
+		public constructor(value: any, parent?: Type);
 
 		public value: any;
 		public is: string;
 
-		private parent: ?Type;
-		private childKeys: Map;
-		private childValues: Map;
+		private parent?: Type;
+		private childKeys: Map<string, Type>;
+		private childValues: Map<string, Type>;
 
 		private readonly childTypes: string;
 
@@ -1289,7 +1289,7 @@ declare module 'klasa' {
 
 		public static resolve(value: any): string;
 
-		private static list(values: Map): string;
+		private static list(values: Map<string, Type>): string;
 	}
 
 	class Util {
@@ -1307,7 +1307,7 @@ declare module 'klasa' {
 		public static isThenable(input: Promise<any>): boolean;
 		public static objectToTuples(obj: ObjectLiteral<any>, entries?: { keys: string[], values: any[] }): [string[], any[]];
 		public static makeObject(path: string, value: any, obj?: object): object;
-		public static arrayFromObject<T = any>(obj: ObjectLiteral<T>, prefix?: string): Array<string, T>;
+		public static arrayFromObject<T = any>(obj: ObjectLiteral<T>, prefix?: string): Array<T>;
 		public static arraysEqual(arr1: any[], arr2: any[], clone?: boolean): boolean;
 		public static mergeDefault(def: object, given?: object): object;
 		public static mergeObjects(objTarget: object, objSource: object): object;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -73,10 +73,10 @@ declare module 'klasa' {
 		public readonly invite: string;
 		public readonly owner?: KlasaUser;
 		public validatePermissionLevels(): PermissionLevels;
-		public registerStore<K, V>(store: Store<K, V>): KlasaClient;
-		public unregisterStore<K, V>(store: Store<K, V>): KlasaClient;
+		public registerStore<K, V extends Piece>(store: Store<K, V>): KlasaClient;
+		public unregisterStore<K, V extends Piece>(store: Store<K, V>): KlasaClient;
 
-		public registerPiece<K, V>(pieceName: string, store: Store<K, V>): KlasaClient;
+		public registerPiece<K, V extends Piece>(pieceName: string, store: Store<K, V>): KlasaClient;
 		public unregisterPiece(pieceName: string): KlasaClient;
 
 		public login(token: string): Promise<string>;
@@ -236,7 +236,7 @@ declare module 'klasa' {
 		public readonly responses: KlasaMessage[];
 		public readonly args: string[];
 		public readonly params: any[];
-		public readonly flags: object;
+		public readonly flags: ObjectLiteral<string>;
 		public readonly reprompted: boolean;
 		public readonly reactable: boolean;
 		public prompt(text: string, time?: number): Promise<KlasaMessage>;
@@ -328,7 +328,7 @@ declare module 'klasa' {
 
 		public custom(arg: string, possible: Possible, msg: KlasaMessage, custom: ArgResolverCustomMethod): Promise<any>;
 		public piece(arg: string, possible: Possible, msg: KlasaMessage): Promise<Piece>;
-		public store<K, V>(arg: string, possible: Possible, msg: KlasaMessage): Promise<Store<K, V>>;
+		public store<K, V extends Piece>(arg: string, possible: Possible, msg: KlasaMessage): Promise<Store<K, V>>;
 
 		public cmd(arg: string, possible: Possible, msg: KlasaMessage): Promise<Command>;
 		public command(arg: string, possible: Possible, msg: KlasaMessage): Promise<Command>;
@@ -518,7 +518,7 @@ declare module 'klasa' {
 		public readonly gateway: Gateway;
 		public readonly id: string;
 		private _existsInDB: boolean;
-		private _syncStatus?: Promise<object>;
+		private _syncStatus?: Promise<void>;
 
 		public get(key: string): any;
 		public get<T>(key: string): T;
@@ -528,12 +528,13 @@ declare module 'klasa' {
 
 		public reset(key?: string | string[], avoidUnconfigurable?: boolean): Promise<ConfigurationUpdateResult>;
 		public reset(key?: string | string[], guild?: KlasaGuild, avoidUnconfigurable?: boolean): Promise<ConfigurationUpdateResult>;
-		public update(key: object, guild?: GatewayGuildResolvable): Promise<ConfigurationUpdateResult>;
+		public update(key: ObjectLiteral<any>, guild?: GatewayGuildResolvable): Promise<ConfigurationUpdateResult>;
 		public update(key: string, value: any, guild?: GatewayGuildResolvable, options?: ConfigurationUpdateOptions): Promise<ConfigurationUpdateResult>;
 		public update(key: string[], value: any[], guild?: GatewayGuildResolvable, options?: ConfigurationUpdateOptions): Promise<ConfigurationUpdateResult>;
 		public list(msg: KlasaMessage, path: SchemaFolder | string): string;
 		public resolveString(msg: KlasaMessage, path: SchemaPiece | string): string;
 
+		private _sync(): Promise<this>;
 		private _get(route: string | string[], piece?: boolean): object;
 		private _get<T>(route: string | string[], piece?: boolean): T;
 		private _save(data: ConfigurationUpdateResult): Promise<void>;
@@ -543,11 +544,11 @@ declare module 'klasa' {
 		private _setValueByPath(piece: SchemaPiece, parsedID: any): { updated: boolean, old: any };
 		private _patch(data: any): void;
 
-		public toJSON(): object;
+		public toJSON<T extends ObjectLiteral<PrimitiveType | PrimitiveType[]>>(): T;
 		public toString(): string;
 
-		private static _merge(data: any, folder: SchemaFolder | SchemaPiece): any;
-		private static _clone(data: any, schema: SchemaFolder): any;
+		private static _merge<T extends ObjectLiteral<any>>(data: any, folder: SchemaFolder | SchemaPiece): T;
+		private static _clone<T extends ObjectLiteral<any>>(data: any, schema: SchemaFolder): T;
 		private static _patch(inst: any, data: any, schema: SchemaFolder): void;
 	}
 
@@ -559,17 +560,15 @@ declare module 'klasa' {
 		public readonly resolver: SettingResolver;
 		public readonly cache: Collection<string, Configuration>;
 
-		public getEntry(input: string, create?: boolean): object | Configuration;
-		public createEntry(input: string): Promise<Configuration>;
-		public insertEntry(id: string, data?: object): Configuration;
-		public deleteEntry(input: string): Promise<boolean>;
+		public get(input: string | number, create?: boolean): Configuration;
 		public sync(input?: object | string, download?: boolean): Promise<any>;
 		public getPath(key?: string, options?: GatewayGetPathOptions): GatewayGetPathResult | null;
 
-		private init(download?: boolean): Promise<void>;
+		public init(options: { download?: boolean, defaultSchema?: object }): Promise<void>;
+		private _download(): Promise<void>;
 		private _ready(): Promise<Array<Collection<string, Configuration>>>;
 		private _resolveGuild(guild: GatewayGuildResolvable): KlasaGuild;
-		private _shardSync(path: string[], data: any, action: 'add' | 'delete' | 'update', force: boolean): Promise<void>;
+		private _shardSync(path: string[], data: any, action: 'add' | 'delete' | 'update'): Promise<void>;
 
 		public toJSON(): GatewayJSON;
 		public toString(): string;
@@ -625,8 +624,9 @@ declare module 'klasa' {
 		public readonly provider?: Provider;
 		public readonly defaults: any;
 
+		public init(defaultSchema: object): Promise<void>;
 		private initTable(): Promise<void>;
-		private initSchema(): Promise<SchemaFolder>;
+		private initSchema(defaultSchema: object): Promise<SchemaFolder>;
 		private parseEntry(entry: any): any;
 
 		private static _parseSQLValue(value: any, schemaPiece: SchemaPiece): any;
@@ -667,7 +667,7 @@ declare module 'klasa' {
 		public keys(recursive?: boolean): Iterator<string>;
 		public [Symbol.iterator](): Iterator<[string, SchemaFolder | SchemaPiece]>;
 
-		public toJSON(): any;
+		public toJSON(): ObjectLiteral<SchemaFolderAddOptions>;
 		public toString(): string;
 	}
 
@@ -683,7 +683,7 @@ declare module 'klasa' {
 		public validator?: (resolved: any, guild?: KlasaGuild) => void;
 
 		public setValidator(fn: Function): this;
-		public parse(value: any, guild: KlasaGuild): Promise<any>;
+		public parse<T = any>(value: any, guild: KlasaGuild): Promise<T>;
 		public modify(options: SchemaPieceEditOptions): Promise<this>;
 
 		private _generateDefault(): Array<any> | false | null;
@@ -705,8 +705,8 @@ declare module 'klasa' {
 
 //#region Pieces
 
-	export class Piece {
-		public constructor(client: KlasaClient, store: Store<string, Piece>, type: string, file: string | string[], core: boolean, options?: PieceOptions);
+	export abstract class Piece {
+		public constructor(client: KlasaClient, store: Store<string, Piece, typeof Piece>, type: string, file: string | string[], core: boolean, options?: PieceOptions);
 		public readonly client: KlasaClient;
 		public readonly core: boolean;
 		public readonly type: string;
@@ -715,12 +715,11 @@ declare module 'klasa' {
 		public enabled: boolean;
 		public store: Store<string, this>;
 
-		public reload(): Promise<Piece>;
+		public reload(): Promise<this>;
 		public unload(): void;
-		public enable(): Piece;
-		public disable(): Piece;
+		public enable(): this;
+		public disable(): this;
 		public init(): Promise<any>;
-
 		public toJSON(): PieceJSON;
 		public toString(): string;
 	}
@@ -751,10 +750,9 @@ declare module 'klasa' {
 		public usage: CommandUsage;
 		private cooldowns: Map<Snowflake, number>;
 
-		public definePrompt(usageString: string, usageDelim: string): Usage;
 		public createCustomResolver(type: string, resolver: ArgResolverCustomMethod): this;
 		public customizeResponse(name: string, response: string | ((msg: KlasaMessage, possible: Possible) => string)): this;
-
+		public definePrompt(usageString: string, usageDelim: string): Usage;
 		public run(msg: KlasaMessage, params: any[]): Promise<KlasaMessage | KlasaMessage[]>;
 		public toJSON(): PieceCommandJSON;
 	}
@@ -800,20 +798,20 @@ declare module 'klasa' {
 	}
 
 	export abstract class Language extends Piece {
-		public language: { [key: string]: any };
+		public language: ObjectLiteral<string | string[] | ((...args) => string | string[])>;
 
-		public get(term: string, ...args: any[]): any;
+		public get<T = string>(term: string, ...args: any[]): T;
 		public toJSON(): PieceLanguageJSON;
 	}
 
 	export abstract class Monitor extends Piece {
 		public constructor(client: KlasaClient, store: MonitorStore, file: string, core: boolean, options?: MonitorOptions);
-
 		public ignoreBots: boolean;
 		public ignoreEdits: boolean;
 		public ignoreOthers: boolean;
 		public ignoreSelf: boolean;
 		public ignoreWebhooks: boolean;
+
 		public abstract run(msg: KlasaMessage): void;
 		public shouldRun(msg: KlasaMessage, edit?: boolean): boolean;
 		public toJSON(): PieceMonitorJSON;
@@ -825,19 +823,20 @@ declare module 'klasa' {
 		public cache: boolean;
 		public sql: boolean;
 
-		public abstract hasTable(table: string): Promise<boolean>;
-		public abstract createTable(table: string): Promise<any>;
-		public abstract deleteTable(table: string): Promise<any>;
-		public abstract getAll<T>(table: string): Promise<T[]>;
-		public abstract getKeys(table: string): Promise<string[]>;
-		public abstract get<T>(table: string, entry: string): Promise<T>;
-		public abstract has(table: string, entry: string): Promise<boolean>;
-		public abstract updateValue(table: string, path: string, newValue: any): Promise<any>;
-		public abstract removeValue(table: string, path: string): Promise<any>;
+		protected parseInput<T extends ObjectLiteral<any>>(data: ConfigurationUpdateResultEntry[] | [string, any][] | ObjectLiteral<any>): T;
 		public abstract create(table: string, entry: string, data: any): Promise<any>;
-		public abstract update(table: string, entry: string, data: any): Promise<any>;
-		public abstract replace(table: string, entry: string, data: any): Promise<any>;
+		public abstract createTable(table: string): Promise<any>;
 		public abstract delete(table: string, entry: string): Promise<any>;
+		public abstract deleteTable(table: string): Promise<any>;
+		public abstract get<T extends ObjectLiteral<any>>(table: string, entry: string): Promise<T>;
+		public abstract getAll<T extends ObjectLiteral<any>>(table: string): Promise<T[]>;
+		public abstract getKeys(table: string): Promise<string[]>;
+		public abstract has(table: string, entry: string): Promise<boolean>;
+		public abstract hasTable(table: string): Promise<boolean>;
+		public abstract removeValue(table: string, path: string): Promise<any>;
+		public abstract replace(table: string, entry: string, data: ConfigurationUpdateResultEntry[] | [string, any][] | ObjectLiteral<any>): Promise<any>;
+		public abstract update(table: string, entry: string, data: ConfigurationUpdateResultEntry[] | [string, any][] | ObjectLiteral<any>): Promise<any>;
+		public abstract updateValue(table: string, path: string, newValue: any): Promise<any>;
 
 		public shutdown(): Promise<void>;
 		public toJSON(): PieceProviderJSON;
@@ -852,90 +851,59 @@ declare module 'klasa' {
 
 //#region Stores
 
-	export class Store<K, V> extends Collection<K, V> {
+	export class Store<K, V extends Piece, VConstructor = Constructable<V>> extends Collection<K, V> {
 		public constructor(client: KlasaClient, name: string, holds: V);
 
 		public readonly client: KlasaClient;
-		public readonly name: string;
-		public readonly holds: V;
 		public readonly coreDir: string;
+		public readonly holds: VConstructor;
+		public readonly name: string;
 		public readonly userDir: string;
 
+		public delete(name: K | V): boolean;
+		public get(key: K): V;
+		public get<T extends V>(key: K): T;
 		public init(): Promise<any[]>;
-		public load(file: string | string[], core?: boolean): Piece;
+		public load(file: string | string[], core?: boolean): V;
 		public loadAll(): Promise<number>;
-		public resolve(name: Piece | string): Piece;
+		public resolve(name: V | string): V;
+		public set<T extends V>(key: K, value: T): this;
+		public set(piece: V): V;
 		public toString(): string;
 	}
 
 	export class CommandStore extends Store<string, Command> {
-		public constructor(client: KlasaClient);
 		public aliases: Collection<string, Command>;
-
-		public get(name: string): Command;
-		public has(name: string): boolean;
-		public set(key: string, value: Command): this;
-		public set(command: Command): Command;
-		public delete(name: Command | string): boolean;
-		public clear(): void;
 	}
 
-	export class EventStore extends Store<string, Event> {
-		public constructor(client: KlasaClient);
+	export class EventStore extends Store<string, Event, typeof Event> {
 		private _onceEvents: Set<string>;
-
-		public clear(): void;
-		public delete(name: Event | string): boolean;
-		public set(key: string, value: Event): this;
-		public set(event: Event): Event;
 	}
 
-	export class ExtendableStore extends Store<string, Extendable> {
-		public constructor(client: KlasaClient);
+	export class ExtendableStore extends Store<string, Extendable, typeof Extendable> { }
 
-		public delete(name: Extendable | string): boolean;
-		public clear(): void;
-		public set(key: string, value: Extendable): this;
-		public set(extendable: Extendable): Extendable;
-	}
-
-	export class FinalizerStore extends Store<string, Finalizer> {
-		public constructor(client: KlasaClient);
-
+	export class FinalizerStore extends Store<string, Finalizer, typeof Finalizer> {
 		public run(msg: KlasaMessage, mes: KlasaMessage, start: number): Promise<void>;
 	}
 
-	export class InhibitorStore extends Store<string, Inhibitor> {
-		public constructor(client: KlasaClient);
-
+	export class InhibitorStore extends Store<string, Inhibitor, typeof Inhibitor> {
 		public run(msg: KlasaMessage, cmd: Command, selective: boolean): Promise<void>;
 	}
 
-	export class LanguageStore extends Store<string, Language> {
-		public constructor(client: KlasaClient);
-
+	export class LanguageStore extends Store<string, Language, typeof Language> {
 		public readonly default: Language;
 	}
 
-	export class MonitorStore extends Store<string, Monitor> {
-		public constructor(client: KlasaClient);
-
+	export class MonitorStore extends Store<string, Monitor, typeof Monitor> {
 		public run(msg: KlasaMessage, edit?: boolean): Promise<void>;
-
 		private _run(msg: KlasaMessage, monitor: Monitor);
 	}
 
-	export class ProviderStore extends Store<string, Provider> {
-		public constructor(client: KlasaClient);
-
+	export class ProviderStore extends Store<string, Provider, typeof Provider> {
 		public readonly default?: Provider;
-		public clear(): void;
-		public delete(name: Provider | string): boolean;
 	}
 
-	export class TaskStore extends Store<string, Task> {
-		public constructor(client: KlasaClient);
-	}
+	export class TaskStore extends Store<string, Task, typeof Task> { }
 
 //#endregion Stores
 
@@ -1328,7 +1296,7 @@ declare module 'klasa' {
 		public static applyToClass(base: object, structure: object, skips?: string[]): void;
 		public static clean(text: string): string;
 		public static codeBlock(lang: string, expression: string): string;
-		public static deepClone(source: any): any;
+		public static deepClone<T = any>(source: T): T;
 		public static exec(exec: string, options?: ExecOptions): Promise<{ stdout: string, stderr: string }>;
 		public static getIdentifier(value: PrimitiveType | { id?: PrimitiveType, name?: PrimitiveType }): PrimitiveType | null;
 		public static getTypeName(input: any): string;
@@ -1342,8 +1310,7 @@ declare module 'klasa' {
 		public static mergeDefault(def: object, given?: object): object;
 		public static mergeObjects(objTarget: object, objSource: object): object;
 		public static regExpEsc(str: string): string;
-		public static sleep(delay: number, args?: any): Promise<any>;
-		public static sleep<T>(delay: number, args?: T): Promise<T>;
+		public static sleep<T = any>(delay: number, args?: T): Promise<T>;
 		public static toTitleCase(str: string): string;
 		public static tryParse(value: string): object;
 		private static initClean(client: KlasaClient): void;
@@ -1415,7 +1382,7 @@ declare module 'klasa' {
 	export type ExecOptions = {
 		cwd?: string;
 		encoding?: string;
-		env?: StringMappedType<string>;
+		env?: ObjectLiteral<string>;
 		gid?: number;
 		killSignal?: string | number;
 		maxBuffer?: number;
@@ -1987,17 +1954,19 @@ declare module 'klasa' {
 		time?: number;
 	};
 
-	type StringMappedType<T> = { [key: string]: T };
+	type ObjectLiteral<T> = { [key: string]: T };
 
-	export type GuildSettings = StringMappedType<any>;
-	export type SchemaObject = StringMappedType<SchemaPiece>;
-	export type SchemaDefaults = StringMappedType<any>;
+	export type GuildSettings = ObjectLiteral<any>;
+	export type SchemaObject = ObjectLiteral<SchemaPiece>;
+	export type SchemaDefaults = ObjectLiteral<any>;
 
 	// TypeScript lacks of Proxy
 	export type Proxy<T> = {
 		get(): T;
 		set(value: T): void;
 	};
+
+	type Constructable<T> = new (...args: any[]) => T;
 
 	export type PrimitiveType = string | number | boolean;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1305,7 +1305,9 @@ declare module 'klasa' {
 		public static isNumber(input: number): boolean;
 		public static isObject(input: object): boolean;
 		public static isThenable(input: Promise<any>): boolean;
-		public static makeObject(path: string, value: any): object;
+		public static objectToTuples(obj: ObjectLiteral<any>, entries?: { keys: string[], values: any[] }): [string[], any[]]
+		public static makeObject(path: string, value: any, obj?: object): object;
+		public static arrayFromObject<T = any>(obj: ObjectLiteral<T>, prefix?: string): Array<string, T>;
 		public static arraysEqual(arr1: any[], arr2: any[], clone?: boolean): boolean;
 		public static mergeDefault(def: object, given?: object): object;
 		public static mergeObjects(objTarget: object, objSource: object): object;


### PR DESCRIPTION
### Description of the PR

This PR ports several refactors from #228 and goes further by fixing several bugs that are caused in other places. The objective of this PR is to backport some bugfixes that need to be merged quickly while improving the interface in general.

The problem with #228 is that its design has not been fully decided, and it's supposed to implement SQL improvements but goes much further than that. However, some bugfixes don't merge due to QueryBuilder and QueryType not being 100% finished nor ready for production.

Probably fixes #247

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Changed**:

- **[PERF]** Refactored `Util.isClass` and `Util.isObject` for a 5x performance jump.
- `Gateway#getEntry` -> `Gateway#get`.
- `SchemaPiece#sql` is now type of `string` instead of `[string, string]`.
- Improved performance in `Gateway#_ready()` by caching the structure instead of getting it for each entry.
- Refactored `GatewayDriver` for optimized and better readability.

**Removed**:

- Removed `Gateway#insertEntry`, `Gateway#createEntry` and `Gateway#deleteEntry` in favor to the OOP paradigm.
- `Gateway#options` and `Gateway#defaultSchema` to improve RAM usage.
- Removed several checks in GatewayDriver being done right after init, instead of in register.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
