### PR TITLE
Update reload.js

### DIFF
--- a/src/commands/Admin/reload.js
+++ b/src/commands/Admin/reload.js
@@ -34,7 +34,7 @@ module.exports = class extends Command {
 					if (this.shard.id !== ${this.client.shard.id}) this.${piece.store}.get('${piece.name}').reload();
 				`);
 			}
-			return message.sendLocale('COMMAND_RELOAD', [itm.type, itm.name, timer.stop]);
+			return message.sendLocale('COMMAND_RELOAD', [itm.type, itm.name, timer.stop()]);
 		} catch (err) {
 			piece.store.set(piece);
 			return message.sendMessage(`❌ ${err}`);


### PR DESCRIPTION
### Description of the PR

Previously, when reloading a single command, the function of `timer.stop` was passed to the language piece, rather than the time itself. This fixes that by changing `timer.stop` to `timer.stop()` on line 37.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [X ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
