### PR TITLE
Change msg.edits.length to msg._edits.length

### DIFF
--- a/src/lib/structures/Monitor.js
+++ b/src/lib/structures/Monitor.js
@@ -87,7 +87,7 @@ class Monitor extends Piece {
 			!(this.ignoreSelf && this.client.user === msg.author) &&
 			!(this.ignoreOthers && this.client.user !== msg.author) &&
 			!(this.ignoreWebhooks && msg.webhookID) &&
-			!(this.ignoreEdits && msg.edits.length);
+			!(this.ignoreEdits && msg._edits.length);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR
`msg.edits` already contains the msg where `msg._edits` doesn't, this causing monitors to not run.
As you can see [Message.js#L323-L327](https://github.com/discordjs/discord.js/blob/master/src/structures/Message.js#L323-L327) it adds the current msg into the array from the `_edits` property,

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
