### PR TITLE
Add support for extension injection

### DIFF
--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -170,7 +170,9 @@ class Store extends Collection {
 	 */
 	static async walk(store, core = false) {
 		const dir = core ? store.coreDir : store.userDir;
-		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && extname(path) === '.js' }).catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
+		const extensions = Object.keys(require.extensions).filter(key => key !== '.json' && key !== '.node');
+		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && extensions.includes(extname(path)) })
+			.catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
 		if (!files) return true;
 
 		return Promise.all([...files.keys()].map(file => store.load(relative(dir, file).split(sep), core)));


### PR DESCRIPTION
### Description of the PR

This PR implements a more abstracted solution to https://github.com/dirigeants/klasa/pull/322, which can support other libraries that inject extensions (let's say somebody does `ts-node` but for Coffescript!). This PR has no impact in the current system, instead, if an installed library injects an extension that can translate a language into valid JS, this will be "caugh" by the loader (if found) and loaded.

Assigning to @bdistin as this affects the loader.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added support for extension injection library

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
