### PR TITLE
Make Store.walk() resolve '.ts' files as well

### DIFF
--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -169,7 +169,7 @@ class Store extends Collection {
 	 */
 	static async walk(store, core = false) {
 		const dir = core ? store.coreDir : store.userDir;
-		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && extname(path) === '.js' }).catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
+		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && ['.js', '.ts'].indexOf(extname(path)) !== -1 }).catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
 		if (!files) return true;
 
 		return Promise.all([...files.keys()].map(file => store.load(relative(dir, file).split(sep), core)));


### PR DESCRIPTION
### Description of the PR
Stores walk their dictionaries and load all '.js' files as pieces. This pull request make them load '.ts' files as well.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)
- Patch Store to load '.ts' files

### Semver Classification
Minor patch

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
