### PR TITLE
Make all props in ColorsFormatOptions optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1688,9 +1688,9 @@ declare module 'klasa' {
 	};
 
 	export type ColorsFormatOptions = {
-		background: string | number | string[];
-		style: string | string[];
-		text: string | number | string[]
+		background?: string | number | string[];
+		style?: string | string[];
+		text?: string | number | string[]
 	};
 
 	export type ColorsFormatType = string | number | [string, string, string] | [number, number, number];


### PR DESCRIPTION
### Description of the PR
fixes `Argument of type '{ text: string; }' is not assignable to parameter of type 'ColorsFormatOptions'.
  Property 'background' is missing in type '{ text: string; }'.` 

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
