### PR TITLE
fix: Configuration#update should never throw

### DIFF
--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -421,10 +421,13 @@ class Configuration {
 	 * @private
 	 */
 	async _parse(value, guild, options, result, { piece, route }) {
-		const parsedID = value !== null ?
-			await (Array.isArray(value) ? this._parseAll(piece, value, guild, result.errors) : piece.parse(value, guild)) :
-			deepClone(piece.default);
+		const parsedID = value === null ?
+			deepClone(piece.default) :
+			await (Array.isArray(value) ?
+				this._parseAll(piece, value, guild, result.errors) :
+				piece.parse(value, guild).catch((error) => { result.errors.push(error); }));
 
+		if (parsedID === undefined) return;
 		if (piece.array && !Array.isArray(value)) {
 			this._parseArraySingle(piece, route, parsedID, options, result);
 		} else if (this._setValueByPath(piece, parsedID, options.force).updated) {

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -427,7 +427,7 @@ class Configuration {
 				this._parseAll(piece, value, guild, result.errors) :
 				piece.parse(value, guild).catch((error) => { result.errors.push(error); }));
 
-		if (parsedID === undefined) return;
+		if (typeof parsedID === 'undefined') return;
 		if (piece.array && !Array.isArray(value)) {
 			this._parseArraySingle(piece, route, parsedID, options, result);
 		} else if (this._setValueByPath(piece, parsedID, options.force).updated) {

--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -170,9 +170,7 @@ class Store extends Collection {
 	 */
 	static async walk(store, core = false) {
 		const dir = core ? store.coreDir : store.userDir;
-		const extensions = Object.keys(require.extensions).filter(key => key !== '.json' && key !== '.node');
-		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && extensions.includes(extname(path)) })
-			.catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
+		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && extname(path) === '.js' }).catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
 		if (!files) return true;
 
 		return Promise.all([...files.keys()].map(file => store.load(relative(dir, file).split(sep), core)));

--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -170,7 +170,9 @@ class Store extends Collection {
 	 */
 	static async walk(store, core = false) {
 		const dir = core ? store.coreDir : store.userDir;
-		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && extname(path) === '.js' }).catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
+		const extensions = Object.keys(require.extensions).filter(key => key !== '.json' && key !== '.node');
+		const files = await fs.scan(dir, { filter: (stats, path) => stats.isFile() && extensions.includes(extname(path)) })
+			.catch(() => { fs.ensureDir(dir).catch(err => store.client.emit('error', err)); });
 		if (!files) return true;
 
 		return Promise.all([...files.keys()].map(file => store.load(relative(dir, file).split(sep), core)));


### PR DESCRIPTION
### Description of the PR

Fixes a bug identified by @bdistin where Configuration#update throws under certain circunstances.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed Configuration#update throwing

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
