### PR TITLE
[RFC] Faster cross-shard synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#333](https://github.com/dirigeants/klasa/pull/333)] Removed cross-shard individual configuration synchronization in favor of patching the current patched `Configuration` instance. (kyranet)
+- [[#333](https://github.com/dirigeants/klasa/pull/333)] Changed `configUpdateEntry` event to take only two parameters (patched `Configuration` instance, and the updated keys as `ConfigurationUpdateResultEntry[]`). (kyranet)
 - [[#320](https://github.com/dirigeants/klasa/pull/320)] **[BREAKING]** Changed the schema file names. (KingDGrizzle)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Changed `SQLProvider#createTable`. SettingsGateway will not provide columns, for consistency with JSON providers. Instead, retrieve the columns from `Gateway`. (kyranet)
 - [[#306](https://github.com/dirigeants/klasa/pull/306)] Changed `SQLProvider#addColumn` to have the arguments `table: string, columns: SchemaFolder | SchemaPiece`. (kyranet)

--- a/src/events/configUpdateEntry.js
+++ b/src/events/configUpdateEntry.js
@@ -1,20 +1,14 @@
 const { Event } = require('klasa');
+const gateways = ['users', 'clientStorage'];
 
 module.exports = class extends Event {
 
 	run(configs) {
-		if (!this.client.shard) return;
-		if (configs.gateway.type === 'users') {
+		if (this.client.shard && gateways.includes(configs.gateway.type)) {
 			this.client.shard.broadcastEval(`
 				if (this.shard.id !== ${this.client.shard.id}) {
-					const user = this.users.get('${configs.id}');
-					if (user) user.configs.sync();
-				}
-			`);
-		} else if (configs.gateway.type === 'clientStorage') {
-			this.client.shard.broadcastEval(`
-				if (this.shard.id !== ${this.client.shard.id}) {
-					this.configs.sync();
+					const entry = this.gateways.${configs.gateway.type}.cache.get('${configs.id}');
+					if (entry) entry._patch(${JSON.stringify(configs)});
 				}
 			`);
 		}

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -546,9 +546,8 @@ KlasaClient.defaultPermissionLevels = new PermissionLevels()
  * Emitted when {@link Configuration#update} or {@link Configuration#reset} is run.
  * @event KlasaClient#configUpdateEntry
  * @since 0.5.0
- * @param {Configuration} oldEntry The old configuration entry
- * @param {Configuration} newEntry The new configuration entry
- * @param {ConfigurationUpdateResultEntry[]} path The path of the key which changed
+ * @param {Configuration} entry The patched configuration entry
+ * @param {ConfigurationUpdateResultEntry[]} updated The keys that were updated
  */
 
 /**

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -443,10 +443,9 @@ class Configuration {
 			this._existsInDB = true;
 			if (this.client.listenerCount('configCreateEntry')) this.client.emit('configCreateEntry', this);
 		}
-		const oldClone = this.client.listenerCount('configUpdateEntry') ? this.clone() : null;
 
 		await this.gateway.provider.update(this.gateway.type, this.id, updated);
-		if (oldClone !== null) this.client.emit('configUpdateEntry', oldClone, this, updated);
+		if (this.client.listenerCount('configUpdateEntry')) this.client.emit('configUpdateEntry', this, updated);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR

For quite a while, the `configUpdateEntry` event was not exactly working properly: the supposed "oldValue" is a patched clone of "newValue". This PR fixes that and removes the "oldValue", removing with it the cost of cloning complex Configuration instances. To check differences, one should use the second argument, `updated`, which is type of `ConfigurationUpdateResultEntry[]` and tells the difference more accurately.

And in this same PR, I have refactored the cross-shard synchronization so if a bot has 20 shards, and a user is in all of them, it wouldn't query the database 20 times (once in each shards), but instead, it'd patch the current configuration instance, that way only one database query is done on cross-shard synchronization.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Changed**:

- Removed cross-shard individual configuration synchronization in favor of patching the current patched `Configuration` instance.
- Changed `configUpdateEntry` event to take only two parameters (patched `Configuration` instance, and the updated keys as `ConfigurationUpdateResultEntry[]`).

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
