### PR TITLE
polish: Settings, replaced Settings#waitSync with Settings#sync(?false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Removed
 
+- [[#401](https://github.com/dirigeants/klasa/pull/401)] Removed `Settings#waitSync` in favor of `Settings#sync(?false);`. (kyranet)
 - [[#398](https://github.com/dirigeants/klasa/pull/398)] Removed the `Settings#update(keys: string[], values: any[])` overload. (kyranet)
 - [[#391](https://github.com/dirigeants/klasa/pull/391)] Removed `Util.getIdentifier()`. (kyranet)
 - [[#391](https://github.com/dirigeants/klasa/pull/391)] Removed Gateways' second caching layer. (kyranet)

--- a/src/lib/settings/Gateway.js
+++ b/src/lib/settings/Gateway.js
@@ -72,7 +72,7 @@ class Gateway extends GatewayStorage {
 		if (entry) return entry.settings;
 		if (create) {
 			const settings = new this.Settings(this, { id });
-			if (this._synced && this.schema.size) settings.sync().catch(err => this.client.emit('error', err));
+			if (this._synced && this.schema.size) settings.sync(true).catch(err => this.client.emit('error', err));
 			return settings;
 		}
 		return null;
@@ -105,7 +105,7 @@ class Gateway extends GatewayStorage {
 		}
 
 		const cache = this.get((input && input.id) || input);
-		return cache ? cache.sync() : null;
+		return cache ? cache.sync(true) : null;
 	}
 
 }

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -122,23 +122,15 @@ class Settings {
 	}
 
 	/**
-	 * Wait for the sync
-	 * @since 0.5.0
-	 * @returns {Promise<this>}
-	 */
-	waitSync() {
-		return this.gateway.syncQueue.get(this.id) || Promise.resolve(this);
-	}
-
-	/**
 	 * Sync the data from the database with the cache.
 	 * @since 0.5.0
+	 * @param {boolean} [force=false] Whether the sync should download from the database
 	 * @returns {Promise<this>}
 	 */
-	sync() {
+	sync(force = false) {
 		// Await current sync status from the sync queue
 		const syncStatus = this.gateway.syncQueue.get(this.id);
-		if (syncStatus) return syncStatus;
+		if (!force || syncStatus) return syncStatus || Promise.resolve(this);
 
 		// If it's not currently synchronizing, create a new sync status for the sync queue
 		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(data => {
@@ -399,7 +391,7 @@ class Settings {
 	 */
 	async _save({ updated }) {
 		if (!updated.length) return;
-		if (this._existsInDB === null) await this.sync();
+		if (this._existsInDB === null) await this.sync(true);
 		if (this._existsInDB === false) {
 			await this.gateway.provider.create(this.gateway.type, this.id);
 			this._existsInDB = true;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -461,8 +461,7 @@ declare module 'klasa' {
 
 		public get<T = any>(path: string | string[]): T;
 		public clone(): Settings;
-		public sync(): Promise<this>;
-		public waitSync(): Promise<this>;
+		public sync(force?: boolean): Promise<this>;
 		public destroy(): Promise<this>;
 
 		public reset(key?: string | string[], options?: SettingsResetOptions): Promise<SettingsUpdateResult>;


### PR DESCRIPTION
### Description of the PR

This PR polishes Settings a bit by removing Settings#waitSync in favor of Settings#sync(?false), which will take an force argument defaulting to false (waitSync's behaviour).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added force argument in `Settings#sync()`. (kyranet)
- Removed `Settings#waitSync()`. (kyranet)

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
