### PR TITLE
Added QueryBuilder, exterminated all SQL from SettingGateway

### DIFF
--- a/guides/.docconfig.json
+++ b/guides/.docconfig.json
@@ -57,6 +57,10 @@
         "path": "CreatingProviders.md"
     },
     {
+        "name": "Creating SQL Providers",
+        "path": "CreatingSQLProviders.md"
+    },
+    {
         "name": "Creating Tasks",
         "path": "CreatingTasks.md"
     }]

--- a/guides/Advanced SettingGateway/UnderstandingSchemaFolders.md
+++ b/guides/Advanced SettingGateway/UnderstandingSchemaFolders.md
@@ -4,7 +4,6 @@ A schema works like a diagram or a blueprint, in SettingGateway, the schema defi
 
 1. Define what keys the {@link Gateway} manages and their properties.
 1. Define what type the keys must hold.
-1. Define the SQL schema when using a SQL database.
 1. Speed up performance when iterating over keys.
 
 ## Adding keys

--- a/guides/Advanced SettingGateway/UnderstandingSchemaPieces.md
+++ b/guides/Advanced SettingGateway/UnderstandingSchemaPieces.md
@@ -13,7 +13,6 @@ There are multiple options that configure the piece, they are:
 | default      | The default value for this key                                             |
 | max          | The maximum value for this key, only applies for string and numbers        |
 | min          | The minimum value for this key, only applies for string and numbers        |
-| sql          | The SQL datatype for this key                                              |
 | type         | The type for this key                                                      |
 
 > Check {@tutorial SettingGatewayKeyTypes} for the supported types and how to extend them.
@@ -27,8 +26,6 @@ The default option is one of the last options to default, **array** defaults to 
 - If **array** is true, default will be an empty array: `[]`.
 - If **type** is boolean, default will be `false`.
 - In any other case, it will be `null`.
-
-After default, the sql type is calculated with a valid datatype. Keep in mind that it uses standard SQL types, but may work better for PostgreSQL. In any case, if you want to use a type that is very specific to your database, consider including this option.
 
 ## Editing key options
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ module.exports = {
 	Gateway: require('./lib/settings/Gateway'),
 	GatewayDriver: require('./lib/settings/GatewayDriver'),
 	GatewayStorage: require('./lib/settings/GatewayStorage'),
+	QueryBuilder: require('./lib/settings/QueryBuilder'),
 	Schema: require('./lib/settings/Schema'),
 	SchemaFolder: require('./lib/settings/SchemaFolder'),
 	SchemaPiece: require('./lib/settings/SchemaPiece'),

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -1,4 +1,4 @@
-const { isObject, makeObject, deepClone, tryParse, toTitleCase, arraysStrictEquals, mergeObjects, getDeepTypeName, objectToTuples } = require('../util/util');
+const { isObject, deepClone, tryParse, toTitleCase, arraysStrictEquals, getDeepTypeName, objectToTuples } = require('../util/util');
 const SchemaFolder = require('./SchemaFolder');
 const SchemaPiece = require('./SchemaPiece');
 
@@ -433,16 +433,7 @@ class Configuration {
 		}
 		const oldClone = this.client.listenerCount('configUpdateEntry') ? this.clone() : null;
 
-		if (this.gateway.sql) {
-			const keys = new Array(updated.length), values = new Array(updated.length);
-			for (let i = 0; i < updated.length; i++) [keys[i], values[i]] = updated[i].data;
-			await this.gateway.provider.update(this.gateway.type, this.id, keys, values);
-		} else {
-			const updateObject = {};
-			for (const entry of updated) mergeObjects(updateObject, makeObject(entry.data[0], entry.data[1]));
-			await this.gateway.provider.update(this.gateway.type, this.id, updateObject);
-		}
-
+		await this.gateway.provider.update(this.gateway.type, this.id, updated);
 		if (oldClone !== null) this.client.emit('configUpdateEntry', oldClone, this, updated);
 	}
 

--- a/src/lib/settings/GatewayStorage.js
+++ b/src/lib/settings/GatewayStorage.js
@@ -72,16 +72,6 @@ class GatewayStorage {
 	}
 
 	/**
-	 * Get this gateway's SQL schema.
-	 * @since 0.0.1
-	 * @type {Array<Array<string>>}
-	 * @readonly
-	 */
-	get sqlSchema() {
-		return [['id', 'VARCHAR(19) NOT NULL UNIQUE PRIMARY KEY'], ...this.schema.sqlSchema];
-	}
-
-	/**
 	 * Get the provider that manages the persistent data.
 	 * @since 0.5.0
 	 * @type {?Provider}
@@ -133,7 +123,7 @@ class GatewayStorage {
 
 		// Init the table
 		const hasTable = await this.provider.hasTable(this.type);
-		if (!hasTable) await this.provider.createTable(this.type, this.sqlSchema);
+		if (!hasTable) await this.provider.createTable(this.type, this.schema);
 	}
 
 }

--- a/src/lib/settings/QueryBuilder.js
+++ b/src/lib/settings/QueryBuilder.js
@@ -1,0 +1,106 @@
+const { isObject, mergeDefault } = require('./util');
+const Type = require('./Type');
+
+class QueryBuilder {
+
+	/**
+	 * @typedef {Object} QueryBuilderDatatype
+	 * @property {Function} [array = () => 'TEXT'] A function that converts the current datatype into an array
+	 * @property {Function} [resolver = null] The resolver to convert JS objects into compatible data for the SQL database. This can be used to prevent SQL injections
+	 * @property {string} type The name of the datatype, e.g. VARCHAR, DATE, or BIT
+	 */
+
+	/**
+	 * @typedef {QueryBuilderDatatype} QueryBuilderOptions
+	 * @property {Function} formatDatatype The datatype formatter for the SQL database
+	 */
+
+	/**
+	 * @since 0.5.0
+	 * @param {Object<QueryBuilderDatatype>} datatypes The datatype to insert
+	 * @param {QueryBuilderOptions} [options = {}] The default options for all datatypes plus formatDatatype
+	 */
+	constructor(datatypes, options = {}) {
+		if (!isObject(datatypes)) throw `Expected 'datatypes' to be an object literal, got ${new Type(datatypes)}`;
+		mergeDefault({ array: () => 'TEXT', resolver: null, type: null }, options);
+		const { array, resolver, type } = options;
+
+		// Merge defaults on all keys
+		for (const key of Object.keys(datatypes)) {
+			const value = datatypes[key];
+			if (!isObject(value)) throw `Expected 'datatypes.${key}' to be an object literal, got ${new Type(value)}`;
+			mergeDefault({ array, resolver, type }, value);
+		}
+
+		/**
+		 * The defined datatypes for this instance
+		 * @since 0.5.0
+		 * @readonly
+		 * @private
+		 */
+		Object.defineProperty(this, '_datatypes', { value: Object.seal(datatypes) });
+
+		/**
+		 * The datatype formatter for the SQL database
+		 * @param {string} name The column's name
+		 * @param {string} datatype The column's datatype
+		 * @param {string} [def = null] The default value for the column
+		 * @returns {string}
+		 * @private
+		 */
+		this.formatDatatype = options.formatDatatype || ((name, datatype, def = null) => `${name} ${datatype}${def !== null ? ` NOT NULL DEFAULT ${def}` : ''}`);
+	}
+
+	/**
+	 * Get a datatype
+	 * @since 0.5.0
+	 * @param {string} datatype The datatype to get
+	 * @returns {QueryBuilderDatatype}
+	 * @example
+	 * this.qb.get('string');
+	 */
+	get(datatype) {
+		return this._datatypes[datatype] || null;
+	}
+
+	/**
+	 * Resolve data from a configured dedicated resolver for the selected datatype
+	 * @since 0.5.0
+	 * @param {string} type The SchemaPiece's type to try to resolve
+	 * @param {*} input The input to resolve
+	 * @returns {*}
+	 * @example
+	 * this.qb.resolve('boolean', true);
+	 * // -> 1 (MySQL)
+	 * // -> true (PGSQL)
+	 * // -> 'true' (SQLite)
+	 */
+	resolve(type, input) {
+		const datatype = this.get(type);
+		return datatype && typeof datatype.resolver === 'function' ? datatype.resolver(input) : input;
+	}
+
+	/**
+	 * Parse a SchemaPiece for the SQL datatype creation
+	 * @since 0.5.0
+	 * @param {schemaPiece} schemaPiece The SchemaPiece to process
+	 * @returns {string}
+	 * @example
+	 * this.qb.parse(this.client.gateways.guilds.schema.prefix);
+	 * // type: 'string', array: true, max: 10
+	 * // -> prefix VARCHAR(10)[]
+	 */
+	parse(schemaPiece) {
+		const datatype = this.get(schemaPiece.type);
+		if (!datatype || !datatype.type) throw `The type '${schemaPiece.type}' is unavailable, please set its definition in the constructor.`;
+		if (schemaPiece.array && !datatype.array) throw `The datatype '${datatype.type}' does not support arrays.`;
+
+		const parsedDatatype = schemaPiece.array ?
+			datatype.array(typeof datatype.type === 'function' ? datatype.type(schemaPiece) : datatype.type) :
+			datatype.type;
+		return this.format(schemaPiece.path, parsedDatatype, schemaPiece.default);
+	}
+
+}
+
+module.exports = QueryBuilder;

--- a/src/lib/settings/QueryBuilder.js
+++ b/src/lib/settings/QueryBuilder.js
@@ -42,6 +42,7 @@ class QueryBuilder {
 
 		/**
 		 * The datatype formatter for the SQL database
+		 * @type {Function}
 		 * @param {string} name The column's name
 		 * @param {string} datatype The column's datatype
 		 * @param {string} [def = null] The default value for the column

--- a/src/lib/settings/SchemaFolder.js
+++ b/src/lib/settings/SchemaFolder.js
@@ -17,7 +17,6 @@ class SchemaFolder extends Schema {
 	 * @property {number} [min] The min value for the key (String.length for String, value for number)
 	 * @property {number} [max] The max value for the key (String.length for String, value for number)
 	 * @property {boolean} [array] Whether the key should be stored as Array or not
-	 * @property {string} [sql] The datatype of the key
 	 * @property {boolean} [configurable] Whether the key should be configurable by the config command or not
 	 */
 
@@ -78,18 +77,6 @@ class SchemaFolder extends Schema {
 	}
 
 	/**
-	 * Get all SQL datatypes from this SchemaFolder's children.
-	 * @since 0.5.0
-	 * @type {Array<Array<string>>}
-	 * @readonly
-	 */
-	get sqlSchema() {
-		const schema = [];
-		for (const piece of this.values(true)) schema.push([piece.path, piece.sql]);
-		return schema;
-	}
-
-	/**
 	 * Create a new nested folder.
 	 * @since 0.5.0
 	 * @param {string} key The name's key for the folder
@@ -127,7 +114,7 @@ class SchemaFolder extends Schema {
 		const piece = this._add(key, options, options.type === 'Folder' ? SchemaFolder : SchemaPiece);
 		await fs.outputJSONAtomic(this.gateway.filePath, this.gateway.schema);
 
-		if (piece.type !== 'Folder' || piece.keyArray.length) await this.gateway.provider.addColumn(this.gateway.type, piece.sqlSchema);
+		if (piece.type !== 'Folder' || piece.keyArray.length) await this.gateway.provider.addColumn(this.gateway.type, piece);
 		await this.force('add', piece);
 
 		await this._shardSyncSchema(piece, 'add');

--- a/src/lib/settings/SchemaPiece.js
+++ b/src/lib/settings/SchemaPiece.js
@@ -15,7 +15,6 @@ class SchemaPiece extends Schema {
 	 * @property {number} [min] The new minimum range value
 	 * @property {number} [max] The new maximum range value
 	 * @property {boolean} [configurable] The new configurable value
-	 * @property {string} [sql] The new sql datatype
 	 */
 
 	/**
@@ -24,7 +23,6 @@ class SchemaPiece extends Schema {
 	 * @property {*} default The default value for the key
 	 * @property {number} min The min value for the key (String.length for String, value for number)
 	 * @property {number} max The max value for the key (String.length for String, value for number)
-	 * @property {string} sql A tuple containing the name of the column and its data type
 	 * @property {boolean} array Whether the key should be stored as Array or not
 	 * @property {boolean} configurable Whether the key should be configurable by the config command or not
 	 */
@@ -76,13 +74,6 @@ class SchemaPiece extends Schema {
 		this.max = 'max' in options ? options.max : null;
 
 		/**
-		 * A tuple of strings containing the path and the datatype.
-		 * @since 0.5.0
-		 * @type {string}
-		 */
-		this.sql = null;
-
-		/**
 		 * Whether this key should be configurable by the config command. When type is any, this key defaults to false.
 		 * @since 0.5.0
 		 * @type {boolean}
@@ -97,16 +88,6 @@ class SchemaPiece extends Schema {
 		this.validator = null;
 
 		this._init(options);
-	}
-
-	/**
-	 * Get this piece's SQL schema.
-	 * @since 0.5.0
-	 * @type {Array<string>}
-	 * @readonly
-	 */
-	get sqlSchema() {
-		return [this.path, this.sql];
 	}
 
 	/**
@@ -147,15 +128,9 @@ class SchemaPiece extends Schema {
 		if (!isObject(options)) throw new TypeError(`SchemaPiece#edit expected an object as a parameter. Got: ${typeof options}`);
 
 		const edited = new Set();
-		if (typeof options.sql === 'string' && this.sql !== options.sql) {
-			this.sql = options.sql;
-			edited.add('SQL');
-			if (this.gateway.sql) await this.gateway.provider.updateColumn(this.gateway.type, this.path, options.sql);
-		}
 		if (typeof options.default !== 'undefined' && this.default !== options.default) {
 			this._schemaCheckDefault({ ...this.toJSON(), ...options });
 			this.default = options.default;
-			if (!edited.has('SQL')) this.sql = this._generateSQLDatatype(options.sql);
 			edited.add('DEFAULT');
 		}
 		if (typeof options.min !== 'undefined' && this.min !== options.min) {
@@ -175,9 +150,7 @@ class SchemaPiece extends Schema {
 		}
 		if (edited.size > 0) {
 			await fs.outputJSONAtomic(this.gateway.filePath, this.gateway.schema.toJSON());
-			if (this.gateway.sql && typeof this.gateway.provider.updateColumn === 'function') {
-				this.gateway.provider.updateColumn(this.gateway.type, this.key, this._generateSQLDatatype(options.sql));
-			}
+			await this.gateway.provider.updateColumn(this.gateway.type, this);
 			await this.parent._shardSyncSchema(this, 'update', false);
 			if (this.client.listenerCount('schemaKeyUpdate')) this.client.emit('schemaKeyUpdate', this);
 		}
@@ -261,18 +234,6 @@ class SchemaPiece extends Schema {
 	}
 
 	/**
-	 * Generate a new SQL datatype.
-	 * @since 0.5.0
-	 * @param {string} [sql] The new SQL datatype
-	 * @returns {string}
-	 * @private
-	 */
-	_generateSQLDatatype(sql) {
-		return typeof sql === 'string' ? sql : (this.type === 'integer' || this.type === 'float' ? 'INTEGER' :
-			this.max !== null ? `VARCHAR(${this.max})` : 'TEXT') + (this.default !== null ? ` DEFAULT ${SchemaPiece._parseSQLValue(this.default)}` : '');
-	}
-
-	/**
 	 * Patch an object applying all its properties to this instance.
 	 * @since 0.5.0
 	 * @param {Object} object The object to patch
@@ -283,7 +244,6 @@ class SchemaPiece extends Schema {
 		if (typeof object.default !== 'undefined') this.default = object.default;
 		if (typeof object.min === 'number') this.min = object.min;
 		if (typeof object.max === 'number') this.max = object.max;
-		if (typeof object.sql === 'string') this.sql = object.sql;
 		if (typeof object.configurable === 'boolean') this.configurable = object.configurable;
 	}
 
@@ -306,7 +266,6 @@ class SchemaPiece extends Schema {
 		this._schemaCheckLimits(this.min, this.max);
 		this._schemaCheckConfigurable(this.configurable);
 		this._schemaCheckDefault(this);
-		this.sql = this._generateSQLDatatype(options.sql);
 
 		return true;
 	}
@@ -323,7 +282,6 @@ class SchemaPiece extends Schema {
 			default: this.default,
 			min: this.min,
 			max: this.max,
-			sql: this.sql,
 			configurable: this.configurable
 		};
 	}
@@ -335,21 +293,6 @@ class SchemaPiece extends Schema {
 	 */
 	toString() {
 		return `SchemaPiece(${this.gateway.type}:${this.path})`;
-	}
-
-	/**
-	 * Parses a value to a valid string that can be used for SQL input.
-	 * @since 0.5.0
-	 * @param {*} value The value to parse
-	 * @returns {string}
-	 * @private
-	 */
-	static _parseSQLValue(value) {
-		const type = typeof value;
-		if (type === 'boolean' || type === 'number' || value === null) return String(value);
-		if (type === 'string') return `'${value.replace(/'/g, "''")}'`;
-		if (type === 'object') return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
-		return '';
 	}
 
 }

--- a/src/lib/structures/Provider.js
+++ b/src/lib/structures/Provider.js
@@ -195,7 +195,7 @@ class Provider extends Piece {
 	 * Parse the gateway input for easier operation
 	 * @since 0.5.0
 	 * @param {ConfigurationUpdateResult} updated The updated entries
-	 * @returns {Array<any[]>}
+	 * @returns {Object<*>}
 	 * @protected
 	 */
 	parseGatewayInput(updated) {

--- a/src/lib/structures/Provider.js
+++ b/src/lib/structures/Provider.js
@@ -1,4 +1,5 @@
 const Piece = require('./base/Piece');
+const { mergeObjects, makeObject } = require('../util/util');
 const { join } = require('path');
 
 /**
@@ -8,23 +9,6 @@ const { join } = require('path');
  * @extends {Piece}
  */
 class Provider extends Piece {
-
-	/**
-	 * @typedef {PieceOptions} ProviderOptions
-	 */
-	constructor(...args) {
-		super(...args);
-
-		/**
-		 * If the provider provides to a sql data source
-		 * @since 0.0.1
-		 * @name Provider#sql
-		 * @type {boolean}
-		 * @readonly
-		 * @private
-		 */
-		Object.defineProperty(this, 'sql', { configurable: true, value: false });
-	}
 
 	/**
 	 * The createTable method which inserts/creates a new table to the database.
@@ -203,15 +187,21 @@ class Provider extends Piece {
 		// Reserved for SQL databases
 	}
 
+	async updateColumn() {
+		// Reserved for SQL databases
+	}
+
 	/**
-	 * Defines the JSON.stringify behavior of this provider.
-	 * @returns {Object}
+	 * Parse the gateway input for easier operation
+	 * @since 0.5.0
+	 * @param {ConfigurationUpdateResult} updated The updated entries
+	 * @returns {Array<any[]>}
+	 * @protected
 	 */
-	toJSON() {
-		return {
-			...super.toJSON(),
-			sql: this.sql
-		};
+	parseGatewayInput(updated) {
+		const updateObject = {};
+		for (const entry of updated) mergeObjects(updateObject, makeObject(entry.data[0], entry.data[1]));
+		return updateObject;
 	}
 
 }

--- a/src/lib/structures/SQLProvider.js
+++ b/src/lib/structures/SQLProvider.js
@@ -11,17 +11,11 @@ const { join } = require('path');
  */
 class SQLProvider extends Provider {
 
-	constructor(...args) {
-		super(...args);
-
-		Object.defineProperty(this, 'sql', { value: true });
-	}
-
 	/**
 	 * The addColumn method which inserts/creates a new table to the database.
 	 * @since 0.5.0
 	 * @param {string} table The table to check against
-	 * @param {Array<string[]>} columns An array of tuples keyed by [key, datatype] specifying the new columns
+	 * @param {(SchemaFolder | SchemaPiece)} piece The SchemaFolder or SchemaPiece added to the schema
 	 * @returns {*}
 	 * @abstract
 	 */
@@ -39,6 +33,42 @@ class SQLProvider extends Provider {
 	 */
 	async removeColumn() {
 		throw new Error(`[PROVIDERS] ${join(this.dir, ...this.file)} | Missing method 'removeColumn' of ${this.constructor.name}`);
+	}
+
+	/**
+	 * The updateColumn method which alters the datatype from a column.
+	 * @since 0.5.0
+	 * @param {string} table The table to check against
+	 * @param {SchemaPiece} piece The modified SchemaPiece
+	 * @returns {*}
+	 * @abstract
+	 */
+	async updateColumn() {
+		throw new Error(`[PROVIDERS] ${join(this.dir, ...this.file)} | Missing method 'updateColumn' of ${this.constructor.name}`);
+	}
+
+	/**
+	 * Parse the gateway input for easier operation
+	 * @since 0.5.0
+	 * @param {ConfigurationUpdateResult} updated The updated entries
+	 * @param {boolean} [resolve=true] Whether this should resolve the values using QueryBuider#resolve or not
+	 * @returns {Array<any[]>}
+	 * @protected
+	 */
+	parseGatewayInput(updated, resolve = true) {
+		const keys = new Array(updated.length), values = new Array(updated.length);
+
+		// If QueryBuilder is available, try to resolve the data
+		if (resolve && this.qb) {
+			for (let i = 0; i < updated.length; i++) {
+				const entry = updated[i];
+				[keys[i]] = entry.data;
+				values[i] = this.qb.resolve(entry.piece);
+			}
+		} else {
+			for (let i = 0; i < updated.length; i++) [keys[i], values[i]] = updated[i].data;
+		}
+		return [keys, values];
 	}
 
 	/**

--- a/src/lib/structures/SQLProvider.js
+++ b/src/lib/structures/SQLProvider.js
@@ -63,7 +63,7 @@ class SQLProvider extends Provider {
 			for (let i = 0; i < updated.length; i++) {
 				const entry = updated[i];
 				[keys[i]] = entry.data;
-				values[i] = this.qb.resolve(entry.piece);
+				values[i] = this.qb.resolve(entry.piece, entry.data[1]);
 			}
 		} else {
 			for (let i = 0; i < updated.length; i++) [keys[i], values[i]] = updated[i].data;

--- a/src/providers/json.js
+++ b/src/providers/json.js
@@ -157,16 +157,8 @@ module.exports = class extends Provider {
 	 * @param {Object} data The object with all properties you want to insert into the document
 	 * @returns {Promise<void>}
 	 */
-	create(table, document, data) {
-		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), util.mergeObjects({ id: document }, data));
-	}
-
-	set(...args) {
-		return this.create(...args);
-	}
-
-	insert(...args) {
-		return this.create(...args);
+	create(table, document, data = {}) {
+		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), util.mergeObjects({ id: document }, this.parseGatewayInput(data)));
 	}
 
 	/**
@@ -178,7 +170,7 @@ module.exports = class extends Provider {
 	 */
 	async update(table, document, data) {
 		const existent = await this.get(table, document);
-		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), util.mergeObjects(existent || { id: document }, data));
+		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), util.mergeObjects(existent || { id: document }, this.parseGatewayInput(data)));
 	}
 
 	/**
@@ -189,7 +181,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<void>}
 	 */
 	replace(table, document, data) {
-		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), data);
+		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), this.parseGatewayInput(data));
 	}
 
 	/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -761,6 +761,7 @@ declare module 'klasa' {
 		public abstract replace(table: string, entry: string, data: ConfigurationUpdateResultEntry[] | [string, any][] | ObjectLiteral<any>): Promise<any>;
 		public abstract update(table: string, entry: string, data: ConfigurationUpdateResultEntry[] | [string, any][] | ObjectLiteral<any>): Promise<any>;
 		public abstract updateValue(table: string, path: string, newValue: any): Promise<any>;
+		protected parseGatewayInput<T = ObjectLiteral<any>>(updated: ConfigurationUpdateResult): T;
 
 		public shutdown(): Promise<void>;
 		public toJSON(): PieceProviderJSON;
@@ -770,6 +771,7 @@ declare module 'klasa' {
 		public abstract addColumn(table: string, columns: SchemaFolder | SchemaPiece): Promise<any>;
 		public abstract removeColumn(table: string, columns: string | string[]): Promise<any>;
 		public abstract updateColumn(table: string, piece: SchemaPiece): Promise<any>;
+		protected parseGatewayInput<T = [string, any]>(updated: ConfigurationUpdateResult): T;
 		protected parseEntry<T = ObjectLiteral<any>>(gateway: string | Gateway, entry: ObjectLiteral<any>): T;
 		protected parseValue<T = any>(value: any, schemaPiece: SchemaPiece): T;
 	}


### PR DESCRIPTION
### Description of the PR

As requested for a long time, **ALL** SQL state has been removed without track from the entire SettingGateway code. **ALL** of it has been moved to providers, and **ALL** providers shall update to support the new code.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- QueryBuilder
- `Provider#parseGatewayInput`
- `SQLProvider#updateColumn`
- `SQLProvider#parseGatewayInput`

**Modified**:

- Made `new Gateway()` public for developer usage.

**Removed**:

- `SchemaPiece#sqlSchema` and `SchemaFolder#sqlSchema`
- `SchemaPiece#sql`
- `SchemaPiece#_generateSQLDatatype`
- `SchemaPiece._parseSQLValue`
- `Provider#sql`
- `SQLProvider#sql`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
