### PR TITLE
Fix float/num/number returning a string

### DIFF
--- a/src/arguments/float.js
+++ b/src/arguments/float.js
@@ -10,7 +10,7 @@ module.exports = class extends Argument {
 		const { min, max } = possible;
 		const number = parseFloat(arg);
 		if (isNaN(number)) throw (msg.language || this.client.languages.default).get('RESOLVER_INVALID_FLOAT', possible.name);
-		return this.constructor.minOrMax(this.client, arg, min, max, possible, msg) ? arg : null;
+		return this.constructor.minOrMax(this.client, arg, min, max, possible, msg) ? number : null;
 	}
 
 };

--- a/src/arguments/float.js
+++ b/src/arguments/float.js
@@ -10,7 +10,7 @@ module.exports = class extends Argument {
 		const { min, max } = possible;
 		const number = parseFloat(arg);
 		if (isNaN(number)) throw (msg.language || this.client.languages.default).get('RESOLVER_INVALID_FLOAT', possible.name);
-		return this.constructor.minOrMax(this.client, arg, min, max, possible, msg) ? number : null;
+		return this.constructor.minOrMax(this.client, number, min, max, possible, msg) ? number : null;
 	}
 
 };


### PR DESCRIPTION
### Description of the PR
The float argument would return the original arg instead of the parsed arg aka `number` so fixed

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
