### PR TITLE
Changed string literals to use flags

### DIFF
--- a/src/extendables/attachable.js
+++ b/src/extendables/attachable.js
@@ -1,4 +1,5 @@
 const { Extendable } = require('klasa');
+const { Permissions: { FLAGS } } = require('discord.js');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	get extend() {
-		return !this.guild || (this.postable && this.permissionsFor(this.guild.me).has('ATTACH_FILES'));
+		return !this.guild || (this.postable && this.permissionsFor(this.guild.me).has(FLAGS.ATTACH_FILES));
 	}
 
 };

--- a/src/extendables/embedable.js
+++ b/src/extendables/embedable.js
@@ -1,4 +1,5 @@
 const { Extendable } = require('klasa');
+const { Permissions: { FLAGS } } = require('discord.js');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	get extend() {
-		return !this.guild || (this.postable && this.permissionsFor(this.guild.me).has('EMBED_LINKS'));
+		return !this.guild || (this.postable && this.permissionsFor(this.guild.me).has(FLAGS.EMBED_LINKS));
 	}
 
 };

--- a/src/extendables/postable.js
+++ b/src/extendables/postable.js
@@ -1,4 +1,5 @@
 const { Extendable } = require('klasa');
+const { Permissions: { FLAGS } } = require('discord.js');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	get extend() {
-		return !this.guild || (this.readable && this.permissionsFor(this.guild.me).has('SEND_MESSAGES'));
+		return !this.guild || this.permissionsFor(this.guild.me).has([FLAGS.VIEW_CHANNEL, FLAGS.SEND_MESSAGES]);
 	}
 
 };

--- a/src/extendables/readable.js
+++ b/src/extendables/readable.js
@@ -1,4 +1,5 @@
 const { Extendable } = require('klasa');
+const { Permissions: { FLAGS } } = require('discord.js');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	get extend() {
-		return !this.guild || this.permissionsFor(this.guild.me).has('VIEW_CHANNEL');
+		return !this.guild || this.permissionsFor(this.guild.me).has(FLAGS.VIEW_CHANNEL);
 	}
 
 };

--- a/src/inhibitors/missingBotPermissions.js
+++ b/src/inhibitors/missingBotPermissions.js
@@ -1,22 +1,15 @@
 const { Inhibitor, util } = require('klasa');
-const { Permissions } = require('discord.js');
+const { Permissions, Permissions: { FLAGS } } = require('discord.js');
 
 module.exports = class extends Inhibitor {
 
 	constructor(...args) {
 		super(...args);
-		this.impliedPermissions = new Permissions([
-			'VIEW_CHANNEL',
-			'SEND_MESSAGES',
-			'SEND_TTS_MESSAGES',
-			'EMBED_LINKS',
-			'ATTACH_FILES',
-			'READ_MESSAGE_HISTORY',
-			'MENTION_EVERYONE',
-			'USE_EXTERNAL_EMOJIS',
-			'ADD_REACTIONS'
-		]);
-		this.friendlyPerms = Object.keys(Permissions.FLAGS).reduce((obj, key) => {
+		this.impliedPermissions = new Permissions(515136).freeze();
+		// VIEW_CHANNEL, SEND_MESSAGES, SEND_TTS_MESSAGES, EMBED_LINKS, ATTACH_FILES,
+		// READ_MESSAGE_HISTORY, MENTION_EVERYONE, USE_EXTERNAL_EMOJIS, ADD_REACTIONS
+
+		this.friendlyPerms = Object.keys(FLAGS).reduce((obj, key) => {
 			obj[key] = util.toTitleCase(key.split('_').join(' '));
 			return obj;
 		}, {});

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -311,7 +311,7 @@ class KlasaClient extends Discord.Client {
 	 */
 	get invite() {
 		if (!this.user.bot) throw 'Why would you need an invite link for a selfbot...';
-		const permissions = Permissions.resolve(this.commands.reduce((a, b) => a.add(b.botPerms), new Permissions(3072)));
+		const permissions = new Permissions(3072).add(...this.commands.map(command => command.botPerms)).bitfield;
 		// VIEW_CHANNEL, SEND_MESSAGES
 		return `https://discordapp.com/oauth2/authorize?client_id=${this.application.id}&permissions=${permissions}&scope=bot`;
 	}

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -1,4 +1,5 @@
 const Discord = require('discord.js');
+const { Permissions, Permissions: { FLAGS } } = Discord;
 const path = require('path');
 
 // lib/permissions
@@ -310,7 +311,7 @@ class KlasaClient extends Discord.Client {
 	 */
 	get invite() {
 		if (!this.user.bot) throw 'Why would you need an invite link for a selfbot...';
-		const permissions = Discord.Permissions.resolve(this.commands.reduce((a, b) => a.add(b.botPerms), new Discord.Permissions(['VIEW_CHANNEL', 'SEND_MESSAGES'])));
+		const permissions = Permissions.resolve(this.commands.reduce((a, b) => a.add(b.botPerms), new Permissions([FLAGS.VIEW_CHANNEL, FLAGS.SEND_MESSAGES])));
 		return `https://discordapp.com/oauth2/authorize?client_id=${this.application.id}&permissions=${permissions}&scope=bot`;
 	}
 
@@ -446,7 +447,7 @@ class KlasaClient extends Discord.Client {
  */
 KlasaClient.defaultPermissionLevels = new PermissionLevels()
 	.add(0, () => true)
-	.add(6, (client, msg) => msg.guild && msg.member.permissions.has('MANAGE_GUILD'), { fetch: true })
+	.add(6, (client, msg) => msg.guild && msg.member.permissions.has(FLAGS.MANAGE_GUILD), { fetch: true })
 	.add(7, (client, msg) => msg.guild && msg.member === msg.guild.owner, { fetch: true })
 	.add(9, (client, msg) => msg.author === client.owner, { break: true })
 	.add(10, (client, msg) => msg.author === client.owner);

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -311,7 +311,8 @@ class KlasaClient extends Discord.Client {
 	 */
 	get invite() {
 		if (!this.user.bot) throw 'Why would you need an invite link for a selfbot...';
-		const permissions = Permissions.resolve(this.commands.reduce((a, b) => a.add(b.botPerms), new Permissions([FLAGS.VIEW_CHANNEL, FLAGS.SEND_MESSAGES])));
+		const permissions = Permissions.resolve(this.commands.reduce((a, b) => a.add(b.botPerms), new Permissions(3072)));
+		// VIEW_CHANNEL, SEND_MESSAGES
 		return `https://discordapp.com/oauth2/authorize?client_id=${this.application.id}&permissions=${permissions}&scope=bot`;
 	}
 

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -1,4 +1,4 @@
-const { Structures, splitMessage, Collection, MessageAttachment, MessageEmbed } = require('discord.js');
+const { Structures, splitMessage, Collection, MessageAttachment, MessageEmbed, Permissions: { FLAGS } } = require('discord.js');
 const { isObject } = require('../util/util');
 
 module.exports = Structures.extend('Message', Message => {
@@ -122,7 +122,7 @@ module.exports = Structures.extend('Message', Message => {
 		 */
 		get reactable() {
 			if (!this.guild) return true;
-			return this.channel.readable && this.channel.permissionsFor(this.guild.me).has('ADD_REACTIONS');
+			return this.channel.readable && this.channel.permissionsFor(this.guild.me).has(FLAGS.ADD_REACTIONS);
 		}
 
 		/**


### PR DESCRIPTION
### Description of the PR

This PR changes string literals from all permissions to use [`Permissions.FLAGS`](https://discord.js.org/#/docs/main/master/class/Permissions?scrollTo=s-FLAGS) which are not only faster to resolve, but are also harder to mistype as they are enforced by IntelliSense.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Changed permissions to use flags instead of literal strings.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
