### PR TITLE
polish: Schedule and ScheduledTask

### DIFF
--- a/src/lib/schedule/ScheduledTask.js
+++ b/src/lib/schedule/ScheduledTask.js
@@ -233,8 +233,7 @@ class ScheduledTask {
 	 * @private
 	 */
 	static _generateID(client) {
-		i = i < 46656 ? i + 1 : 0;
-		return Date.now().toString(36) + (client.shard ? client.shard.id.toString(36) : '') + i.toString(36);
+		return Date.now().toString(36) + (client.shard ? client.shard.id.toString(36) : '');
 	}
 
 	/**
@@ -252,5 +251,3 @@ class ScheduledTask {
 }
 
 module.exports = ScheduledTask;
-
-let i = 0;

--- a/src/lib/schedule/ScheduledTask.js
+++ b/src/lib/schedule/ScheduledTask.js
@@ -71,7 +71,7 @@ class ScheduledTask {
 		/**
 		 * The Date when this scheduled task ends
 		 * @since 0.5.0
-		 * @type {?Date}
+		 * @type {Date}
 		 */
 		this.time = 'time' in options ? new Date(options.time) : _time;
 
@@ -233,7 +233,8 @@ class ScheduledTask {
 	 * @private
 	 */
 	static _generateID(client) {
-		return Date.now().toString(36) + (client.shard ? client.shard.id.toString(36) : '') + String.fromCharCode((1 % 26) + 97);
+		i = i < 46656 ? i + 1 : 0;
+		return Date.now().toString(36) + (client.shard ? client.shard.id.toString(36) : '') + i.toString(36);
 	}
 
 	/**
@@ -245,8 +246,11 @@ class ScheduledTask {
 	static _validate(st) {
 		if (!st.task) throw new Error('invalid task');
 		if (!st.time) throw new Error('time or repeat option required');
+		if (Number.isNaN(st.time.getTime())) throw new Error('invalid time passed');
 	}
 
 }
 
 module.exports = ScheduledTask;
+
+let i = 0;


### PR DESCRIPTION
### Description of the PR

This PR only polishes the schedule classes and removes old code from Schedule#init (which I forgot to remove in #383, I have checked for any other occurrence of this pattern but I couldn't find any other).

Additionally, this also adds a check for unvalid dates, to prevent Schedule from successfully adding tasks that will be due in a million years (which are displayed as `Invalid Date`).

Also refactors `Schedule#@@iterator` by yielding the array's iterator rather than yielding each value from the array.

Finally, this also makes ScheduleTask.createID much safer by using an incremental number, and fixes ScheduledTask#time's jsdoc type by removing the `?` (it's always a Date instance).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Removes old code, pulishes and makes some checks more robust

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
