### PR TITLE
fix: Schedule#delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#355](https://github.com/dirigeants/klasa/pull/355)] Fixed Schedule not deleting entries that do not exist in ClientStorage but are still cached in Schedule#tasks. (kyranet)
 - [[#284](https://github.com/dirigeants/klasa/pull/284)] Fixed a bug where SG's cache would download twice when `GatewayDriverRegisterOptions.download` is true. (kyranet)
 - [[#284](https://github.com/dirigeants/klasa/pull/284)] Fixed `Gateway#parseEntry` not being a function. (kyranet)
 - [[#256](https://github.com/dirigeants/klasa/pull/256)] Fixed `Util.deepClone` trying to iterate over `WeakMap`s and `WeakSet`s. (kyranet)

--- a/src/lib/schedule/Schedule.js
+++ b/src/lib/schedule/Schedule.js
@@ -162,11 +162,16 @@ class Schedule {
 	 * @returns {this}
 	 */
 	async delete(id) {
-		const _task = this._tasks.find(entry => entry.id === id);
-		if (!_task) throw new Error('This task does not exist.');
+		const task = this._tasks.find(entry => entry.id === id);
+		if (!task) {
+			const possibleIndex = this.tasks.findIndex(entry => entry.id === id);
+			if (possibleIndex === -1) throw new Error('This task does not exist.');
+			this.tasks.splice(possibleIndex, 1);
+			return this;
+		}
 
 		// Get the task and use it to remove
-		await this.client.configs.update('schedules', _task, { action: 'remove' });
+		await this.client.configs.update('schedules', task, { action: 'remove' });
 
 		// Remove the task from the current cache if successful
 		this.tasks.splice(this.tasks.findIndex(entry => entry.id === id), 1);

--- a/src/lib/schedule/Schedule.js
+++ b/src/lib/schedule/Schedule.js
@@ -162,19 +162,13 @@ class Schedule {
 	 * @returns {this}
 	 */
 	async delete(id) {
-		const task = this._tasks.find(entry => entry.id === id);
-		if (!task) {
-			const possibleIndex = this.tasks.findIndex(entry => entry.id === id);
-			if (possibleIndex === -1) throw new Error('This task does not exist.');
-			this.tasks.splice(possibleIndex, 1);
-			return this;
-		}
+		const taskIndex = this.tasks.findIndex(entry => entry.id === id);
+		if (taskIndex === -1) throw new Error('This task does not exist.');
 
+		this.tasks.splice(taskIndex, 1);
 		// Get the task and use it to remove
-		await this.client.configs.update('schedules', task, { action: 'remove' });
-
-		// Remove the task from the current cache if successful
-		this.tasks.splice(this.tasks.findIndex(entry => entry.id === id), 1);
+		const task = this._tasks.find(entry => entry.id === id);
+		if (task) await this.client.configs.update('schedules', task, { action: 'remove' });
 
 		return this;
 	}


### PR DESCRIPTION
### Description of the PR

This PR adds a small fix, a full fix would be checking whenever the client's config updated the schedules entry. (Pending for discussion about this)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed Schedule not deleting entries that do not exist in ClientStorage but are still cached in Schedule#tasks.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
