### PR TITLE
SG: Rename `$NAME_Schema.json` to `$NAME.schema.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#320](https://github.com/dirigeants/klasa/pull/320)] **[BREAKING]** Changed the schema file names. (KingDGrizzle)
 - [[#299](https://github.com/dirigeants/klasa/pull/299)] Escape strings from initClean. (KingDGrizzle)
 - [[#272](https://github.com/dirigeants/klasa/pull/272)] Changed `Monitor#shouldRun` to accept a single argument. (bdistin)
 - [[#256](https://github.com/dirigeants/klasa/pull/256)] **[BREAKING]** Modified all SettingResolvers to resolve to primitives (string, number, boolean...) or storable data. (kyranet)

--- a/src/lib/settings/GatewayStorage.js
+++ b/src/lib/settings/GatewayStorage.js
@@ -56,7 +56,7 @@ class GatewayStorage {
 		 * @type {string}
 		 * @readonly
 		 */
-		Object.defineProperty(this, 'filePath', { value: resolve(this.baseDir, `${this.type}_Schema.json`) });
+		Object.defineProperty(this, 'filePath', { value: resolve(this.baseDir, `${this.type}.schema.json`) });
 
 		/**
 		 * @since 0.5.0


### PR DESCRIPTION
### Description of the PR
As of [this](https://github.com/dirigeants/klasa/projects/1#card-10071329) project card, the schema files will now be named `{type}.schema.json`, where type is the gateway name. (guilds, users, clientStorage, etc).

This PR does the change. 

It's been discussed if we should have a fallback. Copying from kyra,
```prolog
1. Let $NAME be the Gateway's name
2. Attempt fsn.read('$NAME.schema.json');
    2.1. If it fullfills
        2.1.1. Let `readData` be the output from `2`
        2.1.2. Load `readData` as the gateway's schema. Otherwise, if `2` rejected,
    2.2. attempt fsn.read('$NAME_Schema.json');
        2.2.1. If it fullfills,
            2.2.1.1. call fsn.copy('$NAME_Schema.json', '$NAME.schema.json');
            2.2.1.2. Let `data` be the output from `2.2.1`
            2.2.1.3. Load `data` as the gateway's schema. Otherwise, if `2.2` rejected,
        2.2.2. Let `defaultSchema` be $NAME's default schema
            2.2.2.1. call fsn.writeJSONAtomic('$NAME.schema.json', defaultSchema);
            2.2.2.2. Load `defaultSchema` as the gateway's schema.
```

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change the name of schema json files.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
