### PR TITLE
Migrate to one _patch

### DIFF
--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -532,16 +532,18 @@ class Configuration {
 	 * Path this Configuration instance.
 	 * @since 0.5.0
 	 * @param {Object} data The data to patch
-	 * @param {Object} [inst=this] The reference of the Configuration instance
+	 * @param {Object} [instance=this] The reference of the Configuration instance
 	 * @param {SchemaFolder} [schema=this.gateway.schema] A SchemaFolder instance
 	 * @private
 	 */
-	_patch(data, inst = this, schema = this.gateway.schema) {
+	_patch(data, instance = this, schema = this.gateway.schema) {
 		if (typeof data !== 'object' || data === null) return;
 		for (const [key, piece] of schema) {
 			const value = data[key];
-			if (value === undefined || value === null) continue;
-			inst[key] = piece.type === 'Folder' ? this._patch(inst[key], value, piece) : deepClone(value);
+			if (value === undefined) continue;
+			if (value === null) instance[key] = deepClone(piece.defaults);
+			else if (piece.type === 'Folder') this._patch(value, instance[key], piece);
+			else instance[key] = value;
 		}
 	}
 

--- a/src/lib/settings/Configuration.js
+++ b/src/lib/settings/Configuration.js
@@ -532,11 +532,17 @@ class Configuration {
 	 * Path this Configuration instance.
 	 * @since 0.5.0
 	 * @param {Object} data The data to patch
+	 * @param {Object} [inst=this] The reference of the Configuration instance
+	 * @param {SchemaFolder} [schema=this.gateway.schema] A SchemaFolder instance
 	 * @private
 	 */
-	_patch(data) {
+	_patch(data, inst = this, schema = this.gateway.schema) {
 		if (typeof data !== 'object' || data === null) return;
-		this.constructor._patch(this, data, this.gateway.schema);
+		for (const [key, piece] of schema) {
+			const value = data[key];
+			if (value === undefined || value === null) continue;
+			inst[key] = piece.type === 'Folder' ? this._patch(inst[key], value, piece) : deepClone(value);
+		}
 	}
 
 	/**
@@ -555,25 +561,6 @@ class Configuration {
 	 */
 	toString() {
 		return `Configuration(${this.gateway.type}:${this.id})`;
-	}
-
-	/**
-	 * Patch an object.
-	 * @since 0.5.0
-	 * @param {Object} inst The reference of the Configuration instance
-	 * @param {Object} data The original object
-	 * @param {SchemaFolder} schema A SchemaFolder instance
-	 * @returns {Object}
-	 * @private
-	 */
-	static _patch(inst, data, schema) {
-		for (const [key, piece] of schema) {
-			const value = data[key];
-			if (value === undefined || value === null) continue;
-			inst[key] = piece.type === 'Folder' ? this._patch(inst[key], value, piece) : deepClone(value);
-		}
-
-		return inst;
 	}
 
 }


### PR DESCRIPTION
### Description of the PR
As per ~~complain**t**s~~ from Faith, the Configuration#_patch and Configuration._patch methods are now merged into one, working.

Now I just wait for eslint to bug me.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change the _patch to remain consistent, without having another extra _patch that's static

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
