### PR TITLE
temporary fix the configUpdateEntry event for sharding

### DIFF
--- a/src/events/configUpdateEntry.js
+++ b/src/events/configUpdateEntry.js
@@ -2,16 +2,16 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
-	run(configs) {
+	run(oldConf, newConf) {
 		if (!this.client.shard) return;
-		if (configs.gateway.type === 'users') {
+		if (newConf.gateway.type === 'users') {
 			this.client.shard.broadcastEval(`
 				if (this.shard.id !== ${this.client.shard.id}) {
-					const user = this.users.get('${configs.id}');
+					const user = this.users.get('${newConf.id}');
 					if (user) user.configs.sync();
 				}
 			`);
-		} else if (configs.gateway.type === 'clientStorage') {
+		} else if (newConf.gateway.type === 'clientStorage') {
 			this.client.shard.broadcastEval(`
 				if (this.shard.id !== ${this.client.shard.id}) {
 					this.configs.sync();


### PR DESCRIPTION
### Description of the PR
This temporary fix the configUpdateEntry by using the updated entry instead an cloned version which was created before the update.

This doesn't fix the core problem but @kyranet should take a look at the Clone method of Configuration since the cloned instances doesn't have the id property.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- updated configUpdateEntry.js 

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
