### PR TITLE
fix: isThenable returning true on Promise constructor

### DIFF
--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -200,7 +200,9 @@ class Util {
 	 * @returns {boolean}
 	 */
 	static isThenable(input) {
-		return (input instanceof Promise) || (Boolean(input) && Util.isFunction(input.then) && Util.isFunction(input.catch));
+		if (!input) return false;
+		return (input instanceof Promise) ||
+			(input !== Promise.prototype && Util.isFunction(input.then) && Util.isFunction(input.catch));
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR

Causing errors on `new Type(Promise.constructor);` as it'll try to call `value.then`, being incompatible.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Made Util.isThenable returning true on Promise constructor

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
