### PR TITLE
Better Language#get

### DIFF
--- a/src/lib/structures/Language.js
+++ b/src/lib/structures/Language.js
@@ -24,18 +24,16 @@ class Language extends Piece {
 	 */
 	get(term, ...args) {
 		if (!this.enabled && this !== this.store.default) return this.store.default.get(term, ...args);
+		const value = this.language[term];
 		/* eslint-disable new-cap */
-		if (!this.language[term]) {
-			if (this === this.store.default) return this.language.DEFAULT(term);
-			return [
-				`${this.language.DEFAULT(term)}`,
-				'',
-				`**${this.language.DEFAULT_LANGUAGE}:**`,
-				`${(args.length ? this.store.default.language[term](...args) : this.store.default.language[term]) || this.store.default.language.DEFAULT(term)}`
-			].join('\n');
+		switch (typeof value) {
+			case 'function': return value(...args);
+			case 'undefined':
+				if (this === this.store.default) return this.language.DEFAULT(term);
+				return `${this.language.DEFAULT(term)}\n\n**${this.language.DEFAULT_LANGUAGE}:**\n${this.store.default.get(term, ...args)}`;
+			default: return value;
 		}
 		/* eslint-enable new-cap */
-		return args.length ? this.language[term](...args) : this.language[term];
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR

This PR refactors `Language#get` by using a switch checking the key's type and take advantage of the mechanic to reduce complexity when a key is not translated in a language but is (or not) in the default language.

It also allows language keys with no arguments to be run, considering this example:

```javascript
const FUNNY_RESPONSES = [
	'We were three, now we are two!',
	'The... what?'
];

module.exports = class extends Language {

	constructor(...args) {
		this.language = {
			// ...
			TRYING_TO_BE_FUNNY: () => FUNNY_RESPONSES[Math.floor(FUNNY_RESPONSES.length * Math.random())]
			// ...
		}
	}

}
```

Which the current system does not allow. It also fixes the [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) thrown when the key is not a function and you accidentally input more than one argument.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Refactored `Language#get`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
