### PR TITLE
breaking: Start work on new and improved usage strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[422](https://github.com/dirigeants/klasa/pull/422)] **[BREAKING]** Completely change the way usage is parsed, remove `usageDelim`, and change how arguments are returned in the run function.
 - [[#392](https://github.com/dirigeants/klasa/pull/392)] Changed default prefix from `'!'` to `''`. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed SchemaFolder to extend Schema, which extends Map. All keys are now stored inside the map as opposed to being properties. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed `Schema#add` and `Schema#remove` to be synchronous. They must be called before ready. (Unseenfaith)

--- a/guides/Advanced Commands/CommandsSubcommands.md
+++ b/guides/Advanced Commands/CommandsSubcommands.md
@@ -12,8 +12,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			subcommands: true,
-			usage: '<set|remove|reset|show> (key:key) (value:value) [...]',
-			usageDelim: ' '
+			usage: '<set|remove|reset|show> (key:key) (value:value) [...]'
 		});
 	}
 
@@ -32,8 +31,7 @@ module.exports = class extends Command {
 
 	constructor(...args) {
 		super(...args, {
-			usage: '<set|remove|reset|show> (key:key) (value:value) [...]',
-			usageDelim: ' '
+			usage: '<set|remove|reset|show> (key:key) (value:value) [...]'
 		});
 	}
 

--- a/guides/Piece Basics/CreatingCommands.md
+++ b/guides/Piece Basics/CreatingCommands.md
@@ -23,7 +23,6 @@ module.exports = class extends Command {
 			description: '',
 			quotedStringSupport: false,
 			usage: '',
-			usageDelim: undefined,
 			extendedHelp: 'No extended help available.'
 		});
 	}
@@ -61,7 +60,6 @@ module.exports = class extends Command {
 | **subcommands**         | `false`                          | boolean | Whether to enable sub commands or not                                       |
 | **description**         | `''`                             | string  | The help description for the command                                        |
 | **usage**               | `''`                             | string  | The usage string for the command - See {@tutorial UnderstandingUsageStrings}|
-| **usageDelim**          | `''`                             | string  | The string to deliminate the command input for usage                        |
 | **quotedStringSupport** | `false`                          | boolean | Whether args for this command should not deliminated inside quotes          |
 | **extendedHelp**        | `'No extended help available.'`  | string  | Extended help strings                                                       |
 

--- a/src/commands/Admin/blacklist.js
+++ b/src/commands/Admin/blacklist.js
@@ -8,7 +8,6 @@ module.exports = class extends Command {
 			permissionLevel: 10,
 			description: language => language.get('COMMAND_BLACKLIST_DESCRIPTION'),
 			usage: '<User:user|Guild:guild|guild:str> [...]',
-			usageDelim: ' ',
 			guarded: true
 		});
 	}

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -9,7 +9,7 @@ module.exports = class extends Command {
 			guarded: true,
 			subcommands: true,
 			description: language => language.get('COMMAND_CONF_SERVER_DESCRIPTION'),
-			usage: '<set|show|remove|reset> (key:key) (value:value) [...]',
+			usage: '<set|show|remove|reset> (key:key) (value:value) [...]'
 		});
 
 		this

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -10,7 +10,6 @@ module.exports = class extends Command {
 			subcommands: true,
 			description: language => language.get('COMMAND_CONF_SERVER_DESCRIPTION'),
 			usage: '<set|show|remove|reset> (key:key) (value:value) [...]',
-			usageDelim: ' '
 		});
 
 		this

--- a/src/commands/Admin/load.js
+++ b/src/commands/Admin/load.js
@@ -10,14 +10,13 @@ module.exports = class extends Command {
 			permissionLevel: 10,
 			guarded: true,
 			description: language => language.get('COMMAND_LOAD_DESCRIPTION'),
-			usage: '[core] <Store:store> <path:string> [...]',
-			usageDelim: ' '
+			usage: '[core] <Store:store> <path:string> [...]'
 		});
 		this.regExp = /\\\\?|\//g;
 	}
 
 	async run(message, [core, store, ...path]) {
-		path = path.join(this.usageDelim);
+		path = path.join(' ');
 		path = (path.endsWith('.js') ? path : `${path}.js`).split(this.regExp);
 		const timer = new Stopwatch();
 		const piece = await (core ? this.tryEach(store, path) : store.load(store.userDirectory, path));

--- a/src/commands/General/User Settings/userconf.js
+++ b/src/commands/General/User Settings/userconf.js
@@ -7,8 +7,7 @@ module.exports = class extends Command {
 			guarded: true,
 			subcommands: true,
 			description: language => language.get('COMMAND_CONF_USER_DESCRIPTION'),
-			usage: '<set|show|remove|reset> (key:key) (value:value) [...]',
-			usageDelim: ' '
+			usage: '<set|show|remove|reset> (key:key) (value:value) [...]'
 		});
 
 		this

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -70,7 +70,7 @@ module.exports = Structures.extend('Message', Message => {
 		}
 
 		/**
-		 * The string arguments derived from the usageDelim of the command
+		 * The string arguments derived from the usage of the command
 		 * @since 0.0.1
 		 * @type {string[]}
 		 * @readonly

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -34,7 +34,6 @@ class Command extends Piece {
 	 * @property {string[]} [runIn=['text','dm']] What channel types the command should run in
 	 * @property {boolean} [subcommands=false] Whether to enable sub commands or not
 	 * @property {string} [usage=''] The usage string for the command
-	 * @property {?string} [usageDelim=undefined] The string to delimit the command input for usage
 	 */
 
 	/**
@@ -173,7 +172,7 @@ class Command extends Piece {
 		 * @since 0.0.1
 		 * @type {CommandUsage}
 		 */
-		this.usage = new CommandUsage(client, options.usage, options.usageDelim, this);
+		this.usage = new CommandUsage(client, options.usage, this);
 
 		/**
 		 * The level at which cooldowns should apply
@@ -233,16 +232,6 @@ class Command extends Piece {
 	}
 
 	/**
-	 * The usage deliminator for the command input
-	 * @since 0.0.1
-	 * @type {?string}
-	 * @readonly
-	 */
-	get usageDelim() {
-		return this.usage.usageDelim;
-	}
-
-	/**
 	 * The usage string for the command
 	 * @since 0.0.1
 	 * @type {string}
@@ -255,11 +244,10 @@ class Command extends Piece {
 	/**
 	 * Creates a Usage to run custom prompts off of
 	 * @param {string} usageString The string designating all parameters expected
-	 * @param {string} usageDelim The string to delimit the input
 	 * @returns {Usage}
 	 */
-	definePrompt(usageString, usageDelim) {
-		return new Usage(this.client, usageString, usageDelim);
+	definePrompt(usageString) {
+		return new Usage(this.client, usageString);
 	}
 
 	/**
@@ -299,7 +287,7 @@ class Command extends Piece {
 	 * The run method to be overwritten in actual commands
 	 * @since 0.0.1
 	 * @param {KlasaMessage} message The command message mapped on top of the message used to trigger this command
-	 * @param {any[]} params The fully resolved parameters based on your usage / usageDelim
+	 * @param {any[]} params The fully resolved parameters based on your usage
 	 * @returns {KlasaMessage|KlasaMessage[]} You should return the response message whenever possible
 	 * @abstract
 	 */
@@ -336,10 +324,9 @@ class Command extends Piece {
 			subcommands: this.subcommands,
 			usage: {
 				usageString: this.usage.usageString,
-				usageDelim: this.usage.usageDelim,
+				delimiters: this.usage.delimiters,
 				nearlyFullUsage: this.usage.nearlyFullUsage
 			},
-			usageDelim: this.usageDelim,
 			usageString: this.usageString
 		};
 	}

--- a/src/lib/usage/CommandUsage.js
+++ b/src/lib/usage/CommandUsage.js
@@ -35,7 +35,7 @@ class CommandUsage extends Usage {
 		 * @since 0.0.1
 		 * @type {string}
 		 */
-		this.nearlyFullUsage = `${this.commands}${this.usageString}`;
+		this.nearlyFullUsage = `${this.commands} ${this.usageString}`;
 	}
 
 	/**

--- a/src/lib/usage/CommandUsage.js
+++ b/src/lib/usage/CommandUsage.js
@@ -11,11 +11,10 @@ class CommandUsage extends Usage {
 	 * @since 0.0.1
 	 * @param {KlasaClient} client The klasa client
 	 * @param {usageString} usageString The usage string for this command
-	 * @param {usageDelim} usageDelim The usage deliminator for this command
 	 * @param {Command} command The command this parsed usage is for
 	 */
-	constructor(client, usageString, usageDelim, command) {
-		super(client, usageString, usageDelim);
+	constructor(client, usageString, command) {
+		super(client, usageString);
 
 		/**
 		 * All names and aliases for the command
@@ -36,7 +35,7 @@ class CommandUsage extends Usage {
 		 * @since 0.0.1
 		 * @type {string}
 		 */
-		this.nearlyFullUsage = `${this.commands}${this.deliminatedUsage}`;
+		this.nearlyFullUsage = `${this.commands}${this.usageString}`;
 	}
 
 	/**

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -342,15 +342,10 @@ class TextPrompt {
 	 * @private
 	 */
 	_setup(original) {
-		if (!this.usage.delimiters.length) {
-			this.args = original ? [original] : [];
-			return;
-		}
-
 		let code;
 		let content = '';
 		let delimiterIndex = 0;
-		let delimiter = this.usage.delimiters[delimiterIndex];
+		let delimiter = this.usage.delimiters.length ? this.usage.delimiters[delimiterIndex] : null;
 		const lastIndex = this.usage.delimiters.length - 1;
 		while (++this.index < original.length) {
 			code = original.charCodeAt(this.index);
@@ -368,7 +363,7 @@ class TextPrompt {
 				const parsed = this._parseQuoteString(this.index, original, QUOTES.find(pair => code === pair[0])[1]);
 				this.index = parsed.index;
 				this.args.push(parsed.content.trim());
-			} else if (original.substr(this.index, delimiter.length) === delimiter) {
+			} else if (delimiter && original.substr(this.index, delimiter.length) === delimiter) {
 				if (content) {
 					this.args.push(content.trim());
 					content = '';
@@ -389,7 +384,7 @@ class TextPrompt {
 		// Get all the remaining flags from the content, if the parse was partial
 		if (this.index < original.length) {
 			const sliced = original.slice(this.index, original.length);
-			sliced.replace(/—|--/g, (__, index) => this.parseFlag(index, sliced));
+			sliced.replace(/—|--/g, (__, index) => this._parseFlag(index, sliced));
 		}
 
 		// Cleanup
@@ -400,6 +395,7 @@ class TextPrompt {
 	 * Parse a flag, if valid
 	 * @since 0.5.0
 	 * @param {number} index The index to start from
+	 * @param {string} original The original text
 	 * @returns {Object}
 	 */
 	_parseFlag(index, original) {
@@ -437,7 +433,8 @@ class TextPrompt {
 	 * Parse a quote string
 	 * @since 0.5.0
 	 * @param {number} index The index to start from
-	 * @param {number[]} pair The pair of quotes
+	 * @param {string} original The original text
+	 * @param {number} quote The quotes to find
 	 * @returns {Object}
 	 */
 	_parseQuoteString(index, original, quote) {

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -396,6 +396,11 @@ class TextPrompt {
 		}
 		if (content) this.args.push(content.trim());
 
+		// Get all the remaining flags from the content, if the parse was partial
+		if (this.index < this.content.length) {
+			this.content.slice(this.index, this.content.length).replace(/—|--/g, (__, index) => this.parseFlag(index + this.index));
+		}
+
 		// Cleanup
 		this.index = -1;
 		this.content = null;

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -350,6 +350,11 @@ class TextPrompt {
 	 * @private
 	 */
 	_setup(original) {
+		if (!this.usage.delimiters.length) {
+			this.args = original ? [original] : [];
+			return;
+		}
+
 		this.content = original;
 
 		let code;

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -434,7 +434,7 @@ class TextPrompt {
 			}
 		}
 
-		this.flags[name] = openedValue ? value : name;
+		this.flags[name] = openedValue && value ? value : name;
 		return { index, content: '' };
 	}
 

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -61,7 +61,7 @@ class TextPrompt {
 		this.flags = {};
 
 		/**
-		 * The string arguments derived from the usageDelim of the command
+		 * The string arguments derived from the usage of the command
 		 * @since 0.0.1
 		 * @type {string[]}
 		 */
@@ -402,7 +402,7 @@ class TextPrompt {
 }
 
 /**
- * Map of RegExps caching usageDelim's RegExps.
+ * Map of RegExps caching delimiter's RegExps.
  * @since 0.5.0
  * @type {Map<string, RegExp>}
  * @static

--- a/src/lib/usage/Usage.js
+++ b/src/lib/usage/Usage.js
@@ -52,7 +52,7 @@ class Usage {
 		this.lastRepeating = false;
 
 		/**
-		 * The usage object to compare against later
+		 * The parsed usage to compare against later
 		 * @since 0.0.1
 		 * @type {Tag[]}
 		 */

--- a/src/lib/usage/Usage.js
+++ b/src/lib/usage/Usage.js
@@ -130,7 +130,6 @@ class Usage {
 			current: '',
 			openRegex: false,
 			openReq: false,
-			first: true,
 			last: false,
 			char: 0,
 			from: 0,
@@ -141,7 +140,7 @@ class Usage {
 		};
 
 		for (const [i, char] of Object.entries(usageString)) {
-			currentUsage.char = i + 1;
+			currentUsage.char = Number(i) + 1;
 			currentUsage.from = currentUsage.char - currentUsage.current.length;
 			currentUsage.at = `at char #${currentUsage.char} '${char}'`;
 			currentUsage.fromTo = `from char #${currentUsage.from} to #${currentUsage.char} '${currentUsage.current}'`;
@@ -183,12 +182,9 @@ class Usage {
 	 */
 	static tagOpen(usage, char) {
 		if (usage.opened) throw `${usage.at}: you may not open a tag inside another tag.`;
-		if (usage.first) {
-			// First usage, cannot have a delimiter
-			usage.first = false;
-		} else if (!usage.current) {
+		if (usage.char !== 1 && !usage.current) {
 			throw `${usage.at}: you need to provide a delimiter between two tags.`;
-		} else {
+		} else if (usage.char !== 1) {
 			usage.delimiters.push(usage.current);
 			usage.current = '';
 		}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -629,7 +629,6 @@ declare module 'klasa' {
 		public readonly category: string;
 		public readonly cooldown: number;
 		public readonly subCategory: string;
-		public readonly usageDelim: string;
 		public readonly usageString: string;
 		public aliases: string[];
 		public requiredPermissions: Permissions;
@@ -652,7 +651,7 @@ declare module 'klasa' {
 
 		public createCustomResolver(type: string, resolver: ArgResolverCustomMethod): this;
 		public customizeResponse(name: string, response: string | ((message: KlasaMessage, possible: Possible) => string)): this;
-		public definePrompt(usageString: string, usageDelim?: string): Usage;
+		public definePrompt(usageString: string): Usage;
 		public run(message: KlasaMessage, params: any[]): Promise<KlasaMessage | KlasaMessage[] | null>;
 		public toJSON(): PieceCommandJSON;
 	}
@@ -923,13 +922,13 @@ declare module 'klasa' {
 	}
 
 	export class Usage {
-		public constructor(client: KlasaClient, usageString: string, usageDelim: string);
+		public constructor(client: KlasaClient, usageString: string);
 		public readonly client: KlasaClient;
-		public deliminatedUsage: string;
 		public usageString: string;
-		public usageDelim: string;
-		public parsedUsage: Tag[];
+		public delimiters: string[];
 		public customResolvers: ObjectLiteral<ArgResolverCustomMethod>;
+		public lastRepeating: boolean;
+		public parsedUsage: Tag[];
 
 		public createCustomResolver(type: string, resolver: ArgResolverCustomMethod): this;
 		public customizeResponse(name: string, response: ((message: KlasaMessage) => string)): this;
@@ -937,7 +936,7 @@ declare module 'klasa' {
 		public toJSON(): Tag[];
 		public toString(): string;
 
-		private static parseUsage(usageString: string): Tag[];
+		private static parseUsage(usage: Usage): Tag[];
 		private static tagOpen(usage: ObjectLiteral, char: string): void;
 		private static tagClose(usage: ObjectLiteral, char: string): void;
 		private static tagSpace(usage: ObjectLiteral, char: string): void;
@@ -1557,7 +1556,6 @@ declare module 'klasa' {
 		runIn?: Array<'text' | 'dm' | 'group'>;
 		subcommands?: boolean;
 		usage?: string;
-		usageDelim?: string;
 	} & PieceOptions;
 
 	export type ExtendableOptions = {
@@ -1628,10 +1626,9 @@ declare module 'klasa' {
 		subcommands: boolean;
 		usage: {
 			usageString: string;
-			usageDelim: string;
+			delims: string[];
 			nearlyFullUsage: string;
 		};
-		usageDelim: string;
 		usageString: string;
 	} & PieceJSON;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1626,7 +1626,7 @@ declare module 'klasa' {
 		subcommands: boolean;
 		usage: {
 			usageString: string;
-			delims: string[];
+			delimiters: string[];
 			nearlyFullUsage: string;
 		};
 		usageString: string;


### PR DESCRIPTION
### Description of the PR

This PR is ~~phase one out of two phases of my proposal~~ that will change the way we write our usage strings forever, making the experience easier (in my opinion) and with less bugs too.

This PR completely nukes the concept of `usageDelim`, and instead integrates it into the `usage` string itself.

Take the following usage: `<member:member> [reason:string]`; Before this PR, you'd need to specify usageDelim as " ", and add `[...]` at the end of reason to get it all. Not anymore.

The usage delimiter is now anything between a closed tag and a newly opened one. Yes, that means you can do `<member:member> in <time:duration>`, and you would have to type `@member in 2 days`.

*More in-depth stuff will be found in the guides I'm lazy to write :P*

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- **[BREAKING]** Remove `Command#usageDelim`, `Usage#usageDelim` and `Usage#delimitedUsage`

- Others things to be added

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
