### PR TITLE
[Awaiting Stability] ESM Support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ resources:
       endpoint: dirigeants
 
 jobs:
-  - template: lint.yml@templates
+  #- template: lint.yml@templates
 
   - template: docs.yml@templates
     parameters:

--- a/guides/Getting Started/GettingStarted.md
+++ b/guides/Getting Started/GettingStarted.md
@@ -1,4 +1,6 @@
-# Welcome to the klasa#{@branch} documentation
+# Warning: This is an experimental version of Klasa
+
+Running this version requires Node v10 and for now `--experimental-modules`. This will not merge until the feature is no-longer under a flag.
 
 ## Installing Klasa
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "author": "BDistin",
-  "main": "src/index.js",
+  "main": "src/index",
   "types": "typings/index.d.ts",
   "repository": {
     "type": "git",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,82 @@
+import klasaPackage from '../package.json';
+
+// KlasaClient
+export { default as Client } from './lib/Client';
+export { default as KlasaClient } from './lib/Client';
+
+// lib/extensions
+export { default as KlasaGuild } from './lib/extensions/KlasaGuild';
+export { default as KlasaMessage } from './lib/extensions/KlasaMessage';
+export { default as KlasaUser } from './lib/extensions/KlasaUser';
+
+// lib/permissions
+export { default as PermissionLevels } from './lib/permissions/PermissionLevels';
+
+// lib/schedule
+export { default as Schedule } from './lib/schedule/Schedule';
+export { default as ScheduledTask } from './lib/schedule/ScheduledTask';
+
+// lib/settings
+export { default as Settings } from './lib/settings/Settings';
+export { default as Gateway } from './lib/settings/Gateway';
+export { default as GatewayDriver } from './lib/settings/GatewayDriver';
+export { default as GatewayStorage } from './lib/settings/GatewayStorage';
+export { default as Schema } from './lib/settings/schema/Schema';
+export { default as SchemaFolder } from './lib/settings/schema/SchemaFolder';
+export { default as SchemaPiece } from './lib/settings/schema/SchemaPiece';
+
+// lib/structures/base
+export { default as Piece } from './lib/structures/base/Piece';
+export { default as Store } from './lib/structures/base/Store';
+
+// lib/structures
+export { default as Argument } from './lib/structures/Argument';
+export { default as ArgumentStore } from './lib/structures/ArgumentStore';
+export { default as Command } from './lib/structures/Command';
+export { default as CommandStore } from './lib/structures/CommandStore';
+export { default as Event } from './lib/structures/Event';
+export { default as EventStore } from './lib/structures/EventStore';
+export { default as Extendable } from './lib/structures/Extendable';
+export { default as ExtendableStore } from './lib/structures/ExtendableStore';
+export { default as Finalizer } from './lib/structures/Finalizer';
+export { default as FinalizerStore } from './lib/structures/FinalizerStore';
+export { default as Inhibitor } from './lib/structures/Inhibitor';
+export { default as InhibitorStore } from './lib/structures/InhibitorStore';
+export { default as Language } from './lib/structures/Language';
+export { default as LanguageStore } from './lib/structures/LanguageStore';
+export { default as Monitor } from './lib/structures/Monitor';
+export { default as MonitorStore } from './lib/structures/MonitorStore';
+export { default as Provider } from './lib/structures/Provider';
+export { default as ProviderStore } from './lib/structures/ProviderStore';
+export { default as Serializer } from './lib/structures/Serializer';
+export { default as SerializerStore } from './lib/structures/SerializerStore';
+export { default as Task } from './lib/structures/Task';
+export { default as TaskStore } from './lib/structures/TaskStore';
+
+// lib/usage
+export { default as CommandPrompt } from './lib/usage/CommandPrompt';
+export { default as CommandUsage } from './lib/usage/CommandUsage';
+export { default as Usage } from './lib/usage/Usage';
+export { default as Possible } from './lib/usage/Possible';
+export { default as Tag } from './lib/usage/Tag';
+export { default as TextPrompt } from './lib/usage/TextPrompt';
+
+// lib/util
+export { default as Colors } from './lib/util/Colors';
+export { default as KlasaConsole } from './lib/util/KlasaConsole';
+export { default as constants } from './lib/util/constants';
+export { default as Cron } from './lib/util/Cron';
+export { default as Duration } from './lib/util/Duration';
+export { default as QueryBuilder } from './lib/util/QueryBuilder';
+export { default as RateLimit } from './lib/util/RateLimit';
+export { default as RateLimitManager } from './lib/util/RateLimitManager';
+export { default as ReactionHandler } from './lib/util/ReactionHandler';
+export { default as RichDisplay } from './lib/util/RichDisplay';
+export { default as RichMenu } from './lib/util/RichMenu';
+export { default as Stopwatch } from './lib/util/Stopwatch';
+export { default as Timestamp } from './lib/util/Timestamp';
+export { default as Type } from './lib/util/Type';
+export { default as util } from './lib/util/util';
+
+// version
+export const { version } = klasaPackage;

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -36,6 +36,14 @@ const util = require('./util/util');
 // external plugins
 const plugins = new Set();
 
+// Dev's package.json
+let main;
+try {
+	({ main } = require(path.join(process.cwd(), 'package.json')));
+} catch (error) {
+	// noop
+}
+
 /**
  * The client for handling everything. See {@tutorial GettingStarted} for more information how to get started using this class.
  * @extends external:Client
@@ -150,7 +158,8 @@ class KlasaClient extends Discord.Client {
 		 * @since 0.0.1
 		 * @type {string}
 		 */
-		this.userBaseDirectory = path.dirname(require.main.filename);
+		this.userBaseDirectory = main ? path.resolve(process.cwd(), path.dirname(main)) : path.join(process.cwd(), 'src');
+
 
 		/**
 		 * The console for this instance of klasa. You can disable timestamps, colors, and add writable streams as configuration options to configure this.

--- a/src/lib/structures/base/Piece.js
+++ b/src/lib/structures/base/Piece.js
@@ -1,3 +1,4 @@
+const { basename, extname } = require('path');
 const { mergeDefault } = require('../../util/util');
 const { join } = require('path');
 
@@ -55,7 +56,7 @@ class Piece {
 		 * @since 0.0.1
 		 * @type {string}
 		 */
-		this.name = options.name || file[file.length - 1].slice(0, -3);
+		this.name = options.name || basename(file[file.length - 1], extname(file[file.length - 1]));
 
 		/**
 		 * If the Piece is enabled or not
@@ -105,7 +106,7 @@ class Piece {
 	 * @returns {Piece} The newly loaded piece
 	 */
 	async reload() {
-		const piece = this.store.load(this.directory, this.file);
+		const piece = await this.store.load(this.directory, this.file);
 		await piece.init();
 		if (this.client.listenerCount('pieceReloaded')) this.client.emit('pieceReloaded', piece);
 		return piece;


### PR DESCRIPTION
### Description of the PR
Adds EMCAscript Modules support to Klasa, so that you can write your bots with .mjs: import/export syntax, or as you normally would now.

This breaks require.main.filename, and I don't have a solution for that currently, except hardcoding with the src/ folder, as the vs code extension suggests. A better solution will be required before merging.

This will not merge until the feature is no-longer behind the `--experimental-modules` flag, but will track changes with the master branch for anyone who wants to give this a try.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
