### PR TITLE
Missing conditional in the core command unload.js

### DIFF
--- a/src/commands/Admin/unload.js
+++ b/src/commands/Admin/unload.js
@@ -13,6 +13,9 @@ module.exports = class extends Command {
 	}
 
 	async run(message, [piece]) {
+		if ((piece.type === 'event' && piece.name === 'message') || (piece.type === 'monitor' && piece.name === 'commandHandler')) {
+			return message.sendMessage(message.language.get('COMMAND_UNLOAD_WARN'));
+		}
 		piece.unload();
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -80,6 +80,7 @@ module.exports = class extends Language {
 			COMMAND_EVAL_SENDCONSOLE: (time, type) => `Output was too long... sent the result to console.\n**Type**:${type}\n${time}`,
 			COMMAND_UNLOAD: (type, name) => `✅ Unloaded ${type}: ${name}`,
 			COMMAND_UNLOAD_DESCRIPTION: 'Unloads the klasa piece.',
+			COMMAND_UNLOAD_WARN: 'You probably don\'t want to unload that, since you wouldn\'t be able to run any command to enable it again',
 			COMMAND_TRANSFER_ERROR: '❌ That file has been transfered already or never existed.',
 			COMMAND_TRANSFER_SUCCESS: (type, name) => `✅ Successfully transferred ${type}: ${name}`,
 			COMMAND_TRANSFER_FAILED: (type, name) => `Transfer of ${type}: ${name} to Client has failed. Please check your Console.`,


### PR DESCRIPTION
### Description of the PR
Mostly do the same that disable.js does when you try to disable commandHandler or message (and add the language key-value of it)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)
* Add the same conditional from disable.js
* Add the key-value on en-US.js for COMMAND_UNLOAD_WARN

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
