### PR TITLE
fix: A 9-month old bug

### DIFF
--- a/src/events/guildDelete.js
+++ b/src/events/guildDelete.js
@@ -3,7 +3,7 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(guild) {
-		if (guild.available && !this.client.settings.preserveSettings) guild.settings.destroy().catch(() => null);
+		if (this.client.ready && guild.available && !this.client.options.preserveSettings) guild.settings.destroy().catch(() => null);
 	}
 
 };


### PR DESCRIPTION
### Description of the PR

The option `preserveSettings` was, since the first day of 0.5.0-dev, in ClientStorage. This variable is a KlasaClientOption as described in the documentation. This PR fixes it by changing client.settings to client.options

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fix a 9-month old bug

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
