### PR TITLE
A little better grammar for multiple prefixes

### DIFF
--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -7,7 +7,10 @@ module.exports = class extends Language {
 		this.language = {
 			DEFAULT: (key) => `${key} has not been localized for en-US yet.`,
 			DEFAULT_LANGUAGE: 'Default Language',
-			PREFIX_REMINDER: (prefix) => `The prefix${Array.isArray(prefix) ? 'es for this guild are:' : ' in this guild is set to:'} ${Array.isArray(prefix) ? prefix.map(pre => `\`${pre}\``).join(', ') : `\`${prefix}\``}`,
+			PREFIX_REMINDER: (prefix) => `The prefix${Array.isArray(prefix) ?
+				`es for this guild are: ${prefix.map(pre => `\`${pre}\``).join(', ')}` :
+				` in this guild is set to: \`${prefix}\``
+			}`,
 			SETTING_GATEWAY_EXPECTS_GUILD: 'The parameter <Guild> expects either a Guild or a Guild Object.',
 			SETTING_GATEWAY_VALUE_FOR_KEY_NOEXT: (data, key) => `The value ${data} for the key ${key} does not exist.`,
 			SETTING_GATEWAY_VALUE_FOR_KEY_ALREXT: (data, key) => `The value ${data} for the key ${key} already exists.`,

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -7,7 +7,7 @@ module.exports = class extends Language {
 		this.language = {
 			DEFAULT: (key) => `${key} has not been localized for en-US yet.`,
 			DEFAULT_LANGUAGE: 'Default Language',
-			PREFIX_REMINDER: (prefix) => `The prefix in this guild is set to: ${Array.isArray(prefix) ? prefix.map(pre => `\`${pre}\``).join(', ') : `\`${prefix}\``}`,
+			PREFIX_REMINDER: (prefix) => `The prefix${Array.isArray(prefix) ? 'es for this guild are:' : ' in this guild is set to:'} ${Array.isArray(prefix) ? prefix.map(pre => `\`${pre}\``).join(', ') : `\`${prefix}\``}`,
 			SETTING_GATEWAY_EXPECTS_GUILD: 'The parameter <Guild> expects either a Guild or a Guild Object.',
 			SETTING_GATEWAY_VALUE_FOR_KEY_NOEXT: (data, key) => `The value ${data} for the key ${key} does not exist.`,
 			SETTING_GATEWAY_VALUE_FOR_KEY_ALREXT: (data, key) => `The value ${data} for the key ${key} already exists.`,


### PR DESCRIPTION
### Description of the PR
Update the prefix reminder to say "the prefixes for this guild are: ....", in case of multiple (array of) prefixes. The single prefix reminder message has stayed the same.

I'd probably do the other languages, however I'm not confident/competent enough to.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- See above

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
