### PR TITLE
feat: Added overwrite action, allow add/remove/auto to update multiple entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#398](https://github.com/dirigeants/klasa/pull/398)] Added the `Settings#update(entries: Array<[string, any]>);` overload. (kyranet)
 - [[#392](https://github.com/dirigeants/klasa/pull/392)] Added support for empty prefixes. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added the `SETTING_GATEWAY_INVALID_FILTERED_VALUE` language key. (bdistin)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Added `Base` class for schemas, extending `Map`. (Unseenfaith)
@@ -226,6 +227,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#398](https://github.com/dirigeants/klasa/pull/398)] Removed the `Settings#update(keys: string[], values: any[])` overload. (kyranet)
 - [[#391](https://github.com/dirigeants/klasa/pull/391)] Removed `Util.getIdentifier()`. (kyranet)
 - [[#391](https://github.com/dirigeants/klasa/pull/391)] Removed Gateways' second caching layer. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Removed `bwd/*.schema.json` files. (Unseenfaith)

--- a/guides/Advanced SettingsGateway/SettingsGatewaySettingsUpdate.md
+++ b/guides/Advanced SettingsGateway/SettingsGatewaySettingsUpdate.md
@@ -25,7 +25,7 @@ message.guild.settings.update('userBlacklist', '272689325521502208', { action: '
 message.guild.settings.update('userBlacklist', '272689325521502208', { action: 'remove' });
 
 // Updating multiple keys
-message.guild.settings.update(['prefix', 'language'], ['k!', 'en-ES']);
+message.guild.settings.update([['prefix', 'k!'], ['language', 'es-ES']]);
 ```
 
 > **Note**: Some types require a Guild instance to work, for example, *channels*, *roles* and *members*.

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -252,7 +252,7 @@ class Settings {
 		if (isObject(key)) {
 			[guild, options] = [value, guild];
 			entries = objectToTuples(key);
-		} else if (typeof keys === 'string') {
+		} else if (typeof key === 'string') {
 			// Overload update(string, any, ...any[]);
 			entries = [key, value];
 		} else if (!Array.isArray(key) || key.some(entry => !Array.isArray(entry) || entry.length !== 2)) {

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -428,33 +428,28 @@ class Settings {
 			}
 			return;
 		}
-		const lengthErrors = errors.length;
 		const array = this.get(route);
-		const clone = array.slice();
 		if (typeof arrayPosition === 'number') {
-			if (arrayPosition >= clone.length) errors.push(new Error(`The option arrayPosition should be a number between 0 and ${clone.length - 1}`));
-			else clone[arrayPosition] = parsed;
+			if (arrayPosition >= array.length) errors.push(new Error(`The option arrayPosition should be a number between 0 and ${array.length - 1}`));
+			else array[arrayPosition] = parsed;
 		} else {
 			for (const value of Array.isArray(parsed) ? parsed : [parsed]) {
-				const index = clone.indexOf(value);
+				const index = array.indexOf(value);
 				if (action === 'auto') {
-					if (index === -1) clone.push(value);
-					else clone.splice(index, 1);
+					if (index === -1) array.push(value);
+					else array.splice(index, 1);
 				} else if (action === 'add') {
 					if (index !== -1) errors.push(new Error(`The value ${parsed} for the key ${piece.path} already exists.`));
-					else clone.push(parsed);
+					else array.push(parsed);
 				} else if (index === -1) {
 					errors.push(new Error(`The value ${parsed} for the key ${piece.path} does not exist.`));
 				} else {
-					clone.splice(index, 1);
+					array.splice(index, 1);
 				}
 			}
 		}
 
-		if (errors.length === lengthErrors) {
-			this._setValueByPath(piece, clone, true);
-			updated.push({ data: [piece.path, clone], piece });
-		}
+		updated.push({ data: [piece.path, array], piece });
 	}
 
 	/**

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -440,7 +440,7 @@ class Settings {
 					else array.splice(index, 1);
 				} else if (action === 'add') {
 					if (index !== -1) errors.push(new Error(`The value ${parsed} for the key ${piece.path} already exists.`));
-					else array.push(parsed);
+					else array.push(...parsed);
 				} else if (index === -1) {
 					errors.push(new Error(`The value ${parsed} for the key ${piece.path} does not exist.`));
 				} else {

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -414,7 +414,7 @@ class Settings {
 	 * Parse a single value for an array
 	 * @since 0.5.0
 	 * @param {SchemaPiece} piece The SchemaPiece pointer that parses this entry
-	 * @param {string[]} route The path bits for property accessment
+	 * @param {string[]} route The path bits for property accesses
 	 * @param {*} parsed The parsed value
 	 * @param {SettingsUpdateOptions} options The parse options
 	 * @param {SettingsUpdateResult} result The updated result

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -254,7 +254,7 @@ class Settings {
 			entries = objectToTuples(key);
 		} else if (typeof key === 'string') {
 			// Overload update(string, any, ...any[]);
-			entries = [key, value];
+			entries = [[key, value]];
 		} else if (!Array.isArray(key) || key.some(entry => !Array.isArray(entry) || entry.length !== 2)) {
 			return Promise.reject(new TypeError(`Invalid value. Expected object, string or Array<[string, any]>. Got: ${new Type(key)}`));
 		} else {

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -245,20 +245,20 @@ class Util {
 	 * Convert an object to a tuple
 	 * @since 0.5.0
 	 * @param {Object<string, *>} object The object to convert
-	 * @param {{ keys: string[], values: any[] }} [entries={}] The initial entries
 	 * @param {string} [prefix=''] The prefix for the key
 	 * @returns {Array<Array<*>>}
 	 */
-	static objectToTuples(object, { keys = [], values = [] } = {}, prefix = '') {
-		for (const key of Object.keys(object)) {
-			if (Util.isObject(object[key])) {
-				Util.objectToTuples(object[key], { keys, values }, `${prefix}${key}.`);
+	static objectToTuples(object, prefix = '') {
+		const entries = [];
+		for (const [key, value] of Object.entries(object)) {
+			if (Util.isObject(value)) {
+				entries.concat(Util.objectToTuples(value, `${prefix}${key}.`));
 			} else {
-				keys.push(`${prefix}${key}`);
-				values.push(object[key]);
+				entries.push([`${prefix}${key}`, value]);
 			}
 		}
-		return [keys, values];
+
+		return entries;
 	}
 
 	/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -470,8 +470,8 @@ declare module 'klasa' {
 		public update(key: ObjectLiteral, guild?: GuildResolvable, options?: SettingsUpdateOptions): Promise<SettingsUpdateResult>;
 		public update(key: string, value: any, options?: SettingsUpdateOptions): Promise<SettingsUpdateResult>;
 		public update(key: string, value: any, guild?: GuildResolvable, options?: SettingsUpdateOptions): Promise<SettingsUpdateResult>;
-		public update(key: string[], value: any[], options?: SettingsUpdateOptions): Promise<SettingsUpdateResult>;
-		public update(key: string[], value: any[], guild?: GuildResolvable, options?: SettingsUpdateOptions): Promise<SettingsUpdateResult>;
+		public update(entries: Array<[string, any]>, options?: SettingsUpdateOptions): Promise<SettingsUpdateResult>;
+		public update(entries: Array<[string, any]>, guild?: GuildResolvable, options?: SettingsUpdateOptions): Promise<SettingsUpdateResult>;
 		public list(message: KlasaMessage, path: SchemaFolder | string): string;
 		public resolveString(message: KlasaMessage, path: SchemaPiece | string): string;
 
@@ -1234,7 +1234,7 @@ declare module 'klasa' {
 		public static makeObject<T = ObjectLiteral, S = ObjectLiteral>(path: string, value: any, obj?: ObjectLiteral): T & S;
 		public static mergeDefault<T = ObjectLiteral, S = ObjectLiteral>(objDefaults: T, objSource: S): T & S;
 		public static mergeObjects<T = ObjectLiteral, S = ObjectLiteral>(objTarget: T, objSource: S): T & S;
-		public static objectToTuples(obj: ObjectLiteral, entries?: { keys: string[], values: any[] }): [string[], any[]];
+		public static objectToTuples(obj: ObjectLiteral): Array<[string, any]>;
 		public static regExpEsc(str: string): string;
 		public static sleep<T = any>(delay: number, args?: T): Promise<T>;
 		public static toTitleCase(str: string): string;
@@ -1465,7 +1465,7 @@ declare module 'klasa' {
 	};
 
 	export type SettingsUpdateOptions = {
-		action?: 'add' | 'remove' | 'auto';
+		action?: 'add' | 'remove' | 'auto' | 'overwrite';
 		arrayPosition?: number;
 		avoidUnconfigurable?: boolean;
 		force?: boolean;


### PR DESCRIPTION
### Description of the PR

What the title says

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- Added the `Settings#update(entries: Array<[string, any]>);` overload. (kyranet)
- Added a new option to `SettingsUpdateOptions.action` (`override`).

**Removed**:

- Removed the `Settings#update(keys: string[], values: any[])` overload. (kyranet)

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
