### PR TITLE
fix: Document Timestamp#displayUTC and patch it up

### DIFF
--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -46,7 +46,7 @@ class Timestamp {
 	 * @param {(Date|number|string)} [time=new Date()] The time to display in utc
 	 * @returns {string}
 	 */
-	displayUTC(time) {
+	displayUTC(time = new Date()) {
 		return Timestamp._display(this._template, Timestamp.utc(time));
 	}
 

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -46,7 +46,7 @@ class Timestamp {
 	 * @param {(Date|number|string)} [time=new Date()] The time to display in utc
 	 * @returns {string}
 	 */
-	displayUTC(time = new Date()) {
+	displayUTC(time) {
 		return Timestamp._display(this._template, Timestamp.utc(time));
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1192,6 +1192,7 @@ declare module 'klasa' {
 		private _template: TimestampObject[];
 
 		public display(time?: Date | number | string): string;
+		public displayUTC(time?: Date | number | string): string;
 		public edit(pattern: string): this;
 
 		public static displayArbitrary(pattern: string, time?: Date | number | string): string;


### PR DESCRIPTION
### Description of the PR
Documents Timestamp#displayUTC in typings
And fixes the default parameter to actually be a Date instance

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
