### PR TITLE
feat: Support for no prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#392](https://github.com/dirigeants/klasa/pull/392)] Added support for empty prefixes. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added the `SETTING_GATEWAY_INVALID_FILTERED_VALUE` language key. (bdistin)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added `Base` class for schemas, extending `Map`. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added `SchemaType` and `SchemaTypes` classes. (Unseenfaith)
@@ -122,6 +123,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#392](https://github.com/dirigeants/klasa/pull/392)] Changed default prefix from `'!'` to `''`. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed SchemaFolder to extend Schema, which extends Map. All keys are now stored inside the map as opposed to being properties. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed `Schema#add` and `Schema#remove` to be synchronous. They must be called before ready. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed `GatewayDriver#register`'s arguments to move `schema`'s argument to `GatewayDriverRegisterOptions`. (kyranet)

--- a/guides/Getting Started/GettingStarted.md
+++ b/guides/Getting Started/GettingStarted.md
@@ -40,6 +40,7 @@ new Client({
 | **ignoreBots**             | `true`                    | boolean            | Whether or not this bot should ignore other bots                                    |
 | **ignoreSelf**             | `client.user.bot`         | boolean            | Whether or not this bot should ignore itself (true for bots, false for selfbots)    |
 | **language**               | `en-US`                   | string             | The default language Klasa should opt-in for the commands                           |
+| **noPrefixDM**             | `false`                   | boolean            | Whether the bot should allow prefixless messages in DMs                     |
 | **ownerID**                | see below¹                | string             | The Discord ID for the user the bot should respect as the owner                     |
 | **permissionLevels**       | `defaultPermissionLevels` | PermissionLevels   | The permission levels to use with this bot                                          |
 | **prefix**                 | `undefined`               | string/array       | The default prefix(es) when the bot first boots up.²                                |

--- a/guides/Getting Started/GettingStarted.md
+++ b/guides/Getting Started/GettingStarted.md
@@ -40,7 +40,7 @@ new Client({
 | **ignoreBots**             | `true`                    | boolean            | Whether or not this bot should ignore other bots                                    |
 | **ignoreSelf**             | `client.user.bot`         | boolean            | Whether or not this bot should ignore itself (true for bots, false for selfbots)    |
 | **language**               | `en-US`                   | string             | The default language Klasa should opt-in for the commands                           |
-| **noPrefixDM**             | `false`                   | boolean            | Whether the bot should allow prefixless messages in DMs                     |
+| **noPrefixDM**             | `false`                   | boolean            | Whether the bot should allow prefixless messages in DMs                             |
 | **ownerID**                | see below¹                | string             | The Discord ID for the user the bot should respect as the owner                     |
 | **permissionLevels**       | `defaultPermissionLevels` | PermissionLevels   | The permission levels to use with this bot                                          |
 | **prefix**                 | `undefined`               | string/array       | The default prefix(es) when the bot first boots up.²                                |

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -492,7 +492,7 @@ KlasaClient.types = new SchemaTypes(Object.entries(require('./settings/schema/ty
  * @type {Schema}
  */
 KlasaClient.defaultGuildSchema = new Schema()
-	.add('prefix', 'string', { default: '' })
+	.add('prefix', 'string')
 	.add('language', 'language')
 	.add('disableNaturalPrefix', 'boolean')
 	.add('disabledCommands', 'command', {

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -492,7 +492,7 @@ KlasaClient.types = new SchemaTypes(Object.entries(require('./settings/schema/ty
  * @type {Schema}
  */
 KlasaClient.defaultGuildSchema = new Schema()
-	.add('prefix', 'string')
+	.add('prefix', 'string', { default: '' })
 	.add('language', 'language')
 	.add('disableNaturalPrefix', 'boolean')
 	.add('disabledCommands', 'command', {

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -47,6 +47,7 @@ class KlasaClient extends Discord.Client {
 	 * @property {string[]} [disabledCorePieces=[]] An array of disabled core piece types, e.g., ['commands', 'arguments']
 	 * @property {KlasaGatewaysOptions} [gateways={}] The options for each built-in gateway
 	 * @property {string} [language='en-US'] The default language Klasa should opt-in for the commands
+	 * @property {boolean} [noPrefixDM=false] Whether the bot should allow prefixless messages in DMs
 	 * @property {string} [ownerID] The discord user id for the user the bot should respect as the owner (gotten from Discord api if not provided)
 	 * @property {PermissionLevels} [permissionLevels=KlasaClient.defaultPermissionLevels] The permission levels to use with this bot
 	 * @property {KlasaPieceDefaults} [pieceDefaults={}] Overrides the defaults for all pieces

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -23,6 +23,7 @@ exports.DEFAULTS = {
 		},
 		disabledCorePieces: [],
 		language: 'en-US',
+		noPrefixDM: false,
 		prefix: '',
 		preserveSettings: true,
 		readyMessage: (client) => `Successfully initialized. Ready to serve ${client.guilds.size} guild${client.guilds.size === 1 ? '' : 's'}.`,

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -23,7 +23,7 @@ exports.DEFAULTS = {
 		},
 		disabledCorePieces: [],
 		language: 'en-US',
-		prefix: '!',
+		prefix: '',
 		preserveSettings: true,
 		readyMessage: (client) => `Successfully initialized. Ready to serve ${client.guilds.size} guild${client.guilds.size === 1 ? '' : 's'}.`,
 		typing: false,

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -55,14 +55,14 @@ module.exports = class extends Monitor {
 
 	getPrefix(message) {
 		if (this.prefixMention.test(message.content)) return { length: this.nick.test(message.content) ? this.prefixMentionLength + 1 : this.prefixMentionLength, regex: this.prefixMention };
-		if (message.guildSettings.disableNaturalPrefix !== true && this.client.options.regexPrefix) {
+		if (!message.guildSettings.disableNaturalPrefix && this.client.options.regexPrefix) {
 			const results = this.client.options.regexPrefix.exec(message.content);
 			if (results) return { length: results[0].length, regex: this.client.options.regexPrefix };
 		}
-		const prefix = message.guildSettings.prefix || this.client.options.prefix;
+		const { prefix } = message.guildSettings;
 		if (Array.isArray(prefix)) {
-			for (let i = prefix.length - 1; i >= 0; i--) {
-				const testingPrefix = this.prefixes.get(prefix[i]) || this.generateNewPrefix(prefix[i]);
+			for (const prf of prefix) {
+				const testingPrefix = this.prefixes.get(prf) || this.generateNewPrefix(prf);
 				if (testingPrefix.regex.test(message.content)) return testingPrefix;
 			}
 		} else if (prefix) {

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -4,6 +4,7 @@ module.exports = class extends Monitor {
 
 	constructor(...args) {
 		super(...args, { ignoreOthers: false });
+		this.noPrefix = { length: 0, regex: null };
 		this.prefixes = new Map();
 		this.prefixMention = null;
 		this.prefixMentionLength = null;
@@ -69,7 +70,7 @@ module.exports = class extends Monitor {
 			const testingPrefix = this.prefixes.get(prefix) || this.generateNewPrefix(prefix);
 			if (testingPrefix.regex.test(message.content)) return testingPrefix;
 		}
-		return false;
+		return this.client.options.noPrefixDM && message.channel.type === 'dm' ? this.noPrefix : false;
 	}
 
 	generateNewPrefix(prefix) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1265,12 +1265,13 @@ declare module 'klasa' {
 		disabledCorePieces?: string[];
 		gateways?: KlasaGatewaysOptions;
 		language?: string;
+		noPrefixDM?: boolean;
 		ownerID?: string;
 		permissionLevels?: PermissionLevels;
 		pieceDefaults?: KlasaPieceDefaults;
 		prefix?: string | string[];
-		preserveSettings?: boolean;
 		prefixCaseInsensitive?: boolean;
+		preserveSettings?: boolean;
 		providers?: KlasaProvidersOptions;
 		readyMessage?: (client: KlasaClient) => string;
 		regexPrefix?: RegExp;


### PR DESCRIPTION
### Description of the PR

This PR targets the `sg-schema-changes` branch to not have merge conflicts.

To continue our `klasa@1.0.0` milestone, a no-prefix option was planned for quite some time, this PR adds support for it using an empty string for so.

This PR also refactors `CommandHandler#getPrefix` a little to use a for-of loop instead of a reverse for loop and to remove the prefix fallback (`message.guildSettings.prefix` is always defined).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added support for empty prefixes. (kyranet)
- Changed default prefix from `'!'` to `''`. (kyranet)

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
