### PR TITLE
[RFC] Gateway syncQueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#331](https://github.com/dirigeants/klasa/pull/331)] Added `Gateway#syncQueue` for centralized lazy load cache and memory reduction. (kyranet)
+- [[#331](https://github.com/dirigeants/klasa/pull/331)] Added `Configuration#synchronizing` getter to check whether a Configuration instance is lazy loading or not. (kyranet)
 - [[#284](https://github.com/dirigeants/klasa/pull/284)] Added `Util.chunk`. (bdistin)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Added `Util.isPrimitive`. (kyranet)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Added `constants.DEFAULTS.QUERYBUILDER`. (kyranet)
@@ -197,6 +199,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#331](https://github.com/dirigeants/klasa/pull/331)] Removed `Configuration#_syncStatus`. (kyranet)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Removed `GatewayGuildResolvable` type from typings. (kyranet)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Removed `JSONProvider#set` and `JSONProvider#insert`. (kyranet)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Removed `Provider#sql` and `SQLProvider#sql`. (kyranet)

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -118,8 +118,7 @@ class Configuration {
 	 * @returns {Promise<this>}
 	 */
 	waitSync() {
-		const syncStatus = this.gateway.syncQueue.get(this.id);
-		return syncStatus || Promise.resolve(this);
+		return this.gateway.syncQueue.get(this.id) || Promise.resolve(this);
 	}
 
 	/**

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -126,7 +126,7 @@ class Configuration {
 	 * @since 0.5.0
 	 * @returns {this}
 	 */
-	async sync() {
+	sync() {
 		// Await current sync status from the sync queue
 		const syncStatus = this.gateway.syncQueue.get(this.id);
 		if (syncStatus) return syncStatus;

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -124,7 +124,7 @@ class Configuration {
 	/**
 	 * Sync the data from the database with the cache.
 	 * @since 0.5.0
-	 * @returns {this}
+	 * @returns {Promise<this>}
 	 */
 	sync() {
 		// Await current sync status from the sync queue

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -46,16 +46,25 @@ class Gateway extends GatewayStorage {
 		super(store.client, type, provider);
 
 		/**
+		 * The GatewayDriver that manages this Gateway
 		 * @since 0.0.1
 		 * @type {GatewayDriver}
 		 */
 		this.store = store;
 
 		/**
+		 * The cached entries for this Gateway
 		 * @since 0.0.1
 		 * @type {external:Collection<string, Configuration>}
 		 */
 		this.cache = new Collection();
+
+		/**
+		 * The synchronization queue for all Configuration instances
+		 * @since 0.5.0
+		 * @type {external:Collection<string, Promise<Configuration>>}
+		 */
+		this.syncQueue = new Collection();
 
 		/**
 		 * @since 0.5.0

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -445,8 +445,8 @@ declare module 'klasa' {
 		public readonly client: KlasaClient;
 		public readonly gateway: Gateway;
 		public readonly id: string;
+		public readonly synchronizing: boolean;
 		private _existsInDB: boolean;
-		private _syncStatus?: Promise<void>;
 
 		public get(key: string): any;
 		public get<T>(key: string): T;
@@ -487,6 +487,7 @@ declare module 'klasa' {
 		public defaultSchema: object;
 		public readonly resolver: SettingResolver;
 		public readonly cache: Collection<string, Configuration>;
+		public readonly syncQueue: Collection<string, Promise<Configuration>>;
 
 		public get(input: string | number, create?: boolean): Configuration;
 		public sync(input?: object | string): Promise<Configuration>;


### PR DESCRIPTION
### Description of the PR

Since lazy loading exists in SettingsGateway, a `Configuration#_syncStatus` was made to hold the sync Promise, however, this was present in all Configuration instances, resulting on a slight memory increase. This PR refactors this and moves all synchronization status into `Gateway#syncQueue` and removes `Configuration#_syncStatus`.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- Added `Gateway#syncQueue` for centralized lazy load cache and memory reduction.
- Added `Configuration#synchronizing` getter to check whether a Configuration instance is lazy loading or not.

**Removed**:

- Removed `Configuration#_syncStatus`.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
