### PR TITLE
Fix broken language message

### DIFF
--- a/src/arguments/message.js
+++ b/src/arguments/message.js
@@ -9,7 +9,7 @@ module.exports = class extends Argument {
 	async run(arg, possible, message) {
 		const msg = this.constructor.regex.snowflake.test(arg) ? await message.channel.messages.fetch(arg).catch(() => null) : undefined;
 		if (msg) return msg;
-		throw (message.language || this.client.languages.default).get('RESOLVER_INVALID_message', possible.name);
+		throw (message.language || this.client.languages.default).get('RESOLVER_INVALID_MESSAGE', possible.name);
 	}
 
 };

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -17,7 +17,7 @@ module.exports = class extends Language {
 			SETTING_GATEWAY_INVALID_TYPE: 'The type parameter must be either add or remove.',
 			RESOLVER_INVALID_CUSTOM: (name, type) => `${name} must be a valid ${type}.`,
 			RESOLVER_INVALID_PIECE: (name, piece) => `${name} must be a valid ${piece} name.`,
-			RESOLVER_INVALID_MSG: (name) => `${name} must be a valid message id.`,
+			RESOLVER_INVALID_MESSAGE: (name) => `${name} must be a valid message id.`,
 			RESOLVER_INVALID_USER: (name) => `${name} must be a mention or valid user id.`,
 			RESOLVER_INVALID_MEMBER: (name) => `${name} must be a mention or valid user id.`,
 			RESOLVER_INVALID_CHANNEL: (name) => `${name} must be a channel tag or valid channel id.`,


### PR DESCRIPTION
### Description of the PR

This broke when everything got changed from msg -> message, also updated the language to be MESSAGE instead of MSG

![mnxfon9](https://user-images.githubusercontent.com/30398469/39969304-2343adce-571d-11e8-8e6f-b6f43644a54a.png)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [X] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
