### PR TITLE
fix(Loader): CommonJS modules appending duplicated modules on reload

### DIFF
--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -90,15 +90,15 @@ class Store extends Collection {
 		const loc = join(dir, ...file);
 		let piece = null;
 		try {
-			const mod = require.cache[require.resolve(loc)];
+			const mod = require.cache[loc];
 			const Piece = (req => req.default || req)(require(loc));
 			if (!isClass(Piece)) throw new TypeError(`Failed to load file '${loc}'. The exported structure is not a class.`);
 			piece = this.set(new Piece(this.client, this, file, core));
 
 			// If the mod was previously loaded (piece reload), remove it from the cache
 			if (mod) {
-				const index = mod.parent.children.indexOf(mod);
-				if (index !== -1) mod.parent.children.splice(index, 1);
+				const index = module.children.indexOf(mod);
+				if (index !== -1) module.children.splice(index, 1);
 			}
 		} catch (error) {
 			this.client.emit('wtf', `Failed to load file '${loc}'. Error:\n${error.stack || error}`);

--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -90,9 +90,16 @@ class Store extends Collection {
 		const loc = join(dir, ...file);
 		let piece = null;
 		try {
+			const mod = require.cache[require.resolve(loc)];
 			const Piece = (req => req.default || req)(require(loc));
 			if (!isClass(Piece)) throw new TypeError(`Failed to load file '${loc}'. The exported structure is not a class.`);
 			piece = this.set(new Piece(this.client, this, file, core));
+
+			// If the mod was previously loaded (piece reload), remove it from the cache
+			if (mod) {
+				const index = mod.parent.children.indexOf(mod);
+				if (index !== -1) mod.parent.children.splice(index, 1);
+			}
 		} catch (error) {
 			this.client.emit('wtf', `Failed to load file '${loc}'. Error:\n${error.stack || error}`);
 		}


### PR DESCRIPTION
### Description of the PR

When a CommonJS module loads another, it appends the `Module` instance inside `module.children`. But when you reload the same module, the old module is not replaced, but rather duplicated, causing a memory leak.

This PR fixes that issue by removing the old module (if it exists).

Thanks @cthuluhoop123 for pointing it out in https://github.com/AnIdiotsGuide/guidebot/pull/46

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Remove the old module from `Module#children`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
