### PR TITLE
fix: Escape strings in Util#initClean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#299](https://github.com/dirigeants/klasa/pull/299)] Escape strings from initClean. (KingDGrizzle)
 - [[#272](https://github.com/dirigeants/klasa/pull/272)] Changed `Monitor#shouldRun` to accept a single argument. (bdistin)
 - [[#256](https://github.com/dirigeants/klasa/pull/256)] **[BREAKING]** Modified all SettingResolvers to resolve to primitives (string, number, boolean...) or storable data. (kyranet)
 - [[#256](https://github.com/dirigeants/klasa/pull/256)] Added value array overload to `Configuration#update`. (kyranet)

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -54,9 +54,9 @@ class Util {
 	 */
 	static initClean(client) {
 		const patterns = [];
-		if (client.token) patterns.push(client.token);
-		if (client.user.email) patterns.push(client.user.email);
-		if (client.password) patterns.push(client.password);
+		if (client.token) patterns.push(Util.regExpEsc(client.token));
+		if (client.user.email) patterns.push(Util.regExpEsc(client.user.email));
+		if (client.password) patterns.push(Util.regExpEsc(client.password));
 		sensitivePattern = new RegExp(patterns.join('|'), 'gi');
 	}
 


### PR DESCRIPTION
### Description of the PR
Strings like a bot token can have the `.` character, which can cause the regex to misreplace. This fixes that by escaping any special characters from the password, email and token. Better safe than sorry!

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Escape all strings in initClean

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
