### PR TITLE
fix: JSON provider being inconsistent with other providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#362](https://github.com/dirigeants/klasa/pull/362)] Added `GatewayDriverRegisterOptions.syncArg` for custom arguments for `GatewayDriver#sync()`'s call. (kyranet)
 - [[#331](https://github.com/dirigeants/klasa/pull/331)] Added `Gateway#syncQueue` for centralized lazy load cache and memory reduction. (kyranet)
 - [[#331](https://github.com/dirigeants/klasa/pull/331)] Added `Configuration#synchronizing` getter to check whether a Configuration instance is lazy loading or not. (kyranet)
 - [[#284](https://github.com/dirigeants/klasa/pull/284)] Added `Util.chunk`. (bdistin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 ### Added
 
 - [[#362](https://github.com/dirigeants/klasa/pull/362)] Added `GatewayDriverRegisterOptions.syncArg` for custom arguments for `GatewayDriver#sync()`'s call. (kyranet)
+- [[#362](https://github.com/dirigeants/klasa/pull/362)] Added `GatewayDriver#@@iterator`. (kyranet)
 - [[#331](https://github.com/dirigeants/klasa/pull/331)] Added `Gateway#syncQueue` for centralized lazy load cache and memory reduction. (kyranet)
 - [[#331](https://github.com/dirigeants/klasa/pull/331)] Added `Configuration#synchronizing` getter to check whether a Configuration instance is lazy loading or not. (kyranet)
 - [[#284](https://github.com/dirigeants/klasa/pull/284)] Added `Util.chunk`. (bdistin)
@@ -253,6 +254,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#362](https://github.com/dirigeants/klasa/pull/362)] Fixed object mutation in `GatewayDriver#toJSON()`. (kyranet)
 - [[#284](https://github.com/dirigeants/klasa/pull/284)] Fixed a bug where SG's cache would download twice when `GatewayDriverRegisterOptions.download` is true. (kyranet)
 - [[#284](https://github.com/dirigeants/klasa/pull/284)] Fixed `Gateway#parseEntry` not being a function. (kyranet)
 - [[#256](https://github.com/dirigeants/klasa/pull/256)] Fixed `Util.deepClone` trying to iterate over `WeakMap`s and `WeakSet`s. (kyranet)

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -117,13 +117,13 @@ class Gateway extends GatewayStorage {
 	/**
 	 * Sync either all entries from the cache with the persistent database, or a single one.
 	 * @since 0.0.1
-	 * @param {(Array<string>|string|true)} [input=Array<string>] An object containing a id property, like discord.js objects, or a string
+	 * @param {(Array<string>|string)} [input=Array<string>] An object containing a id property, like discord.js objects, or a string
 	 * @returns {?(Gateway|Configuration)}
 	 */
 	async sync(input = [...this.cache.keys()]) {
-		if (input === true || Array.isArray(input)) {
+		if (Array.isArray(input)) {
 			if (!this._synced) this._synced = true;
-			const entries = await this.provider.getAll(this.type, input === true ? undefined : input);
+			const entries = await this.provider.getAll(this.type, input);
 			for (const entry of entries) {
 				if (!entry) continue;
 				const cache = this.cache.get(entry.id);

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -117,11 +117,11 @@ class Gateway extends GatewayStorage {
 	/**
 	 * Sync either all entries from the cache with the persistent database, or a single one.
 	 * @since 0.0.1
-	 * @param {(Object|string|boolean)} [input=Array<string>] An object containing a id property, like discord.js objects, or a string
+	 * @param {(Array<string>|string|true)} [input=Array<string>] An object containing a id property, like discord.js objects, or a string
 	 * @returns {?(Gateway|Configuration)}
 	 */
 	async sync(input = [...this.cache.keys()]) {
-		if (Array.isArray(input)) {
+		if (input === true || Array.isArray(input)) {
 			if (!this._synced) this._synced = true;
 			const entries = await this.provider.getAll(this.type, input);
 			for (const entry of entries) {

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -123,7 +123,7 @@ class Gateway extends GatewayStorage {
 	async sync(input = [...this.cache.keys()]) {
 		if (input === true || Array.isArray(input)) {
 			if (!this._synced) this._synced = true;
-			const entries = await this.provider.getAll(this.type, input === true ? null : input);
+			const entries = await this.provider.getAll(this.type, input === true ? undefined : input);
 			for (const entry of entries) {
 				if (!entry) continue;
 				const cache = this.cache.get(entry.id);

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -123,7 +123,7 @@ class Gateway extends GatewayStorage {
 	async sync(input = [...this.cache.keys()]) {
 		if (input === true || Array.isArray(input)) {
 			if (!this._synced) this._synced = true;
-			const entries = await this.provider.getAll(this.type, input);
+			const entries = await this.provider.getAll(this.type, input === true ? null : input);
 			for (const entry of entries) {
 				if (!entry) continue;
 				const cache = this.cache.get(entry.id);

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -198,6 +198,7 @@ class GatewayDriver {
 		this.keys.add(name);
 		this[name] = gateway;
 		this._queue.push(gateway.init.bind(gateway, defaultSchema));
+		if (!(name in this.client.options.gateways)) this.client.options.gateways[name] = {};
 		return this;
 	}
 
@@ -214,11 +215,11 @@ class GatewayDriver {
 	/**
 	 * Sync all gateways
 	 * @since 0.5.0
-	 * @param {...*} args The arguments to pass to each Gateway#sync
+	 * @param {(string|string[])} input The arguments to pass to each Gateway#sync
 	 * @returns {Promise<Array<Gateway>>}
 	 */
-	sync(...args) {
-		return Promise.all([...this].map(([key, gateway]) => gateway.sync(...args.length ? args : this.client.options.gateways[key].syncArg)));
+	sync(input) {
+		return Promise.all([...this].map(([key, gateway]) => gateway.sync(typeof input === 'undefined' ? this.client.options.gateways[key].syncArg : input)));
 	}
 
 	/**

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -221,6 +221,21 @@ class GatewayDriver {
 	}
 
 	/**
+	 * Returns a new Iterator object that contains the values for each gateway contained in this driver.
+	 * @name @@iterator
+	 * @since 0.5.0
+	 * @method
+	 * @instance
+	 * @generator
+	 * @returns {Iterator<Array<string | Gateway>>}
+	 * @memberof GatewayDriver
+	 */
+
+	*[Symbol.iterator]() {
+		for (const key of this.keys) yield [key, this[key]];
+	}
+
+	/**
 	 * The GatewayDriver with all gateways, types and keys as JSON.
 	 * @since 0.5.0
 	 * @returns {Object}
@@ -231,7 +246,7 @@ class GatewayDriver {
 			keys: [...this.keys],
 			ready: this.ready
 		};
-		for (const key of this.keys) object[key] = this[key].toJSON();
+		for (const [key, value] of this) object[key] = value.toJSON();
 
 		return object;
 	}

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -241,14 +241,12 @@ class GatewayDriver {
 	 * @returns {Object}
 	 */
 	toJSON() {
-		const object = {
+		return {
 			types: [...this.types],
 			keys: [...this.keys],
-			ready: this.ready
+			ready: this.ready,
+			...Object.assign({}, [...this].map(([key, value]) => ({ [key]: value.toJSON() })))
 		};
-		for (const [key, value] of this) object[key] = value.toJSON();
-
-		return object;
 	}
 
 	/**

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -11,6 +11,7 @@ class GatewayDriver {
 	/**
 	 * @typedef {Object} GatewayDriverRegisterOptions
 	 * @property {string} [provider] The name of the provider to use
+	 * @property {string|string[]|true} [syncArg] The sync args to pass to Gateway#sync during Gateway init
 	 */
 
 	/**
@@ -217,7 +218,7 @@ class GatewayDriver {
 	 * @returns {Promise<Array<Gateway>>}
 	 */
 	sync(...args) {
-		return Promise.all([...this.keys].map(key => this[key].sync(...args)));
+		return Promise.all([...this].map(([key, gateway]) => gateway.sync(...args.length ? args : this.client.options.gateways[key].syncArg)));
 	}
 
 	/**

--- a/src/providers/json.js
+++ b/src/providers/json.js
@@ -56,7 +56,7 @@ module.exports = class extends Provider {
 	 * @returns {Object[]}
 	 */
 	async getAll(table, entries) {
-		if (!Array.isArray(entries)) entries = await this.getKeys(table);
+		if (!Array.isArray(entries) || !entries.length) entries = await this.getKeys(table);
 		if (entries.length < 5000) {
 			return Promise.all(entries.map(this.get.bind(this, table)));
 		} else {

--- a/src/providers/json.js
+++ b/src/providers/json.js
@@ -59,12 +59,12 @@ module.exports = class extends Provider {
 		if (!Array.isArray(entries) || !entries.length) entries = await this.getKeys(table);
 		if (entries.length < 5000) {
 			return Promise.all(entries.map(this.get.bind(this, table)));
-		} else {
-			const chunks = util.chunk(entries, 5000);
-			const output = [];
-			for (const chunk of chunks) output.push(...await Promise.all(chunk.map(this.get.bind(this, table))));
-			return output;
 		}
+
+		const chunks = util.chunk(entries, 5000);
+		const output = [];
+		for (const chunk of chunks) output.push(...await Promise.all(chunk.map(this.get.bind(this, table))));
+		return output;
 	}
 
 	/**
@@ -108,7 +108,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<Object>}
 	 */
 	getRandom(table) {
-		return this.getAll(table).then(data => data[Math.floor(Math.random() * data.length)]);
+		return this.getKeys(table).then(data => this.get(table, data[Math.floor(Math.random() * data.length)].id));
 	}
 
 	/**
@@ -136,7 +136,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<void>}
 	 */
 	create(table, document, data = {}) {
-		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), util.mergeObjects({ id: document }, data));
+		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), { id: document, ...data });
 	}
 
 	/**
@@ -159,7 +159,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<void>}
 	 */
 	replace(table, document, data) {
-		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), this.parseUpdateInput(data));
+		return fs.outputJSONAtomic(resolve(this.baseDir, table, `${document}.json`), { id: document, ...this.parseUpdateInput(data) });
 	}
 
 	/**

--- a/src/providers/json.js
+++ b/src/providers/json.js
@@ -56,7 +56,7 @@ module.exports = class extends Provider {
 	 * @returns {Object[]}
 	 */
 	async getAll(table, entries) {
-		if (!entries) entries = await this.getKeys(table);
+		if (!Array.isArray(entries)) entries = await this.getKeys(table);
 		if (entries.length < 5000) {
 			return Promise.all(entries.map(this.get.bind(this, table)));
 		} else {

--- a/src/providers/json.js
+++ b/src/providers/json.js
@@ -108,7 +108,7 @@ module.exports = class extends Provider {
 	 * @returns {Promise<Object>}
 	 */
 	getRandom(table) {
-		return this.getKeys(table).then(data => this.get(table, data[Math.floor(Math.random() * data.length)].id));
+		return this.getKeys(table).then(data => this.get(table, data[Math.floor(Math.random() * data.length)]));
 	}
 
 	/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -494,8 +494,8 @@ declare module 'klasa' {
 		public readonly syncQueue: Collection<string, Promise<Configuration>>;
 
 		public get(input: string | number, create?: boolean): Configuration;
-		public sync(input?: string[]): Promise<Gateway>;
-		public sync(input: string | { id?: string, name?: string }): Promise<Configuration>;
+		public sync(input: string): Promise<Configuration>;
+		public sync(input?: string[] | true): Promise<Gateway>;
 		public getPath(key?: string, options?: GatewayGetPathOptions): GatewayGetPathResult | null;
 
 		private _resolveGuild(guild: GuildResolvable): KlasaGuild;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -497,7 +497,7 @@ declare module 'klasa' {
 
 		public get(input: string | number, create?: boolean): Configuration;
 		public sync(input: string): Promise<Configuration>;
-		public sync(input?: string[] | true): Promise<Gateway>;
+		public sync(input?: string[]): Promise<Gateway>;
 		public getPath(key?: string, options?: GatewayGetPathOptions): GatewayGetPathResult | null;
 
 		private _resolveGuild(guild: GuildResolvable): KlasaGuild;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1320,6 +1320,7 @@ declare module 'klasa' {
 		clientStorage?: GatewayDriverRegisterOptions;
 		guilds?: GatewayDriverRegisterOptions;
 		users?: GatewayDriverRegisterOptions;
+		[key: string]: GatewayDriverRegisterOptions;
 	} & object;
 
 	export type ExecOptions = {
@@ -1449,6 +1450,7 @@ declare module 'klasa' {
 
 	export type GatewayDriverRegisterOptions = {
 		provider?: string;
+		syncArg?: string[] | string | true;
 	};
 
 	export type SchemaFolderAddOptions = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -542,6 +542,7 @@ declare module 'klasa' {
 			schedules: SchemaPieceJSON
 		};
 
+		public [Symbol.iterator](): Iterator<[string, Gateway]>;
 		public register(name: string, schema?: object, options?: GatewayDriverRegisterOptions): this;
 		public init(): Promise<void>;
 		public sync(input?: string[]): Promise<Array<Gateway>>;


### PR DESCRIPTION
### Description of the PR

Fixes #361.

In SGv2.2.0, when I refactored Gateway#sync, I removed the `true` overload which meant "sync all". This PR adds it back and adds a more robust check to the JSON provider.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added `GatewayDriverRegisterOptions.syncArg` for custom arguments for `GatewayDriver#sync()`'s call.
- Added  `GatewayDriver#@@iterator`.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
