### PR TITLE
docs: Fixed KlasaConsoleColorStyles not having optionals

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1772,12 +1772,12 @@ declare module 'klasa' {
 	};
 
 	export type KlasaConsoleColorStyles = {
-		debug: KlasaConsoleColorObjects;
-		error: KlasaConsoleColorObjects;
-		log: KlasaConsoleColorObjects;
-		verbose: KlasaConsoleColorObjects;
-		warn: KlasaConsoleColorObjects;
-		wtf: KlasaConsoleColorObjects;
+		debug?: KlasaConsoleColorObjects;
+		error?: KlasaConsoleColorObjects;
+		log?: KlasaConsoleColorObjects;
+		verbose?: KlasaConsoleColorObjects;
+		warn?: KlasaConsoleColorObjects;
+		wtf?: KlasaConsoleColorObjects;
 	};
 
 	export type KlasaConsoleColorObjects = {


### PR DESCRIPTION
### Description of the PR

KlasaConsoleColorStyles is used in KlasaClientOptions, however, its properties are not optional when they should.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Made all properties of KlasaConsoleColorStyles optional

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
