### PR TITLE
Made changes to eval cmd

### DIFF
--- a/src/commands/Admin/eval.js
+++ b/src/commands/Admin/eval.js
@@ -57,7 +57,7 @@ module.exports = class extends Command {
 			success = true;
 		} catch (error) {
 			if (!syncTime) syncTime = stopwatch.friendlyDuration;
-			if (!type) type = new Type(result);
+			if (!type) type = new Type(error);
 			if (thenable && !asyncTime) asyncTime = stopwatch.friendlyDuration;
 			if (error && error.stack) this.client.emit('error', error.stack);
 			result = error;

--- a/src/commands/Admin/eval.js
+++ b/src/commands/Admin/eval.js
@@ -16,7 +16,7 @@ module.exports = class extends Command {
 
 	async run(message, [code]) {
 		const { success, result, time, type } = await this.eval(message, code);
-		const footer = util.codeBlock('ts', type.toString());
+		const footer = util.codeBlock('ts', type);
 		const output = message.language.get(success ? 'COMMAND_EVAL_OUTPUT' : 'COMMAND_EVAL_ERROR',
 			time, util.codeBlock('js', result), footer);
 

--- a/src/commands/Admin/eval.js
+++ b/src/commands/Admin/eval.js
@@ -15,7 +15,7 @@ module.exports = class extends Command {
 	}
 
 	async run(message, [code]) {
-		const { success, result, time, type } = await this.eval(msg, code);
+		const { success, result, time, type } = await this.eval(message, code);
 		const footer = util.codeBlock('ts', type.toString());
 		const output = message.language.get(success ? 'COMMAND_EVAL_OUTPUT' : 'COMMAND_EVAL_ERROR',
 			time, util.codeBlock('js', result), footer);

--- a/src/commands/Admin/eval.js
+++ b/src/commands/Admin/eval.js
@@ -16,7 +16,7 @@ module.exports = class extends Command {
 
 	async run(msg, [code]) {
 		const { success, result, time, type } = await this.eval(msg, code);
-		const footer = this.client.methods.util.codeBlock('ts', type ? type.toString() : '');
+		const footer = this.client.methods.util.codeBlock('ts', type.toString());
 		const output = msg.language.get(success ? 'COMMAND_EVAL_OUTPUT' : 'COMMAND_EVAL_ERROR',
 			time, this.client.methods.util.codeBlock('js', result), footer);
 		const silent = 'silent' in msg.flags;
@@ -57,6 +57,7 @@ module.exports = class extends Command {
 			success = true;
 		} catch (error) {
 			if (!syncTime) syncTime = stopwatch.friendlyDuration;
+			if (!type) type = new Type(result);
 			if (thenable && !asyncTime) asyncTime = stopwatch.friendlyDuration;
 			if (error && error.stack) this.client.emit('error', error.stack);
 			result = error;

--- a/src/lib/structures/Monitor.js
+++ b/src/lib/structures/Monitor.js
@@ -87,7 +87,7 @@ class Monitor extends Piece {
 			!(this.ignoreSelf && this.client.user === msg.author) &&
 			!(this.ignoreOthers && this.client.user !== msg.author) &&
 			!(this.ignoreWebhooks && msg.webhookID) &&
-			!(this.ignoreEdits && msg.edits.length);
+			!(this.ignoreEdits && msg._edits.length);
 	}
 
 	/**

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -1,6 +1,5 @@
 const { promisify } = require('util');
 const { exec } = require('child_process');
-const DiscordUtil = require('discord.js').Util;
 const zws = String.fromCharCode(8203);
 const has = (ob, ke) => Object.prototype.hasOwnProperty.call(ob, ke);
 let sensitivePattern;
@@ -11,6 +10,10 @@ const REGEXPESC = /[-/\\^$*+?.()|[\]{}]/g;
  * Contains static methods to be used throughout klasa
  */
 class Util {
+
+	/**
+	 * @typedef {(string|*)} Stringable
+	 */
 
 	/**
 	 * This class may not be initiated with new
@@ -26,15 +29,11 @@ class Util {
 	 * Makes a codeblock markup string
 	 * @since 0.0.1
 	 * @param {string} lang The codeblock language
-	 * @param {StringResolvable} expression The expression to be wrapped in the codeblock
+	 * @param {Stringable} expression The expression to be wrapped in the codeblock
 	 * @returns {string}
 	 */
 	static codeBlock(lang, expression) {
-		// The resolved string form of expression, but never empty
-		const resolved = expression ?
-			DiscordUtil.resolveString(expression) || zws :
-			zws;
-		return `\`\`\`${lang}\n${resolved}\`\`\``;
+		return `\`\`\`${lang}\n${expression || zws}\`\`\``;
 	}
 
 	/**

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -1,5 +1,6 @@
 const { promisify } = require('util');
 const { exec } = require('child_process');
+const DiscordUtil = require('discord.js').Util;
 const zws = String.fromCharCode(8203);
 const has = (ob, ke) => Object.prototype.hasOwnProperty.call(ob, ke);
 let sensitivePattern;
@@ -25,11 +26,15 @@ class Util {
 	 * Makes a codeblock markup string
 	 * @since 0.0.1
 	 * @param {string} lang The codeblock language
-	 * @param {string} expression The expression to be wrapped in the codeblock
+	 * @param {StringResolvable} expression The expression to be wrapped in the codeblock
 	 * @returns {string}
 	 */
 	static codeBlock(lang, expression) {
-		return `\`\`\`${lang}\n${expression || zws}\`\`\``;
+		// The resolved string form of expression, but never empty
+		const resolved = expression ?
+			DiscordUtil.resolveString(expression) || zws :
+			zws;
+		return `\`\`\`${lang}\n${resolved}\`\`\``;
 	}
 
 	/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1846,7 +1846,7 @@ declare module 'klasa' {
 		stop?: boolean;
 		time?: number;
 	};
-	
+
 	export type Stringable = string | any;
 
 	type ObjectLiteral<T> = { [key: string]: T };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1226,7 +1226,7 @@ declare module 'klasa' {
 	class Util {
 		public static applyToClass(base: object, structure: object, skips?: string[]): void;
 		public static clean(text: string): string;
-		public static codeBlock(lang: string, expression: string): string;
+		public static codeBlock(lang: string, expression: StringResolvable): string;
 		public static deepClone<T = any>(source: T): T;
 		public static exec(exec: string, options?: ExecOptions): Promise<{ stdout: string, stderr: string }>;
 		public static getIdentifier(value: PrimitiveType | { id?: PrimitiveType, name?: PrimitiveType }): PrimitiveType | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1216,7 +1216,7 @@ declare module 'klasa' {
 	class Util {
 		public static applyToClass(base: object, structure: object, skips?: string[]): void;
 		public static clean(text: string): string;
-		public static codeBlock(lang: string, expression: StringResolvable): string;
+		public static codeBlock(lang: string, expression: Stringable): string;
 		public static deepClone<T = any>(source: T): T;
 		public static exec(exec: string, options?: ExecOptions): Promise<{ stdout: string, stderr: string }>;
 		public static getIdentifier(value: PrimitiveType | { id?: PrimitiveType, name?: PrimitiveType }): PrimitiveType | null;
@@ -1846,6 +1846,8 @@ declare module 'klasa' {
 		stop?: boolean;
 		time?: number;
 	};
+	
+	export type Stringable = string | any;
 
 	type ObjectLiteral<T> = { [key: string]: T };
 


### PR DESCRIPTION
### Description of the PR
Made changes to eval command, some discussed in chat.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)
- in `run`:
  - `type` can be either a Type object or undefined
  - remove error emitting block
- in `eval`:
  - destructure `flags` since it's used a lot
  - add error emitting to catch block

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
