### PR TITLE
SG Auto-Resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#401](https://github.com/dirigeants/klasa/pull/401)] Removed `Settings#waitSync` in favor of `Settings#sync(?false);`. (kyranet)
 - [[#398](https://github.com/dirigeants/klasa/pull/398)] Removed the `Settings#update(keys: string[], values: any[])` overload. (kyranet)
 - [[#391](https://github.com/dirigeants/klasa/pull/391)] Removed `Util.getIdentifier()`. (kyranet)
 - [[#391](https://github.com/dirigeants/klasa/pull/391)] Removed Gateways' second caching layer. (kyranet)

--- a/src/lib/schedule/ScheduledTask.js
+++ b/src/lib/schedule/ScheduledTask.js
@@ -71,7 +71,7 @@ class ScheduledTask {
 		/**
 		 * The Date when this scheduled task ends
 		 * @since 0.5.0
-		 * @type {?Date}
+		 * @type {Date}
 		 */
 		this.time = 'time' in options ? new Date(options.time) : _time;
 
@@ -233,7 +233,7 @@ class ScheduledTask {
 	 * @private
 	 */
 	static _generateID(client) {
-		return Date.now().toString(36) + (client.shard ? client.shard.id.toString(36) : '') + String.fromCharCode((1 % 26) + 97);
+		return Date.now().toString(36) + (client.shard ? client.shard.id.toString(36) : '');
 	}
 
 	/**
@@ -245,6 +245,7 @@ class ScheduledTask {
 	static _validate(st) {
 		if (!st.task) throw new Error('invalid task');
 		if (!st.time) throw new Error('time or repeat option required');
+		if (Number.isNaN(st.time.getTime())) throw new Error('invalid time passed');
 	}
 
 }

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -72,7 +72,7 @@ class Gateway extends GatewayStorage {
 		if (entry) return entry.settings;
 		if (create) {
 			const settings = new this.Settings(this, { id });
-			if (this._synced && this.schema.size) settings.sync().catch(err => this.client.emit('error', err));
+			if (this._synced && this.schema.size) settings.sync(true).catch(err => this.client.emit('error', err));
 			return settings;
 		}
 		return null;
@@ -105,7 +105,7 @@ class Gateway extends GatewayStorage {
 		}
 
 		const cache = this.get((input && input.id) || input);
-		return cache ? cache.sync() : null;
+		return cache ? cache.sync(true) : null;
 	}
 
 }

--- a/src/lib/settings/GatewayStorage.js
+++ b/src/lib/settings/GatewayStorage.js
@@ -162,7 +162,7 @@ class GatewayStorage {
 		const columns = await provider.getColumns(this.type);
 		if (columns.length) {
 			const promises = [];
-			for (const [key, piece] of this.schema.paths) if (!columns.includes(key)) promises.push(provider.addColumn(key, piece));
+			for (const [key, piece] of this.schema.paths) if (!columns.includes(key)) promises.push(provider.addColumn(this.type, piece));
 			await Promise.all(promises);
 		}
 	}

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -384,7 +384,7 @@ class Settings {
 		if (piece.array) {
 			this._parseArray(piece, route, parsedID, options, result);
 		} else if (this._setValueByPath(piece, parsedID, options.force).updated) {
-			result.updated.push({ data: [piece.path, parsedID.id || parsedID], piece });
+			result.updated.push({ data: [piece.path, parsedID.id || parsedID.name || parsedID], piece });
 		}
 	}
 
@@ -421,7 +421,7 @@ class Settings {
 		if (action === 'overwrite') {
 			if (!Array.isArray(parsed)) parsed = [parsed];
 			if (this._setValueByPath(piece, parsed, force).updated) {
-				updated.push({ data: [piece.path, parsed.id || parsed], piece });
+				updated.push({ data: [piece.path, parsed.id || parsed.name || parsed], piece });
 			}
 			return;
 		}
@@ -431,7 +431,7 @@ class Settings {
 			else array[arrayPosition] = parsed;
 		} else {
 			for (let value of Array.isArray(parsed) ? parsed : [parsed]) {
-				value = piece.resolve ? value : value.id;
+				value = piece.resolve ? value : value.id || value.name || value;
 				const index = array.indexOf(value);
 				if (action === 'auto') {
 					if (index === -1) array.push(value);
@@ -447,8 +447,8 @@ class Settings {
 			}
 		}
 
-		// Flatten array down to id where possible so that database only stores the array here
-		updated.push({ data: [piece.path, array.map(value => value.id || value)], piece });
+		// Flatten array down to id/name where possible so that database only stores the array here
+		updated.push({ data: [piece.path, array.map(value => value.id || value.name || value)], piece });
 	}
 
 	/**
@@ -489,7 +489,7 @@ class Settings {
 		// If both parts are equal, don't update
 		if (!force && (piece.array ? arraysStrictEquals(old, parsedID) : old === parsedID)) return { updated: false, old };
 
-		cache[lastKey] = piece.resolve ? parsedID : parsedID.id;
+		cache[lastKey] = piece.resolve ? parsedID : parsedID.id || parsedID.name;
 		return { updated: true, old };
 	}
 
@@ -518,7 +518,7 @@ class Settings {
 	 * @returns {SettingsJSON}
 	 */
 	toJSON() {
-		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key].id || this[key]) })));
+		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key].id || this[key].name || this[key]) })));
 	}
 
 	/**

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -133,10 +133,15 @@ class Settings {
 		if (!force || syncStatus) return syncStatus || Promise.resolve(this);
 
 		// If it's not currently synchronizing, create a new sync status for the sync queue
-		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(data => {
+		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(async data => {
 			if (data) {
 				if (!this._existsInDB) this._existsInDB = true;
-				this._patch(data);
+				if (this.gateway.schema.shouldResolve()) {
+					const resolved = await this.gateway.schema.resolve(data);
+					this._patch(resolved);
+				} else {
+					this._patch(data);
+				}
 			} else {
 				this._existsInDB = false;
 			}

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -136,7 +136,7 @@ class Settings {
 		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(async data => {
 			if (data) {
 				if (!this._existsInDB) this._existsInDB = true;
-				if (this.gateway.schema.shouldResolve()) {
+				if (this.gateway.schema.shouldResolve) {
 					const resolved = await this.gateway.schema.resolve(data);
 					this._patch(resolved);
 				} else {

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -122,23 +122,15 @@ class Settings {
 	}
 
 	/**
-	 * Wait for the sync
-	 * @since 0.5.0
-	 * @returns {Promise<this>}
-	 */
-	waitSync() {
-		return this.gateway.syncQueue.get(this.id) || Promise.resolve(this);
-	}
-
-	/**
 	 * Sync the data from the database with the cache.
 	 * @since 0.5.0
+	 * @param {boolean} [force=false] Whether the sync should download from the database
 	 * @returns {Promise<this>}
 	 */
-	sync() {
+	sync(force = false) {
 		// Await current sync status from the sync queue
 		const syncStatus = this.gateway.syncQueue.get(this.id);
-		if (syncStatus) return syncStatus;
+		if (!force || syncStatus) return syncStatus || Promise.resolve(this);
 
 		// If it's not currently synchronizing, create a new sync status for the sync queue
 		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(data => {
@@ -399,7 +391,7 @@ class Settings {
 	 */
 	async _save({ updated }) {
 		if (!updated.length) return;
-		if (this._existsInDB === null) await this.sync();
+		if (this._existsInDB === null) await this.sync(true);
 		if (this._existsInDB === false) {
 			await this.gateway.provider.create(this.gateway.type, this.id);
 			this._existsInDB = true;

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -516,7 +516,7 @@ class Settings {
 	 * @returns {SettingsJSON}
 	 */
 	toJSON() {
-		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key]) })));
+		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key].id || this[key]) })));
 	}
 
 	/**

--- a/src/lib/settings/schema/Base.js
+++ b/src/lib/settings/schema/Base.js
@@ -138,8 +138,8 @@ class Base extends Map {
 				const piece = this.get(this.path ? `${this.path}.${key}` : key);
 				if (piece.type === 'Folder') return { [key]: await piece.resolve(data) };
 				if (!piece.resolve) return data;
-				if (piece.array) return { [key]: await Promise.all(data.map(dat => piece.parse(dat, guild))) };
-				return { [key]: await piece.parse(data, guild) };
+				if (piece.array) return { [key]: await Promise.all(data.map(dat => piece.autoResolve(dat, guild))) };
+				return { [key]: await piece.autoResolve(data, guild) };
 			}));
 		return Object.assign({}, ...resolved);
 	}

--- a/src/lib/settings/schema/Base.js
+++ b/src/lib/settings/schema/Base.js
@@ -119,8 +119,9 @@ class Base extends Map {
 	 * @readonly
 	 * @returns {boolean}
 	 */
-	shouldResolve() {
-		return [...this.values()].some(piece => piece.type === 'Folder' ? piece.shouldResolve() : piece.resolve);
+	get shouldResolve() {
+		for (const piece of this.values(true)) if (piece.resolve) return true;
+		return false;
 	}
 
 	/**

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -190,7 +190,7 @@ class SchemaPiece {
 	 */
 	async parse(value, guild) {
 		const language = guild ? guild.language : this.client.languages.default;
-		const val = await this.resolver.resolve(value, this, language, guild);
+		const val = await this.resolver.resolve(value, this, language, guild).then(data => data.id || data);
 		if (this.filter && this.filter(this.client, val, this, language)) throw language.get('SETTING_GATEWAY_INVALID_FILTERED_VALUE', this, value);
 		return val;
 	}

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -197,12 +197,7 @@ class SchemaPiece {
 
 	async autoResolve(value, guild) {
 		const language = guild ? guild.language : this.client.languages.default;
-		let val;
-		try {
-			val = await this.resolver.resolve(value, this, language, guild);
-		} catch (error) {
-			val = null;
-		}
+		const val = await this.resolver.resolve(value, this, language, guild).catch(() => null);
 		if (val === null) return null;
 		if (this.filter && this.filter(this.client, val, this, language)) throw language.get('SETTING_GATEWAY_INVALID_FILTERED_VALUE', this, value);
 		return val;

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -190,7 +190,7 @@ class SchemaPiece {
 	 */
 	async parse(value, guild) {
 		const language = guild ? guild.language : this.client.languages.default;
-		const val = await this.resolver.resolve(value, this, language, guild).then(data => data.id || data);
+		const val = await this.resolver.resolve(value, this, language, guild);
 		if (this.filter && this.filter(this.client, val, this, language)) throw language.get('SETTING_GATEWAY_INVALID_FILTERED_VALUE', this, value);
 		return val;
 	}

--- a/src/lib/settings/schema/types/Channel.js
+++ b/src/lib/settings/schema/types/Channel.js
@@ -39,7 +39,7 @@ class ChannelType extends SchemaType {
 			(piece.type === 'textchannel' && data.type === 'text') ||
 			(piece.type === 'voicechannel' && data.type === 'voice') ||
 			(piece.type === 'categorychannel' && data.type === 'category')
-		) return piece.resolve ? data : data.id;
+		) return data;
 		throw language.get('RESOLVER_INVALID_CHANNEL', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Channel.js
+++ b/src/lib/settings/schema/types/Channel.js
@@ -39,7 +39,7 @@ class ChannelType extends SchemaType {
 			(piece.type === 'textchannel' && data.type === 'text') ||
 			(piece.type === 'voicechannel' && data.type === 'voice') ||
 			(piece.type === 'categorychannel' && data.type === 'category')
-		) return data.id;
+		) return piece.resolve ? data : data.id;
 		throw language.get('RESOLVER_INVALID_CHANNEL', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Guild.js
+++ b/src/lib/settings/schema/types/Guild.js
@@ -20,7 +20,7 @@ class GuildType extends SchemaType {
 	async resolve(data, piece, language) {
 		if (data instanceof Guild) return data.id;
 		const guild = this.constructor.regex.snowflake.test(data) ? this.client.guilds.get(data) : null;
-		if (guild) return piece.resolve ? guild : guild.id;
+		if (guild) return guild;
 		throw language.get('RESOLVER_INVALID_GUILD', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Guild.js
+++ b/src/lib/settings/schema/types/Guild.js
@@ -20,7 +20,7 @@ class GuildType extends SchemaType {
 	async resolve(data, piece, language) {
 		if (data instanceof Guild) return data.id;
 		const guild = this.constructor.regex.snowflake.test(data) ? this.client.guilds.get(data) : null;
-		if (guild) return guild.id;
+		if (guild) return piece.resolve ? guild : guild.id;
 		throw language.get('RESOLVER_INVALID_GUILD', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Piece.js
+++ b/src/lib/settings/schema/types/Piece.js
@@ -19,7 +19,7 @@ class PieceType extends SchemaType {
 	async resolve(data, piece, language) {
 		const store = this.client[`${piece.type}s`];
 		const parsed = typeof data === 'string' ? store.get(data) : data;
-		if (parsed && parsed instanceof store.holds) return piece.resolve ? parsed : parsed.name;
+		if (parsed && parsed instanceof store.holds) return parsed;
 		throw language.get('RESOLVER_INVALID_PIECE', piece.key, piece.type);
 	}
 

--- a/src/lib/settings/schema/types/Piece.js
+++ b/src/lib/settings/schema/types/Piece.js
@@ -19,7 +19,7 @@ class PieceType extends SchemaType {
 	async resolve(data, piece, language) {
 		const store = this.client[`${piece.type}s`];
 		const parsed = typeof data === 'string' ? store.get(data) : data;
-		if (parsed && parsed instanceof store.holds) return parsed.name;
+		if (parsed && parsed instanceof store.holds) return piece.resolve ? parsed : parsed.name;
 		throw language.get('RESOLVER_INVALID_PIECE', piece.key, piece.type);
 	}
 

--- a/src/lib/settings/schema/types/Role.js
+++ b/src/lib/settings/schema/types/Role.js
@@ -22,7 +22,7 @@ class RoleType extends SchemaType {
 		if (!guild) throw this.client.languages.default.get('RESOLVER_INVALID_GUILD', piece.key);
 		if (data instanceof Role) return data.id;
 		const role = this.constructor.regex.role.test(data) ? guild.roles.get(data) : guild.roles.find(rol => rol.name === data) || null;
-		if (role) return role.id;
+		if (role) return piece.resolve ? role : role.id;
 		throw language.get('RESOLVER_INVALID_ROLE', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Role.js
+++ b/src/lib/settings/schema/types/Role.js
@@ -20,9 +20,9 @@ class RoleType extends SchemaType {
 	 */
 	async resolve(data, piece, language, guild) {
 		if (!guild) throw this.client.languages.default.get('RESOLVER_INVALID_GUILD', piece.key);
-		if (data instanceof Role) return data.id;
+		if (data instanceof Role) return data;
 		const role = this.constructor.regex.role.test(data) ? guild.roles.get(data) : guild.roles.find(rol => rol.name === data) || null;
-		if (role) return piece.resolve ? role : role.id;
+		if (role) return role;
 		throw language.get('RESOLVER_INVALID_ROLE', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/User.js
+++ b/src/lib/settings/schema/types/User.js
@@ -18,9 +18,9 @@ class UserType extends SchemaType {
 	 */
 	async resolve(data, piece, language) {
 		let user = this.client.users.resolve(data);
-		if (user) return piece.resolve ? user : user.id;
+		if (user) return user;
 		if (this.constructor.regex.userOrMember.test(data)) user = await this.client.users.fetch(this.constructor.regex.userOrMember.exec(data)[1]).catch(() => null);
-		if (user) return piece.resolve ? user : user.id;
+		if (user) return user;
 		throw language.get('RESOLVER_INVALID_USER', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/User.js
+++ b/src/lib/settings/schema/types/User.js
@@ -18,9 +18,9 @@ class UserType extends SchemaType {
 	 */
 	async resolve(data, piece, language) {
 		let user = this.client.users.resolve(data);
-		if (user) return user.id;
+		if (user) return piece.resolve ? user : user.id;
 		if (this.constructor.regex.userOrMember.test(data)) user = await this.client.users.fetch(this.constructor.regex.userOrMember.exec(data)[1]).catch(() => null);
-		if (user) return user.id;
+		if (user) return piece.resolve ? user : user.id;
 		throw language.get('RESOLVER_INVALID_USER', piece.key);
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -461,8 +461,7 @@ declare module 'klasa' {
 
 		public get<T = any>(path: string | string[]): T;
 		public clone(): Settings;
-		public sync(): Promise<this>;
-		public waitSync(): Promise<this>;
+		public sync(force?: boolean): Promise<this>;
 		public destroy(): Promise<this>;
 
 		public reset(key?: string | string[], options?: SettingsResetOptions): Promise<SettingsUpdateResult>;


### PR DESCRIPTION
### Description of the PR
Adds the functionality for creating and resolving configurations automatically. This option is disabled by default, and can be enabled via SchemaPiece#resolve. Klasa will automatically resolve any and all resolvable values from the Schema (where possible).

Current implementation is merely a concept that needs to be built upon because the current code is somewhat ugly (SettingResolver in particular).

Syncing in SG should probably get a rewrite with this as well because it's currently horrendous. SG should automatically sync, and outside sources can fetch && sync at the same time if necessary. This can also add room for Configuration#synced to determine whether or not it's up to date with the database.

A lot of documentation also needs to be added still.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Adds Configuation#resolve(data) => Takes SG data and turns into a fully resolved object

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
