### PR TITLE
feat: Gateway satellites and reverse-proxy Collection/DataStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#389](https://github.com/dirigeants/klasa/pull/389)] Added ability for Gateway to outsource the cache via external SatelliteStores or DataStores. (kyranet)
+- [[#389](https://github.com/dirigeants/klasa/pull/389)] Added `CacheStore`, `SatelliteStore`, and `SettingsStore` classes to proxy external datastores. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added the `SETTING_GATEWAY_INVALID_FILTERED_VALUE` language key. (bdistin)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added `Base` class for schemas, extending `Map`. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added `SchemaType` and `SchemaTypes` classes. (Unseenfaith)
@@ -122,6 +124,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#389](https://github.com/dirigeants/klasa/pull/389)] Changed `Gateway#cache` to be either a `SatelliteStore` or a `SettingsStore` instance. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed SchemaFolder to extend Schema, which extends Map. All keys are now stored inside the map as opposed to being properties. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed `Schema#add` and `Schema#remove` to be synchronous. They must be called before ready. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed `GatewayDriver#register`'s arguments to move `schema`'s argument to `GatewayDriverRegisterOptions`. (kyranet)
@@ -224,6 +227,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#389](https://github.com/dirigeants/klasa/pull/389)] **[BREAKING]** Removed `Gateway#get`. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Removed `bwd/*.schema.json` files. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Removed `Resolver` and `SettingsResolver` classes. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Removed `GatewayDriver#resolver` and `GatewayStorage#resolver`. (kyranet)

--- a/guides/.docconfig.json
+++ b/guides/.docconfig.json
@@ -105,6 +105,10 @@
     {
         "name": "Updating your Settings",
         "path": "SettingsGatewaySettingsUpdate.md"
+    },
+    {
+        "name": "Understanding Satellites",
+        "path": "UnderstandingSatellites.md"
     }]
 },
 {

--- a/guides/Advanced SettingsGateway/SettingsGatewayKeyTypes.md
+++ b/guides/Advanced SettingsGateway/SettingsGatewayKeyTypes.md
@@ -57,3 +57,4 @@ Client.types.add('mytype', MySchemaType);
 - {@tutorial UnderstandingSchemaPieces}
 - {@tutorial UnderstandingSchemaFolders}
 - {@tutorial SettingsGatewaySettingsUpdate}
+- {@tutorial UnderstandingSatellites}

--- a/guides/Advanced SettingsGateway/SettingsGatewaySettingsUpdate.md
+++ b/guides/Advanced SettingsGateway/SettingsGatewaySettingsUpdate.md
@@ -37,3 +37,4 @@ message.guild.settings.update(['prefix', 'language'], ['k!', 'en-ES']);
 - {@tutorial UnderstandingSchemaPieces}
 - {@tutorial UnderstandingSchemaFolders}
 - {@tutorial SettingsGatewayKeyTypes}
+- {@tutorial UnderstandingSatellites}

--- a/guides/Advanced SettingsGateway/UnderstandingSatellites.md
+++ b/guides/Advanced SettingsGateway/UnderstandingSatellites.md
@@ -1,0 +1,26 @@
+# Understanding Gateway Satellites
+
+SettingsGateway serves a [reverse-proxy](https://en.wikipedia.org/wiki/Reverse_proxy)-like caching, which accesses discord.js' [DataStore][DataStore]s such as [`Client#users`](https://discord.js.org/#/docs/main/master/class/Client?scrollTo=users) or [`Client#guilds`](https://discord.js.org/#/docs/main/master/class/Client?scrollTo=guilds). A Gateway's cache can be either a {@link SettingsStore}, of which the get method will attempt to do `DataStore#get(id).settings`, or a {@link SatelliteStore}, which get method will attempt to access to the property `satellite` of the entry instead.
+
+This works because in two of the built-in gateways, `this.client.users.get(id).settings` was identical to `this.client.gateways.users.cache.get(id)`, and so is for guilds. For this, a {@link SettingsStore} is used to remove the double caching layer, as we can access to any of users' or guilds' settings via their [DataStore][DataStore]s.
+
+What are {@link SatelliteStore}s for? A satellite "sits" in an entry of the [DataStore][DataStore], and once {@link Gateway#cache} is used to get an entry, it will access the desired satellite and this will try to proxy the next [DataStore][DataStore] until it reaches the {@link Settings} instance.
+
+One of the most common use cases of {@link SatelliteStore gateway satellites} are to make per-member settings.
+
+Unlike users, members are not stored on the [client][Client] instance, they are stored on a [guilds][Guild] instance, the satellite allows the re-route from [`Client#guilds`](https://discord.js.org/#/docs/main/master/class/Client?scrollTo=guilds) to [`Guild#members`](https://discord.js.org/#/docs/main/master/class/Guild?scrollTo=members). Check the example in {@tutorial CreatingACustomMemberGateway}.
+
+In the example, you can use `Guild#satellite` to access to all Settings instances directly, for instance, `message.guild.satellite.get(message.author.id)` will access the `message.guild.members.get(message.author.id).settings`, being exactly the same as `message.member.settings`. As well as doing `this.client.gateways.members.cache.get([message.guild.id, message.author.id])` will be equivalent to doing `this.client.guilds.get(message.guild.id).members.get(message.author.id).settings`.
+
+> **Note**: Alternatively, you can access to the member settings by joining the array with a dot (`'.'`): ``this.client.gateways.members.cache.get(`${message.guild.id}.${message.author.id}`)``. In the database and in {@link Settings#id `Settings#id`} will be the result of joining the "path" by a dot.
+
+[Client]: https://discord.js.org/#/docs/main/master/class/Client
+[Guild]: https://discord.js.org/#/docs/main/master/class/Guild
+[DataStore]: https://discord.js.org/#/docs/main/master/class/DataStore
+
+## Further Reading:
+
+- {@tutorial UnderstandingSchemaPieces}
+- {@tutorial UnderstandingSchemaFolders}
+- {@tutorial SettingsGatewayKeyTypes}
+- {@tutorial SettingsGatewaySettingsUpdate}

--- a/guides/Advanced SettingsGateway/UnderstandingSatellites.md
+++ b/guides/Advanced SettingsGateway/UnderstandingSatellites.md
@@ -2,9 +2,9 @@
 
 SettingsGateway serves a [reverse-proxy](https://en.wikipedia.org/wiki/Reverse_proxy)-like caching, which accesses discord.js' [DataStore][DataStore]s such as [`Client#users`](https://discord.js.org/#/docs/main/master/class/Client?scrollTo=users) or [`Client#guilds`](https://discord.js.org/#/docs/main/master/class/Client?scrollTo=guilds). A Gateway's cache can be either a {@link SettingsStore}, of which the get method will attempt to do `DataStore#get(id).settings`, or a {@link SatelliteStore}, which get method will attempt to access to the property `satellite` of the entry instead.
 
-This works because in two of the built-in gateways, `this.client.users.get(id).settings` was identical to `this.client.gateways.users.cache.get(id)`, and so is for guilds. For this, a {@link SettingsStore} is used to remove the double caching layer, as we can access to any of users' or guilds' settings via their [DataStore][DataStore]s.
+This works because in two of the built-in gateways, `this.client.users.get(id).settings` was identical to `this.client.gateways.users.cache.get(id)`, and so is for guilds. For this, a {@link SettingsStore} is used to remove the double caching layer, as we can access to any of users' or guilds' settings via their DataStores.
 
-What are {@link SatelliteStore}s for? A satellite "sits" in an entry of the [DataStore][DataStore], and once {@link Gateway#cache} is used to get an entry, it will access the desired satellite and this will try to proxy the next [DataStore][DataStore] until it reaches the {@link Settings} instance.
+What are {@link SatelliteStore}s for? A satellite "sits" in an entry of the DataStore, and once {@link Gateway#cache} is used to get an entry, it will access the desired satellite and this will try to proxy the next DataStore until it reaches the {@link Settings} instance.
 
 One of the most common use cases of {@link SatelliteStore gateway satellites} are to make per-member settings.
 

--- a/guides/Advanced SettingsGateway/UnderstandingSchemaFolders.md
+++ b/guides/Advanced SettingsGateway/UnderstandingSchemaFolders.md
@@ -100,3 +100,4 @@ When adding keys, specially when developing plugins, you may enter in conflict w
 - {@tutorial UnderstandingSchemaPieces}
 - {@tutorial SettingsGatewayKeyTypes}
 - {@tutorial SettingsGatewaySettingsUpdate}
+- {@tutorial UnderstandingSatellites}

--- a/guides/Advanced SettingsGateway/UnderstandingSchemaPieces.md
+++ b/guides/Advanced SettingsGateway/UnderstandingSchemaPieces.md
@@ -48,3 +48,4 @@ In this case, `client` is the {@link KlasaClient} instance, `command` the resolv
 - {@tutorial UnderstandingSchemaFolders}
 - {@tutorial SettingsGatewayKeyTypes}
 - {@tutorial SettingsGatewaySettingsUpdate}
+- {@tutorial UnderstandingSatellites}

--- a/guides/Building Your Bot/CreatingACustomMemberGateway.md
+++ b/guides/Building Your Bot/CreatingACustomMemberGateway.md
@@ -30,14 +30,14 @@ We have the Gateway, so we just need to use [Custom Structures](https://discord.
 
 ```javascript
 const { Structures } = require('discord.js');
-const { SatelliteStore } = require('klasa');
+const { SettingsStore } = require('klasa');
 
 // Extend Guild to register a satellite
 Structures.extend('Guild', Guild => class MyGuild extends Guild {
 
 	constructor(...args) {
 		super(...args);
-		this.satellite = new SatelliteStore();
+		this.satellite = new SettingsStore(this.members);
 	}
 
 });

--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -13,7 +13,7 @@ module.exports = class extends Event {
 		await this.client.fetchApplication();
 		if (!this.client.options.ownerID) this.client.options.ownerID = this.client.application.owner.id;
 
-		this.client.settings = this.client.gateways.clientStorage.get(this.client.user.id, true);
+		this.client.settings = this.client.gateways.clientStorage.create(this.client.user.id);
 		await this.client.gateways.sync();
 
 		// Init all the pieces

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,9 @@ module.exports = {
 	SchemaPiece: require('./lib/settings/schema/SchemaPiece'),
 	SchemaTypes: require('./lib/settings/schema/types/base/SchemaTypes'),
 	SchemaType: require('./lib/settings/schema/types/base/SchemaType'),
+	CacheStore: require('./lib/settings/cache/CacheStore'),
+	SatelliteStore: require('./lib/settings/cache/SatelliteStore'),
+	SettingsStore: require('./lib/settings/cache/SettingsStore'),
 
 	// lib/structures/base
 	Piece: require('./lib/structures/base/Piece'),

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -251,8 +251,8 @@ class KlasaClient extends Discord.Client {
 
 		// Register default gateways
 		this.gateways
-			.register('guilds', { ...guilds, schema: guildSchema })
-			.register('users', { ...users, schema: userSchema })
+			.register('guilds', { ...guilds, schema: guildSchema, datastore: this.guilds })
+			.register('users', { ...users, schema: userSchema, datastore: this.users })
 			.register('clientStorage', { ...clientStorage, schema: clientSchema });
 
 		/**

--- a/src/lib/extensions/KlasaGuild.js
+++ b/src/lib/extensions/KlasaGuild.js
@@ -23,7 +23,7 @@ module.exports = Structures.extend('Guild', Guild => {
 			 * @since 0.5.0
 			 * @type {Settings}
 			 */
-			this.settings = this.client.gateways.guilds.get(this.id, true);
+			this.settings = this.client.gateways.guilds.create(this.id);
 		}
 
 		/**

--- a/src/lib/extensions/KlasaUser.js
+++ b/src/lib/extensions/KlasaUser.js
@@ -23,7 +23,7 @@ module.exports = Structures.extend('User', User => {
 			 * @since 0.5.0
 			 * @type {Settings}
 			 */
-			this.settings = this.client.gateways.users.get(this.id, true);
+			this.settings = this.client.gateways.users.create(this.id);
 		}
 
 		/**

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -2,6 +2,8 @@ const GatewayStorage = require('./GatewayStorage');
 const Settings = require('./Settings');
 const { Collection, Guild, GuildChannel, Message } = require('discord.js');
 const { getIdentifier } = require('../util/util');
+const SatelliteStore = require('./cache/SatelliteStore');
+const SettingsStore = require('./cache/SettingsStore');
 
 /**
  * <danger>You should never create a Gateway instance by yourself.
@@ -35,13 +37,20 @@ class Gateway extends GatewayStorage {
 	 */
 
 	/**
+	 * @typedef {Object} GatewayOptions
+	 * @property {boolean} [satellite=false] Whether this Gateway's first cache level should be a SatelliteStore or not
+	 * @property {Map} [datastore=new Collection()] The datastore to proxy
+	 */
+
+	/**
 	 * @since 0.0.1
 	 * @param {GatewayDriver} store The GatewayDriver instance which initiated this instance
 	 * @param {string} type The name of this Gateway
-	 * @param {Schema} schema The schema for this gateway
+	 * @param {GatewayOptions} schema The schema for this gateway
 	 * @param {string} provider The provider's name for this gateway
+	 * @param {GatewayOptions} [options={}] This gateway's options
 	 */
-	constructor(store, type, schema, provider) {
+	constructor(store, type, schema, provider, { satellite = false, datastore } = {}) {
 		super(store.client, type, schema, provider);
 
 		/**
@@ -54,9 +63,9 @@ class Gateway extends GatewayStorage {
 		/**
 		 * The cached entries for this Gateway
 		 * @since 0.0.1
-		 * @type {external:Collection<string, Settings>}
+		 * @type {SatelliteStore|SettingsStore}
 		 */
-		this.cache = new Collection();
+		this.cache = satellite ? new SatelliteStore(datastore) : new SettingsStore(datastore);
 
 		/**
 		 * The synchronization queue for all Settings instances
@@ -84,24 +93,17 @@ class Gateway extends GatewayStorage {
 		return Settings;
 	}
 
-
 	/**
-	 * Get an entry from the cache.
+	 * Create a new Settings for this gateway
 	 * @since 0.5.0
-	 * @param {string} id The key to get from the cache
-	 * @param {boolean} [create = false] Whether SG should create a new instance of Settings in the background, if the entry does not already exist.
-	 * @returns {?Settings}
+	 * @param {string|string[]} id The id for this instance
+	 * @param {Object<string, *>} [data={}] The data for this Settings instance
+	 * @returns {Settings}
 	 */
-	get(id, create = false) {
-		const entry = this.cache.get(id);
-		if (entry) return entry;
-		if (create) {
-			const settings = new this.Settings(this, { id });
-			this.cache.set(id, settings);
-			if (this._synced && this.schema.keyArray.length) settings.sync().catch(err => this.client.emit('error', err));
-			return settings;
-		}
-		return null;
+	create(id, data = {}) {
+		const settings = new this.Settings(this, { id: typeof id === 'string' ? id : id.join('.'), ...data });
+		if (this._synced) settings.sync();
+		return settings;
 	}
 
 	/**
@@ -116,30 +118,25 @@ class Gateway extends GatewayStorage {
 			const entries = await this.provider.getAll(this.type, input);
 			for (const entry of entries) {
 				if (!entry) continue;
+
+				// Get the entry from the cache
 				const cache = this.cache.get(entry.id);
-				if (cache) {
-					if (!cache._existsInDB) cache._existsInDB = true;
-					cache._patch(entry);
-				} else {
-					const settings = new this.Settings(this, entry);
-					settings._existsInDB = true;
-					this.cache.set(entry.id, settings);
-				}
+				if (!cache) continue;
+
+				cache._existsInDB = true;
+				cache._patch(entry);
 			}
 
 			// Set all the remaining settings from unknown status in DB to not exists.
 			for (const settings of this.cache.values()) if (settings._existsInDB === null) settings._existsInDB = false;
 			return this;
 		}
+
 		const target = getIdentifier(input);
 		if (!target) throw new TypeError('The selected target could not be resolved to a string.');
 
 		const cache = this.cache.get(target);
-		if (cache) return cache.sync();
-
-		const settings = new this.Settings(this, { id: target });
-		this.cache.set(target, settings);
-		return settings.sync();
+		return cache ? cache.sync() : null;
 	}
 
 	/**
@@ -217,7 +214,8 @@ class Gateway extends GatewayStorage {
 	toJSON() {
 		return {
 			type: this.type,
-			options: { provider: this.providerName },
+			cache: this.cache.constructor.name,
+			provider: this.providerName,
 			schema: this.schema.toJSON()
 		};
 	}

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -101,7 +101,11 @@ class Gateway extends GatewayStorage {
 	 * @returns {Settings}
 	 */
 	create(id, data = {}) {
-		const settings = new this.Settings(this, { id: typeof id === 'string' ? id : id.join('.'), ...data });
+		id = typeof id === 'string' ? id : id.join('.');
+		const previous = this.cache.get(id);
+		if (previous) return previous;
+
+		const settings = new this.Settings(this, { id, ...data });
 		if (this._synced) settings.sync();
 		return settings;
 	}

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -12,6 +12,8 @@ class GatewayDriver {
 	 * @property {string} [provider = this.client.options.providers.default] The name of the provider to use
 	 * @property {Schema} [schema] The schema to use for this gateway.
 	 * @property {string|string[]|true} [syncArg] The sync args to pass to Gateway#sync during Gateway init
+	 * @property {boolean} [satellite=false] Whether this Gateway's first cache level should be a SatelliteStore or not
+	 * @property {Map} [datastore=new Collection()] The datastore to proxy
 	 */
 
 	/**
@@ -89,12 +91,12 @@ class GatewayDriver {
 	 * @returns {this}
 	 * @chainable
 	 */
-	register(name, { provider = this.client.options.providers.default, schema = new Schema() } = {}) {
+	register(name, { provider = this.client.options.providers.default, schema = new Schema(), satellite, datastore } = {}) {
 		if (typeof name !== 'string') throw new TypeError('You must pass a name for your new gateway and it must be a string.');
 		if (!(schema instanceof Schema)) throw new TypeError('Schema must be a valid Schema instance.');
 		if (this.name !== undefined && this.name !== null) throw new Error(`The key '${name}' is either taken by another Gateway or reserved for GatewayDriver's functionality.`);
 
-		const gateway = new Gateway(this, name, schema, provider);
+		const gateway = new Gateway(this, name, schema, provider, { satellite, datastore });
 		this.keys.add(name);
 		this[name] = gateway;
 		this._queue.push(gateway.init.bind(gateway));

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -143,7 +143,7 @@ class Settings {
 		// If it's not currently synchronizing, create a new sync status for the sync queue
 		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(data => {
 			if (data) {
-				if (!this._existsInDB) this._existsInDB = true;
+				this._existsInDB = true;
 				this._patch(data);
 			} else {
 				this._existsInDB = false;
@@ -151,6 +151,9 @@ class Settings {
 
 			this.gateway.syncQueue.delete(this.id);
 			return this;
+		}).catch((error) => {
+			this.gateway.syncQueue.delete(this.id);
+			throw error;
 		});
 
 		this.gateway.syncQueue.set(this.id, sync);

--- a/src/lib/settings/cache/CacheStore.js
+++ b/src/lib/settings/cache/CacheStore.js
@@ -1,0 +1,96 @@
+const { Collection } = require('discord.js');
+
+/**
+ * The CacheStore that proxies external collections
+ * @since 0.5.0
+ * @abstract
+ * @private
+ */
+class CacheStore {
+
+	/**
+	 * Creates a CacheStore instance
+	 * @since 0.5.0
+	 * @param {external:Collection} collection The map to proxy
+	 */
+	constructor(collection = new Collection()) {
+		/**
+		 * The cached DataStore or Collection to get the data from.
+		 * @since 0.5.0
+		 * @type {external:Collection}
+		 * @private
+		 */
+		this.collection = collection;
+	}
+
+	/**
+	 * The get method which gets an entry from the collection.
+	 * @since 0.5.0
+	 * @param {string|string[]} path The path to retrieve
+	 * @returns {SatelliteStore|Settings}
+	 * @abstract
+	 */
+	get() {
+		throw new Error(`[CACHESTORE] | Missing method 'get' of ${this.constructor.name}`);
+	}
+
+	/**
+	 * The has method which checks if an entry exists.
+	 * @since 0.5.0
+	 * @param {string|string[]} path The path to check
+	 * @returns {boolean}
+	 * @abstract
+	 */
+	has() {
+		throw new Error(`[CACHESTORE] | Missing method 'has' of ${this.constructor.name}`);
+	}
+
+	/**
+	 * Returns a new Iterator object that contains the keys for each element contained in this store.
+	 * Identical to [Map.keys()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys)
+	 * @since 0.5.0
+	 * @yields {string}
+	 */
+	*keys() {
+		for (const settings of this.values()) yield settings.id;
+	}
+
+	/**
+	 * Returns a new Iterator object that contains the values for each element contained in this store.
+	 * Identical to [Map.values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values)
+	 * @since 0.5.0
+	 * @yields {Settings}
+	 */
+	*values() {
+		yield* this.collection.values();
+	}
+
+	/**
+	 * Returns a new Iterator object that contains the `[key, value]` pairs for each element contained in this store.
+	 * Identical to [Map.entries()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries)
+	 * @since 0.5.0
+	 * @yields {Array<string|Settings>}
+	 */
+	*entries() {
+		for (const settings of this.values()) yield [settings.id, settings];
+	}
+
+	/**
+	 * Returns a new Iterator object that contains the `[key, value]` pairs for each element contained in this store.
+	 * Identical to [Map.entries()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries)
+	 * @name @@iterator
+	 * @since 0.5.0
+	 * @method
+	 * @instance
+	 * @generator
+	 * @returns {Iterator<Array<string|Settings>>}
+	 * @memberof CacheStore
+	 */
+
+	*[Symbol.iterator]() {
+		yield* this.entries();
+	}
+
+}
+
+module.exports = CacheStore;

--- a/src/lib/settings/cache/SatelliteStore.js
+++ b/src/lib/settings/cache/SatelliteStore.js
@@ -1,0 +1,39 @@
+const CacheStore = require('./CacheStore');
+
+class SatelliteStore extends CacheStore {
+
+	/**
+	 * The get method which gets an entry from the collection.
+	 * @since 0.5.0
+	 * @param {string|string[]} path The path to retrieve
+	 * @returns {SatelliteStore|Settings}
+	 */
+	get(path) {
+		const [key, ...rest] = typeof path === 'string' ? path.split('.') : path;
+		const entry = this.collection.get(key);
+		return entry && (rest.length ? entry.satellite.get(rest) : entry.satellite);
+	}
+
+	/**
+	 * The has method which checks if an entry exists.
+	 * @since 0.5.0
+	 * @param {string|string[]} path The path to check
+	 * @returns {boolean}
+	 */
+	has(path) {
+		return Boolean(this.get(path));
+	}
+
+	/**
+	 * Returns a new Iterator object that contains the values for each element contained in this store.
+	 * Identical to [Map.values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values)
+	 * @since 0.5.0
+	 * @yields {Settings}
+	 */
+	*values() {
+		for (const value of this.collection.values()) yield* value.satellite.values();
+	}
+
+}
+
+module.exports = SatelliteStore;

--- a/src/lib/settings/cache/SettingsStore.js
+++ b/src/lib/settings/cache/SettingsStore.js
@@ -1,0 +1,38 @@
+const CacheStore = require('./CacheStore');
+
+class SettingsStore extends CacheStore {
+
+	/**
+	 * The get method which gets an entry from the collection.
+	 * @since 0.5.0
+	 * @param {string|string[]} path The path to retrieve
+	 * @returns {Settings}
+	 */
+	get(path) {
+		const entry = this.collection.get(typeof path === 'string' ? path : path.join('.'));
+		return entry && entry.settings;
+	}
+
+	/**
+	 * The has method which checks if an entry exists.
+	 * @since 0.5.0
+	 * @param {string|string[]} path The path to check
+	 * @returns {boolean}
+	 */
+	has(path) {
+		return this.collection.has(path);
+	}
+
+	/**
+	 * Returns a new Iterator object that contains the values for each element contained in this store.
+	 * Identical to [Map.values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values)
+	 * @since 0.5.0
+	 * @yields {Settings}
+	 */
+	*values() {
+		for (const value of this.collection.values()) yield value.settings;
+	}
+
+}
+
+module.exports = SettingsStore;


### PR DESCRIPTION
### Description of the PR

Blocked until #383 lands, this PR targets the `sg-schema-changes` branch to not have merge conflicts.

---

One of the major concerns in SettingsGateway was the double caching layer, which achieved both a correct functionality for all cache operations, but also a higher memory usage, leading to several issues, as they're never removed unless done manually by the developer.

#### How does the Reverse-Proxy Collection/DataStore work?

Currently, we have three built-in gateways:

- `guilds`, all entries are also in `this.client.guilds.get(guildid).settings;`, which gets guildid's settings.
- `users`, all entries are also in `this.client.users.get(userid).settings;`, which gets userid's settings.
- `clientStorage`, it only has one entry, no datastore.

So what the Reverse-Proxy does is:

- `guilds.cache.get(id);` -> `this.client.guilds.get(id)?.settings;`
- `users.cache.get(id);` -> `this.client.users.get(id)?.settings;`
- `clientStorage` remains the same.

This allows the removal of the second caching layer for gateways that can outsource to external datastores, reducing memory by a lot.

**Additionally, Satellites have been added for nested datastores' gateways, such as per-member configs.**

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- Added ability for Gateway to outsource the cache via external SatelliteStores or DataStores. (kyranet)
- Added `CacheStore`, `SatelliteStore`, and `SettingsStore` classes to proxy external datastores. (kyranet)

**Changed**:

- Changed `Gateway#cache` to be either a `SatelliteStore` or a `SettingsStore` instance. (kyranet)

**Removed**:

- **[BREAKING]** Removed `Gateway#get`. (kyranet)

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
