### PR TITLE
[RFC] Configuration#reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#332](https://github.com/dirigeants/klasa/pull/332)] Refactored `Configuration#reset`. (kyranet)
 - [[#320](https://github.com/dirigeants/klasa/pull/320)] **[BREAKING]** Changed the schema file names. (KingDGrizzle)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Changed `SQLProvider#createTable`. SettingsGateway will not provide columns, for consistency with JSON providers. Instead, retrieve the columns from `Gateway`. (kyranet)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Changed `SQLProvider#addColumn` to have the arguments `table: string, columns: SchemaFolder | SchemaPiece`. (kyranet)

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -176,9 +176,7 @@ class Configuration {
 		else if (typeof keys === 'undefined') keys = [...this.gateway.schema.values(true)].map(piece => piece.path);
 		if (Array.isArray(keys)) {
 			const result = { errors: [], updated: [] };
-			const entries = new Array(keys.length);
-			for (let i = 0; i < keys.length; i++) entries[i] = [keys[i], null];
-			for (const [key, value] of entries) {
+			for (const key of keys) {
 				const path = this.gateway.getPath(key, { piece: true, avoidUnconfigurable, errors: false });
 				if (!path) {
 					result.errors.push(guild && guild.language ?
@@ -186,8 +184,8 @@ class Configuration {
 						`The path ${key} does not exist in the current schema, or does not correspond to a piece.`);
 					continue;
 				}
-				const newValue = value === null ? deepClone(path.piece.default) : value;
-				if (this._setValueByPath(path.piece, newValue, force).updated) result.updated.push({ data: [path.piece.path, newValue], piece: path.piece });
+				const value = deepClone(path.piece.default);
+				if (this._setValueByPath(path.piece, value, force).updated) result.updated.push({ data: [path.piece.path, value], piece: path.piece });
 			}
 			await this._save(result);
 			return result;


### PR DESCRIPTION
### Description of the PR

This PR fixes a possible copypaste of the `Configuration#reset` method by removing useless checks and a useless check.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Refactored `Configuration#reset` for performance.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
