### PR TITLE
docs: Muh templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,6 @@ follow up.
 
 ### Expected and actual behaviour
 
-
 ### Further details
 
 - **discord.js version**:

--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -1,6 +1,6 @@
 ---
 name: Submit an issue
-about: Describe us an issue you've received with Klasa
+about: Describe us an issue you've received with Klasa.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -1,0 +1,35 @@
+---
+name: Submit an issue
+about: Describe us an issue you've received with Klasa
+
+---
+
+<!--
+If you need help with Klasa, please go to the Dirigeants Discord instead:
+  https://discord.gg/FpEFSyY
+This issue tracker is only for issue reports and proposals. You won't receive any basic help here.
+-->
+
+### Describe the issue
+
+### Code or steps to reproduce
+
+```js
+
+```
+
+### Expected and actual behaviour
+
+<!--
+Fill in any of the values that are applicable to your issue.
+If your issue isn't affected by any of the values here, don't fill them in.
+If you are using the master version of Klasa, make sure you provide the commit hash.
+-->
+
+### Further details
+
+- **discord.js version**:
+- **node.js version**:
+- **Klasa version**:
+- [ ] I have modified core files.
+- [ ] I have tested the issue on latest master. Commit hash:

--- a/.github/ISSUE_TEMPLATE/PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/PROPOSAL.md
@@ -1,0 +1,13 @@
+---
+name: Submit a Proposal
+about: Suggest enhancements or improvements to existing features.
+
+---
+
+### Describe your proposal
+
+### If applicable, show us an example for your proposal
+
+### Expected and actual behaviour
+
+### Further details

--- a/.github/ISSUE_TEMPLATE/PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/PROPOSAL.md
@@ -6,7 +6,7 @@ about: Suggest enhancements or improvements to existing features.
 
 ### Describe your proposal
 
-### If applicable, show us an example for your proposal
+### Usecases for your proposal
 
 ### Expected and actual behaviour
 

--- a/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md
+++ b/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md
@@ -1,0 +1,11 @@
+---
+name: Bug Fix
+about: Fixes a bug or more bugs that showed up
+
+---
+
+### Description of the PR
+
+### Bug(s) fixed
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md
+++ b/.github/PULL_REQUEST_TEMPLATE/BUG_FIX.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Fix
-about: Fixes a bug or more bugs that showed up
+about: Fixes a bug or more bugs that showed up.
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
+++ b/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
@@ -1,12 +1,12 @@
 ---
-name: Add or Remove Methods or Properties
-about: Modifies / removes currently existing functions or adds new functions to the framework.
+name: Remove or Change Methods or Properties
+about: Modifies / removes currently existing functions
 
 ---
 
 ### Description of the PR
 
-### Changes Proposed in this Pull Request (List changes in CHANGELOG.MD)
+### Changes done in this Pull Request (List changes in CHANGELOG.MD)
 
 -
 

--- a/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
+++ b/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
@@ -1,6 +1,6 @@
 ---
 name: Change or Remove Methods or Properties
-about: Modifies / removes currently existing functions
+about: Modifies or removes currently existing functions
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
+++ b/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
@@ -1,5 +1,5 @@
 ---
-name: Remove or Change Methods or Properties
+name: Change or Remove Methods or Properties
 about: Modifies / removes currently existing functions
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
+++ b/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
@@ -1,0 +1,13 @@
+---
+name: Add or Remove Methods or Properties
+about: Modifies / removes currently existing functions or adds new functions to the framework
+
+---
+
+### Description of the PR
+
+### Changes Proposed in this Pull Request (List changes in CHANGELOG.MD)
+
+-
+
+- [ ] This PR has been tested.

--- a/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
+++ b/.github/PULL_REQUEST_TEMPLATE/CHANGES.md
@@ -1,6 +1,6 @@
 ---
 name: Add or Remove Methods or Properties
-about: Modifies / removes currently existing functions or adds new functions to the framework
+about: Modifies / removes currently existing functions or adds new functions to the framework.
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md
+++ b/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md
@@ -1,0 +1,11 @@
+---
+name: Correct or Add new Documentations
+about: In case some documentations were wrong
+
+---
+
+### Description of the documentation change
+
+### Changes
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md
+++ b/.github/PULL_REQUEST_TEMPLATE/DOCUMENTATION.md
@@ -1,6 +1,6 @@
 ---
 name: Correct or Add new Documentations
-about: In case some documentations were wrong
+about: In case some documentations were wrong.
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/FEATURES.md
+++ b/.github/PULL_REQUEST_TEMPLATE/FEATURES.md
@@ -1,0 +1,13 @@
+---
+name: New Features
+about: Adds new features or changes current methods or properties to bring in new functionality.
+
+---
+
+### Description of the PR
+
+### Changes added in this Pull Request (List changes in CHANGELOG.MD)
+
+-
+
+- [ ] This PR has been tested.

--- a/.github/PULL_REQUEST_TEMPLATE/FEATURES.md
+++ b/.github/PULL_REQUEST_TEMPLATE/FEATURES.md
@@ -6,7 +6,7 @@ about: Adds new features or changes current methods or properties to bring in ne
 
 ### Description of the PR
 
-### Changes added in this Pull Request (List changes in CHANGELOG.MD)
+### Changes Proposed in this Pull Request (List changes in CHANGELOG.MD)
 
 -
 


### PR DESCRIPTION
### Description of the PR
GitHub has added support for issue and pull request templates that you can choose. (Example: 
![image](https://user-images.githubusercontent.com/17960496/41172759-8cc31c0e-6b5d-11e8-9c96-72da4acdca45.png)
)

I think that will be amazing for klasa, just to help keep everything organized, and consistent (for instance, all proposals having the same template, all bug submissions having the same template, etc.)

I'm awating input from @kyranet, @bdistin and anyone else who wants to give input on this.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
