### PR TITLE
Await promise in member argument

### DIFF
--- a/src/arguments/member.js
+++ b/src/arguments/member.js
@@ -8,7 +8,7 @@ module.exports = class extends Argument {
 		if (this.client.user.bot && this.constructor.regex.userOrMember.test(arg)) {
 			const user = await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]).catch(() => null);
 			if (user) {
-				member = msg.guild.members.fetch(user).catch(() => null);
+				member = await msg.guild.members.fetch(user).catch(() => null);
 				if (member) return member;
 			}
 		}


### PR DESCRIPTION
### Description of the PR
A promise is not awaited in member argument, hence returning a promise even if `member` should be null.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
