### PR TITLE
Cache user responses in TextPrompt#responses to have access to the messages

### DIFF
--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -125,7 +125,6 @@ class TextPrompt {
 		 * @type {Tag}
 		 * @private
 		 */
-
 		this._currentUsage = {};
 
 		/**

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -1,4 +1,5 @@
 const { mergeDefault } = require('../util/util');
+const { Collection } = require('discord.js');
 const quotes = ['"', "'", '“”', '‘’'];
 
 /**
@@ -124,7 +125,15 @@ class TextPrompt {
 		 * @type {Tag}
 		 * @private
 		 */
+
 		this._currentUsage = {};
+
+		/**
+		 * A cache of the users responses
+		 * @since 0.5.0
+		 * @type external:Collection
+		 */
+		this.responses = new Collection();
 	}
 
 	/**
@@ -135,6 +144,7 @@ class TextPrompt {
 	 */
 	async run(prompt) {
 		const message = await this.message.prompt(prompt, this.promptTime);
+		this.responses.set(message.id, message);
 		this._setup(message.content);
 		return this.validateArgs();
 	}
@@ -153,6 +163,8 @@ class TextPrompt {
 			this.message.language.get('MONITOR_COMMAND_HANDLER_REPROMPT', `<@!${this.message.author.id}>`, prompt, this.promptTime / 1000),
 			this.promptTime
 		);
+
+		this.responses.set(message.id, message);
 
 		if (message.content.toLowerCase() === 'abort') throw this.message.language.get('MONITOR_COMMAND_HANDLER_ABORTED');
 
@@ -179,6 +191,7 @@ class TextPrompt {
 				this.message.language.get('MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT', `<@!${this.message.author.id}>`, this._currentUsage.possibles[0].name, this.promptTime / 1000),
 				this.promptTime
 			);
+			this.responses.set(message.id, message);
 		} catch (err) {
 			return this.validateArgs();
 		}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -996,6 +996,7 @@ declare module 'klasa' {
 		public promptTime: number;
 		public promptLimit: number;
 		public quotedStringSupport: boolean;
+		public responses: Collection;
 		private _repeat: boolean;
 		private _required: number;
 		private _prompted: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -996,7 +996,7 @@ declare module 'klasa' {
 		public promptTime: number;
 		public promptLimit: number;
 		public quotedStringSupport: boolean;
-		public responses: Collection;
+		public responses: Collection<string, KlasaMessage>;
 		private _repeat: boolean;
 		private _required: number;
 		private _prompted: number;


### PR DESCRIPTION
### Description of the PR
New Collection to cache user input messages in TextPrompt#responses

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
