### PR TITLE
SG Auto-Resolving

### DIFF
--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -384,7 +384,7 @@ class Settings {
 		if (piece.array) {
 			this._parseArray(piece, route, parsedID, options, result);
 		} else if (this._setValueByPath(piece, parsedID, options.force).updated) {
-			result.updated.push({ data: [piece.path, parsedID.id || parsedID], piece });
+			result.updated.push({ data: [piece.path, parsedID.id || parsedID.name || parsedID], piece });
 		}
 	}
 
@@ -421,7 +421,7 @@ class Settings {
 		if (action === 'overwrite') {
 			if (!Array.isArray(parsed)) parsed = [parsed];
 			if (this._setValueByPath(piece, parsed, force).updated) {
-				updated.push({ data: [piece.path, parsed.id || parsed], piece });
+				updated.push({ data: [piece.path, parsed.id || parsed.name || parsed], piece });
 			}
 			return;
 		}
@@ -431,7 +431,7 @@ class Settings {
 			else array[arrayPosition] = parsed;
 		} else {
 			for (let value of Array.isArray(parsed) ? parsed : [parsed]) {
-				value = piece.resolve ? value : value.id;
+				value = piece.resolve ? value : value.id || value.name || value;
 				const index = array.indexOf(value);
 				if (action === 'auto') {
 					if (index === -1) array.push(value);
@@ -447,8 +447,8 @@ class Settings {
 			}
 		}
 
-		// Flatten array down to id where possible so that database only stores the array here
-		updated.push({ data: [piece.path, array.map(value => value.id || value)], piece });
+		// Flatten array down to id/name where possible so that database only stores the array here
+		updated.push({ data: [piece.path, array.map(value => value.id || value.name || value)], piece });
 	}
 
 	/**
@@ -489,7 +489,7 @@ class Settings {
 		// If both parts are equal, don't update
 		if (!force && (piece.array ? arraysStrictEquals(old, parsedID) : old === parsedID)) return { updated: false, old };
 
-		cache[lastKey] = piece.resolve ? parsedID : parsedID.id;
+		cache[lastKey] = piece.resolve ? parsedID : parsedID.id || parsedID.name;
 		return { updated: true, old };
 	}
 
@@ -518,7 +518,7 @@ class Settings {
 	 * @returns {SettingsJSON}
 	 */
 	toJSON() {
-		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key].id || this[key]) })));
+		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key].id || this[key].name || this[key]) })));
 	}
 
 	/**

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -133,10 +133,15 @@ class Settings {
 		if (!force || syncStatus) return syncStatus || Promise.resolve(this);
 
 		// If it's not currently synchronizing, create a new sync status for the sync queue
-		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(data => {
+		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(async data => {
 			if (data) {
 				if (!this._existsInDB) this._existsInDB = true;
-				this._patch(data);
+				if (this.gateway.schema.shouldResolve()) {
+					const resolved = await this.gateway.schema.resolve(data);
+					this._patch(resolved);
+				} else {
+					this._patch(data);
+				}
 			} else {
 				this._existsInDB = false;
 			}

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -136,7 +136,7 @@ class Settings {
 		const sync = this.gateway.provider.get(this.gateway.type, this.id).then(async data => {
 			if (data) {
 				if (!this._existsInDB) this._existsInDB = true;
-				if (this.gateway.schema.shouldResolve()) {
+				if (this.gateway.schema.shouldResolve) {
 					const resolved = await this.gateway.schema.resolve(data);
 					this._patch(resolved);
 				} else {

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -516,7 +516,7 @@ class Settings {
 	 * @returns {SettingsJSON}
 	 */
 	toJSON() {
-		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key]) })));
+		return Object.assign({}, ...[...this.gateway.schema.keys()].map(key => ({ [key]: deepClone(this[key].id || this[key]) })));
 	}
 
 	/**

--- a/src/lib/settings/schema/Base.js
+++ b/src/lib/settings/schema/Base.js
@@ -138,8 +138,8 @@ class Base extends Map {
 				const piece = this.get(this.path ? `${this.path}.${key}` : key);
 				if (piece.type === 'Folder') return { [key]: await piece.resolve(data) };
 				if (!piece.resolve) return data;
-				if (piece.array) return { [key]: await Promise.all(data.map(dat => piece.parse(dat, guild))) };
-				return { [key]: await piece.parse(data, guild) };
+				if (piece.array) return { [key]: await Promise.all(data.map(dat => piece.autoResolve(dat, guild))) };
+				return { [key]: await piece.autoResolve(data, guild) };
 			}));
 		return Object.assign({}, ...resolved);
 	}

--- a/src/lib/settings/schema/Base.js
+++ b/src/lib/settings/schema/Base.js
@@ -117,7 +117,7 @@ class Base extends Map {
 	 * Whether or not this SchemaFolder or Schema instance should be resolved
 	 * @since 0.5.0
 	 * @readonly
-	 * @returns {boolean}
+	 * @type {boolean}
 	 */
 	get shouldResolve() {
 		for (const piece of this.values(true)) if (piece.resolve) return true;

--- a/src/lib/settings/schema/Base.js
+++ b/src/lib/settings/schema/Base.js
@@ -119,8 +119,9 @@ class Base extends Map {
 	 * @readonly
 	 * @returns {boolean}
 	 */
-	shouldResolve() {
-		return [...this.values()].some(piece => piece.type === 'Folder' ? piece.shouldResolve() : piece.resolve);
+	get shouldResolve() {
+		for (const piece of this.values(true)) if (piece.resolve) return true;
+		return false;
 	}
 
 	/**

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -190,7 +190,7 @@ class SchemaPiece {
 	 */
 	async parse(value, guild) {
 		const language = guild ? guild.language : this.client.languages.default;
-		const val = await this.resolver.resolve(value, this, language, guild);
+		const val = await this.resolver.resolve(value, this, language, guild).then(data => data.id || data);
 		if (this.filter && this.filter(this.client, val, this, language)) throw language.get('SETTING_GATEWAY_INVALID_FILTERED_VALUE', this, value);
 		return val;
 	}

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -11,7 +11,7 @@ class SchemaPiece {
 	 * @property {boolean} [configurable] Whether or not the key should be configurable by the configuration command
 	 * @property {number} [min] The minimum value for this piece
 	 * @property {number} [max] The maximum value for this piece
-	 * @property {boolean} resolve Whether or not this piece should be auto-resolved
+	 * @property {boolean} [resolve] Whether or not this piece should be auto-resolved
 	 */
 
 	/**
@@ -157,8 +157,12 @@ class SchemaPiece {
 			this._checkFilter(options.filter);
 			this.filter = options.filter;
 		}
+		if ('resolve' in options) {
+			this._checkResolve(options.resolve);
+			this.resolve = options.resolve;
+		}
 		if ('default' in options) {
-			this._checkDefault(options);
+			this._checkDefault({ ...this, ...options });
 			this.default = options.default;
 		}
 
@@ -177,6 +181,7 @@ class SchemaPiece {
 		this._checkLimits(this.min, this.max);
 		this._checkFilter(this.filter);
 		this._checkDefault(this);
+		this._checkResolve(this.resolve);
 
 		return true;
 	}

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -197,12 +197,7 @@ class SchemaPiece {
 
 	async autoResolve(value, guild) {
 		const language = guild ? guild.language : this.client.languages.default;
-		let val;
-		try {
-			val = await this.resolver.resolve(value, this, language, guild);
-		} catch (error) {
-			val = null;
-		}
+		const val = await this.resolver.resolve(value, this, language, guild).catch(() => null);
 		if (val === null) return null;
 		if (this.filter && this.filter(this.client, val, this, language)) throw language.get('SETTING_GATEWAY_INVALID_FILTERED_VALUE', this, value);
 		return val;

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -190,7 +190,7 @@ class SchemaPiece {
 	 */
 	async parse(value, guild) {
 		const language = guild ? guild.language : this.client.languages.default;
-		const val = await this.resolver.resolve(value, this, language, guild).then(data => data.id || data);
+		const val = await this.resolver.resolve(value, this, language, guild);
 		if (this.filter && this.filter(this.client, val, this, language)) throw language.get('SETTING_GATEWAY_INVALID_FILTERED_VALUE', this, value);
 		return val;
 	}

--- a/src/lib/settings/schema/types/Channel.js
+++ b/src/lib/settings/schema/types/Channel.js
@@ -39,7 +39,7 @@ class ChannelType extends SchemaType {
 			(piece.type === 'textchannel' && data.type === 'text') ||
 			(piece.type === 'voicechannel' && data.type === 'voice') ||
 			(piece.type === 'categorychannel' && data.type === 'category')
-		) return piece.resolve ? data : data.id;
+		) return data;
 		throw language.get('RESOLVER_INVALID_CHANNEL', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Channel.js
+++ b/src/lib/settings/schema/types/Channel.js
@@ -39,7 +39,7 @@ class ChannelType extends SchemaType {
 			(piece.type === 'textchannel' && data.type === 'text') ||
 			(piece.type === 'voicechannel' && data.type === 'voice') ||
 			(piece.type === 'categorychannel' && data.type === 'category')
-		) return data.id;
+		) return piece.resolve ? data : data.id;
 		throw language.get('RESOLVER_INVALID_CHANNEL', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Guild.js
+++ b/src/lib/settings/schema/types/Guild.js
@@ -20,7 +20,7 @@ class GuildType extends SchemaType {
 	async resolve(data, piece, language) {
 		if (data instanceof Guild) return data.id;
 		const guild = this.constructor.regex.snowflake.test(data) ? this.client.guilds.get(data) : null;
-		if (guild) return piece.resolve ? guild : guild.id;
+		if (guild) return guild;
 		throw language.get('RESOLVER_INVALID_GUILD', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Guild.js
+++ b/src/lib/settings/schema/types/Guild.js
@@ -20,7 +20,7 @@ class GuildType extends SchemaType {
 	async resolve(data, piece, language) {
 		if (data instanceof Guild) return data.id;
 		const guild = this.constructor.regex.snowflake.test(data) ? this.client.guilds.get(data) : null;
-		if (guild) return guild.id;
+		if (guild) return piece.resolve ? guild : guild.id;
 		throw language.get('RESOLVER_INVALID_GUILD', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Piece.js
+++ b/src/lib/settings/schema/types/Piece.js
@@ -19,7 +19,7 @@ class PieceType extends SchemaType {
 	async resolve(data, piece, language) {
 		const store = this.client[`${piece.type}s`];
 		const parsed = typeof data === 'string' ? store.get(data) : data;
-		if (parsed && parsed instanceof store.holds) return piece.resolve ? parsed : parsed.name;
+		if (parsed && parsed instanceof store.holds) return parsed;
 		throw language.get('RESOLVER_INVALID_PIECE', piece.key, piece.type);
 	}
 

--- a/src/lib/settings/schema/types/Piece.js
+++ b/src/lib/settings/schema/types/Piece.js
@@ -19,7 +19,7 @@ class PieceType extends SchemaType {
 	async resolve(data, piece, language) {
 		const store = this.client[`${piece.type}s`];
 		const parsed = typeof data === 'string' ? store.get(data) : data;
-		if (parsed && parsed instanceof store.holds) return parsed.name;
+		if (parsed && parsed instanceof store.holds) return piece.resolve ? parsed : parsed.name;
 		throw language.get('RESOLVER_INVALID_PIECE', piece.key, piece.type);
 	}
 

--- a/src/lib/settings/schema/types/Role.js
+++ b/src/lib/settings/schema/types/Role.js
@@ -22,7 +22,7 @@ class RoleType extends SchemaType {
 		if (!guild) throw this.client.languages.default.get('RESOLVER_INVALID_GUILD', piece.key);
 		if (data instanceof Role) return data.id;
 		const role = this.constructor.regex.role.test(data) ? guild.roles.get(data) : guild.roles.find(rol => rol.name === data) || null;
-		if (role) return role.id;
+		if (role) return piece.resolve ? role : role.id;
 		throw language.get('RESOLVER_INVALID_ROLE', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/Role.js
+++ b/src/lib/settings/schema/types/Role.js
@@ -20,9 +20,9 @@ class RoleType extends SchemaType {
 	 */
 	async resolve(data, piece, language, guild) {
 		if (!guild) throw this.client.languages.default.get('RESOLVER_INVALID_GUILD', piece.key);
-		if (data instanceof Role) return data.id;
+		if (data instanceof Role) return data;
 		const role = this.constructor.regex.role.test(data) ? guild.roles.get(data) : guild.roles.find(rol => rol.name === data) || null;
-		if (role) return piece.resolve ? role : role.id;
+		if (role) return role;
 		throw language.get('RESOLVER_INVALID_ROLE', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/User.js
+++ b/src/lib/settings/schema/types/User.js
@@ -18,9 +18,9 @@ class UserType extends SchemaType {
 	 */
 	async resolve(data, piece, language) {
 		let user = this.client.users.resolve(data);
-		if (user) return piece.resolve ? user : user.id;
+		if (user) return user;
 		if (this.constructor.regex.userOrMember.test(data)) user = await this.client.users.fetch(this.constructor.regex.userOrMember.exec(data)[1]).catch(() => null);
-		if (user) return piece.resolve ? user : user.id;
+		if (user) return user;
 		throw language.get('RESOLVER_INVALID_USER', piece.key);
 	}
 

--- a/src/lib/settings/schema/types/User.js
+++ b/src/lib/settings/schema/types/User.js
@@ -18,9 +18,9 @@ class UserType extends SchemaType {
 	 */
 	async resolve(data, piece, language) {
 		let user = this.client.users.resolve(data);
-		if (user) return user.id;
+		if (user) return piece.resolve ? user : user.id;
 		if (this.constructor.regex.userOrMember.test(data)) user = await this.client.users.fetch(this.constructor.regex.userOrMember.exec(data)[1]).catch(() => null);
-		if (user) return user.id;
+		if (user) return piece.resolve ? user : user.id;
 		throw language.get('RESOLVER_INVALID_USER', piece.key);
 	}
 


### PR DESCRIPTION
### Description of the PR
Adds the functionality for creating and resolving settings automatically. This option is disabled by default, and can be enabled via SchemaPiece#resolve. Klasa will automatically resolve any and all resolvable values from the Schema (where possible).

Upon setting resolve to true on any piece in your schema, SG will automatically resolve that piece (and any other pieces that are resolve: true) for you.  During startup, when SG is synced, SG will resolve those values for you and assign them to `<SettingsInstance>[key]`. If for whatever reason, a key is not resolvable, either due to something missing or being deleted from Discord API, SG will set this key to null to keep it consistent with non-resolved values.


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- SchemaPiece#resolve
- Base#resolve
- Base#shouldResolve
- SchemaTypes always return full objects and SG will flatten them upon saving to database (subject to change)

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
