### PR TITLE
Fix timezone offset

### DIFF
--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -153,7 +153,7 @@ class Timestamp {
 
 /* eslint-disable id-length */
 
-Timestamp.timezoneOffset = new Date().getTimezoneOffset() * 60000;
+Timestamp.timezoneOffset = (new Date().getTimezoneOffset() * 60000) * -1;
 
 // Dates
 

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -90,7 +90,7 @@ class Timestamp {
 	 */
 	static utc(time = new Date()) {
 		time = Timestamp._resolveDate(time);
-		return new Date(time.valueOf() - Timestamp.timezoneOffset);
+		return new Date(time.valueOf() + Timestamp.timezoneOffset);
 	}
 
 	/**
@@ -153,7 +153,7 @@ class Timestamp {
 
 /* eslint-disable id-length */
 
-Timestamp.timezoneOffset = (new Date().getTimezoneOffset() * 60000) * -1;
+Timestamp.timezoneOffset = new Date().getTimezoneOffset() * 60000;
 
 // Dates
 


### PR DESCRIPTION
### Description of the PR
Whenever you used Timestamp#displayUTC it'd remove Timestamp.timezoneOffset from the current date. The issue, is that, in timezones that are +NUMBER, the number would be negative, so instead of subtracting, it would add. (Thanks JS)

This PR fixes that inversion, by multiplying the offset by -1. This makes it to where someones whos on -NUMBER UTC gains hours, and those who are in +NUMBER UTC lose hours.

(Someone in the US help me test)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
