### PR TITLE
add slowmode options and inhibitor to core

### DIFF
--- a/src/inhibitors/slowmode.js
+++ b/src/inhibitors/slowmode.js
@@ -6,6 +6,8 @@ module.exports = class extends Inhibitor {
 		super(...args, { spamProtection: true });
 		this.slowmode = new RateLimitManager(1, this.client.options.slowmode);
 		this.aggressive = this.client.options.slowmodeAggressive;
+
+		if (!this.client.options.slowmode) this.disable();
 	}
 
 	async run(message) {
@@ -20,10 +22,6 @@ module.exports = class extends Inhibitor {
 			if (this.aggressive) rateLimit.resetTime = Date.now() + rateLimit.cooldown;
 			throw true;
 		}
-	}
-
-	init() {
-		if (!this.client.options.slowmode) this.disable();
 	}
 
 };

--- a/src/inhibitors/slowmode.js
+++ b/src/inhibitors/slowmode.js
@@ -1,0 +1,29 @@
+const { Inhibitor, RateLimitManager } = require.main.exports;
+
+module.exports = class extends Inhibitor {
+
+	constructor(...args) {
+		super(...args, { spamProtection: true });
+		this.slowmode = new RateLimitManager(1, this.client.options.slowmode);
+		this.aggressive = this.client.options.slowmodeAggressive;
+	}
+
+	async run(message) {
+		if (message.author === this.client.owner) return;
+
+		const slowmodeLevel = message.author.id;
+		const rateLimit = this.slowmode.get(slowmodeLevel) || this.slowmode.create(slowmodeLevel);
+
+		try {
+			rateLimit.drip();
+		} catch (err) {
+			if (this.aggressive) rateLimit.resetTime = Date.now() + rateLimit.cooldown;
+			throw true;
+		}
+	}
+
+	init() {
+		if (!this.client.options.slowmode) this.disable();
+	}
+
+};

--- a/src/inhibitors/slowmode.js
+++ b/src/inhibitors/slowmode.js
@@ -19,7 +19,7 @@ module.exports = class extends Inhibitor {
 		try {
 			rateLimit.drip();
 		} catch (err) {
-			if (this.aggressive) rateLimit.resetTime = Date.now() + rateLimit.cooldown;
+			if (this.aggressive) rateLimit.resetTime();
 			throw true;
 		}
 	}

--- a/src/inhibitors/slowmode.js
+++ b/src/inhibitors/slowmode.js
@@ -1,4 +1,4 @@
-const { Inhibitor, RateLimitManager } = require.main.exports;
+const { Inhibitor, RateLimitManager } = require('klasa');
 
 module.exports = class extends Inhibitor {
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -66,10 +66,10 @@ class KlasaClient extends Discord.Client {
 	 * @property {(string|Function)} [readyMessage=`Successfully initialized. Ready to serve ${this.guilds.size} guilds.`] readyMessage to be passed throughout Klasa's ready event
 	 * @property {RegExp} [regexPrefix] The regular expression prefix if one is provided
 	 * @property {KlasaClientOptionsSchedule} [schedule={}] The options for the internal clock module that runs Schedule
-	 * @property {boolean} [typing=false] Whether the bot should type while processing commands
-	 * @property {boolean} [prefixCaseInsensitive=false] Wether the bot should respond to case insensitive prefix or not
 	 * @property {number} [slowmode=0] Amount of time in ms before the bot will respond to a users command since the last command that user has run
 	 * @property {boolean} [slowmodeAggressive=false] If the slowmode time should reset if a user spams commands faster than the slowmode allows for
+	 * @property {boolean} [typing=false] Whether the bot should type while processing commands
+	 * @property {boolean} [prefixCaseInsensitive=false] Wether the bot should respond to case insensitive prefix or not
 	 */
 
 	/**

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -68,6 +68,8 @@ class KlasaClient extends Discord.Client {
 	 * @property {KlasaClientOptionsSchedule} [schedule={}] The options for the internal clock module that runs Schedule
 	 * @property {boolean} [typing=false] Whether the bot should type while processing commands
 	 * @property {boolean} [prefixCaseInsensitive=false] Wether the bot should respond to case insensitive prefix or not
+	 * @property {number} [slowmode=0] Amount of time in ms before the bot will respond to a users command since the last command that user has run
+	 * @property {boolean} [slowmodeAggressive=false] If the slowmode time should reset if a user spams commands faster than the slowmode allows for
 	 */
 
 	/**

--- a/src/lib/util/RateLimit.js
+++ b/src/lib/util/RateLimit.js
@@ -33,7 +33,7 @@ class RateLimit {
 	 * @readonly
 	 */
 	get expired() {
-		return Date.now() >= this.resetTime;
+		return this.remainingTime === 0;
 	}
 
 	/**
@@ -53,7 +53,7 @@ class RateLimit {
 	 * @readonly
 	 */
 	get remainingTime() {
-		return this.resetTime - Date.now();
+		return Math.min(this.time - Date.now(), 0);
 	}
 
 	/**
@@ -75,6 +75,15 @@ class RateLimit {
 	 * @returns {this}
 	 */
 	reset() {
+		return this.resetRemaining().resetTime();
+	}
+
+	/**
+	 * Resets the RateLimit's remaining-uses back to full state
+	 * @since 0.5.0
+	 * @returns {this}
+	 */
+	resetRemaining() {
 		/**
 		 * The remaining times this RateLimit can be dripped before the RateLimit bucket is empty
 		 * @since 0.5.0
@@ -83,13 +92,22 @@ class RateLimit {
 		 */
 		this.remaining = this.bucket;
 
+		return this;
+	}
+
+	/**
+	 * Resets the RateLimit's reset-time back to full state
+	 * @since 0.5.0
+	 * @returns {this}
+	 */
+	resetTime() {
 		/**
 		 * When this RateLimit is reset back to a full state
 		 * @since 0.5.0
 		 * @type {number}
 		 * @private
 		 */
-		this.resetTime = Date.now() + this.cooldown;
+		this.time = Date.now() + this.cooldown;
 
 		return this;
 	}

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -102,7 +102,9 @@ exports.DEFAULTS = {
 			},
 			tasks: { enabled: true }
 		},
-		schedule: { interval: 60000 }
+		schedule: { interval: 60000 },
+		slowmode: 0,
+		slowmodeAggressive: false
 	},
 
 	CONSOLE: {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1054,9 +1054,11 @@ declare module 'klasa' {
 		public bucket: number;
 		public cooldown: number;
 		private remaining: number;
-		private resetTime: number;
+		private time: number;
 		public drip(): this;
 		public reset(): this;
+		public resetRemaining(): this;
+		public resetTime(): this;
 	}
 
 	export class RateLimitManager extends Collection<Snowflake, RateLimit> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -47,7 +47,7 @@ declare module 'klasa' {
 		public constructor(options?: KlasaClientOptions);
 		public readonly invite: string;
 		public readonly owner: KlasaUser | null;
-		public options: KlasaClientOptions & ClientOptions;
+		public options: KlasaClientOptions;
 		public userBaseDirectory: string;
 		public console: KlasaConsole;
 		public arguments: ArgumentStore;
@@ -1289,6 +1289,8 @@ declare module 'klasa' {
 		readyMessage?: (client: KlasaClient) => string;
 		regexPrefix?: RegExp;
 		schedule?: KlasaClientOptionsSchedule;
+		slowmode?: number;
+		slowmodeAggressive?: boolean;
 		typing?: boolean;
 	} & ClientOptions;
 


### PR DESCRIPTION
### Description of the PR
Adds options for slowmode, and slowmodeAggressive to alleviate users spamming commands. This works in conjunction with cooldowns.

Say you have a ping command with a 30 second cooldown, you set slowmode to 2000 (2 seconds). If the user uses the ping command, and then again in 5 seconds, they will get the "command is on cooldown" message. However, if they spam the command multiple times in that 2 seconds, only the first request will be handled, and all others will be inhibited silently. With slowmodeAggressive set to true, when a user spams commands, the timer will reset, meaning if they constantly spam, they will constantly not be able to use the bot, until they let it rest for 2 seconds (or whatever you have configured for slowmode).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
