### PR TITLE
Add MultiArguments for all d.js and klasa structures

### DIFF
--- a/src/arguments/arguments.js
+++ b/src/arguments/arguments.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...argument' });
+	}
+
+	get base() {
+		return this.store.get('argument');
+	}
+
+};

--- a/src/arguments/arguments.js
+++ b/src/arguments/arguments.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...argument' });
+		super(...args, { aliases: ['...argument'] });
 	}
 
 	get base() {

--- a/src/arguments/channels.js
+++ b/src/arguments/channels.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...channel' });
+	}
+
+	get base() {
+		return this.store.get('channel');
+	}
+
+};

--- a/src/arguments/channels.js
+++ b/src/arguments/channels.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...channel' });
+		super(...args, { aliases: ['...channel'] });
 	}
 
 	get base() {

--- a/src/arguments/commands.js
+++ b/src/arguments/commands.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...command' });
+		super(...args, { aliases: ['...command'] });
 	}
 
 	get base() {

--- a/src/arguments/commands.js
+++ b/src/arguments/commands.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...command' });
+	}
+
+	get base() {
+		return this.store.get('command');
+	}
+
+};

--- a/src/arguments/emojis.js
+++ b/src/arguments/emojis.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...emoji' });
+		super(...args, { aliases: ['...emoji'] });
 	}
 
 	get base() {

--- a/src/arguments/emojis.js
+++ b/src/arguments/emojis.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...emoji' });
+	}
+
+	get base() {
+		return this.store.get('emoji');
+	}
+
+};

--- a/src/arguments/events.js
+++ b/src/arguments/events.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: ['...event'] });
+	}
+
+	get base() {
+		return this.store.get('event');
+	}
+
+};

--- a/src/arguments/extendables.js
+++ b/src/arguments/extendables.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...extendable' });
+		super(...args, { aliases: ['...extendable'] });
 	}
 
 	get base() {

--- a/src/arguments/extendables.js
+++ b/src/arguments/extendables.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...extendable' });
+	}
+
+	get base() {
+		return this.store.get('extendable');
+	}
+
+};

--- a/src/arguments/finalizers.js
+++ b/src/arguments/finalizers.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...finalizer' });
+		super(...args, { aliases: ['...finalizer'] });
 	}
 
 	get base() {

--- a/src/arguments/finalizers.js
+++ b/src/arguments/finalizers.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...finalizer' });
+	}
+
+	get base() {
+		return this.store.get('finalizer');
+	}
+
+};

--- a/src/arguments/guilds.js
+++ b/src/arguments/guilds.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...guild' });
+	}
+
+	get base() {
+		return this.store.get('guild');
+	}
+
+};

--- a/src/arguments/guilds.js
+++ b/src/arguments/guilds.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...guild' });
+		super(...args, { aliases: ['...guild'] });
 	}
 
 	get base() {

--- a/src/arguments/inhibitors.js
+++ b/src/arguments/inhibitors.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...inhibitor' });
+	}
+
+	get base() {
+		return this.store.get('inhibitor');
+	}
+
+};

--- a/src/arguments/inhibitors.js
+++ b/src/arguments/inhibitors.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...inhibitor' });
+		super(...args, { aliases: ['...inhibitor'] });
 	}
 
 	get base() {

--- a/src/arguments/languages.js
+++ b/src/arguments/languages.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...language' });
+		super(...args, { aliases: ['...language'] });
 	}
 
 	get base() {

--- a/src/arguments/languages.js
+++ b/src/arguments/languages.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...language' });
+	}
+
+	get base() {
+		return this.store.get('language');
+	}
+
+};

--- a/src/arguments/members.js
+++ b/src/arguments/members.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...member' });
+		super(...args, { aliases: ['...member'] });
 	}
 
 	get base() {

--- a/src/arguments/members.js
+++ b/src/arguments/members.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...member' });
+	}
+
+	get base() {
+		return this.store.get('member');
+	}
+
+};

--- a/src/arguments/messages.js
+++ b/src/arguments/messages.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...message' });
+		super(...args, { aliases: ['...message'] });
 	}
 
 	get base() {

--- a/src/arguments/messages.js
+++ b/src/arguments/messages.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...message' });
+	}
+
+	get base() {
+		return this.store.get('message');
+	}
+
+};

--- a/src/arguments/monitors.js
+++ b/src/arguments/monitors.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...monitor' });
+		super(...args, { aliases: ['...monitor'] });
 	}
 
 	get base() {

--- a/src/arguments/monitors.js
+++ b/src/arguments/monitors.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...monitor' });
+	}
+
+	get base() {
+		return this.store.get('monitor');
+	}
+
+};

--- a/src/arguments/pieces.js
+++ b/src/arguments/pieces.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...piece' });
+	}
+
+	get base() {
+		return this.store.get('piece');
+	}
+
+};

--- a/src/arguments/pieces.js
+++ b/src/arguments/pieces.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...piece' });
+		super(...args, { aliases: ['...piece'] });
 	}
 
 	get base() {

--- a/src/arguments/providers.js
+++ b/src/arguments/providers.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...provider' });
+	}
+
+	get base() {
+		return this.store.get('provider');
+	}
+
+};

--- a/src/arguments/providers.js
+++ b/src/arguments/providers.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...provider' });
+		super(...args, { aliases: ['...provider'] });
 	}
 
 	get base() {

--- a/src/arguments/restString.js
+++ b/src/arguments/restString.js
@@ -3,7 +3,7 @@ const { Argument } = require('klasa');
 module.exports = class extends Argument {
 
 	constructor(...args) {
-		super(...args, { aliases: ['...string', '...str'] });
+		super(...args, { name: '...string', aliases: ['...str'] });
 	}
 
 	get stringArg() {

--- a/src/arguments/roles.js
+++ b/src/arguments/roles.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...role' });
+	}
+
+	get base() {
+		return this.store.get('role');
+	}
+
+};

--- a/src/arguments/roles.js
+++ b/src/arguments/roles.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...role' });
+		super(...args, { aliases: ['...role'] });
 	}
 
 	get base() {

--- a/src/arguments/stores.js
+++ b/src/arguments/stores.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...store' });
+	}
+
+	get base() {
+		return this.store.get('store');
+	}
+
+};

--- a/src/arguments/stores.js
+++ b/src/arguments/stores.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...store' });
+		super(...args, { aliases: ['...store'] });
 	}
 
 	get base() {

--- a/src/arguments/strings.js
+++ b/src/arguments/strings.js
@@ -3,7 +3,7 @@ const { Argument } = require('klasa');
 module.exports = class extends Argument {
 
 	constructor(...args) {
-		super(...args, { name: '...string', aliases: ['...str'] });
+		super(...args, { aliases: ['...string', '...str'] });
 	}
 
 	get stringArg() {

--- a/src/arguments/tasks.js
+++ b/src/arguments/tasks.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...task' });
+		super(...args, { aliases: ['...task'] });
 	}
 
 	get base() {

--- a/src/arguments/tasks.js
+++ b/src/arguments/tasks.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...task' });
+	}
+
+	get base() {
+		return this.store.get('task');
+	}
+
+};

--- a/src/arguments/users.js
+++ b/src/arguments/users.js
@@ -3,7 +3,7 @@ const { MultiArgument } = require('klasa');
 module.exports = class extends MultiArgument {
 
 	constructor(...args) {
-		super(...args, { aliases: '...user' });
+		super(...args, { aliases: ['...user'] });
 	}
 
 	get base() {

--- a/src/arguments/users.js
+++ b/src/arguments/users.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: '...user' });
+	}
+
+	get base() {
+		return this.store.get('user');
+	}
+
+};

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ module.exports = {
 	LanguageStore: require('./lib/structures/LanguageStore'),
 	Monitor: require('./lib/structures/Monitor'),
 	MonitorStore: require('./lib/structures/MonitorStore'),
+	MultiArgument: require('./lib/structures/MultiArgument'),
 	Provider: require('./lib/structures/Provider'),
 	ProviderStore: require('./lib/structures/ProviderStore'),
 	Serializer: require('./lib/structures/Serializer'),

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -19,6 +19,7 @@ module.exports = class extends Language {
 			SETTING_GATEWAY_KEY_NOEXT: (key) => `The key ${key} does not exist in the current data schema.`,
 			SETTING_GATEWAY_INVALID_TYPE: 'The type parameter must be either add or remove.',
 			SETTING_GATEWAY_INVALID_FILTERED_VALUE: (piece, value) => `${piece.key} doesn't accept the value: ${value}`,
+			RESOLVER_MULTI_TOO_FEW: (name, min = 1) => `Provided too few ${name}s. Atleast ${min} ${min === 1 ? 'is' : 'are'} required.`,
 			RESOLVER_INVALID_CUSTOM: (name, type) => `${name} must be a valid ${type}.`,
 			RESOLVER_INVALID_PIECE: (name, piece) => `${name} must be a valid ${piece} name.`,
 			RESOLVER_INVALID_MESSAGE: (name) => `${name} must be a valid message id.`,

--- a/src/lib/structures/MultiArgument.js
+++ b/src/lib/structures/MultiArgument.js
@@ -10,6 +10,7 @@ class MultiArgument extends Argument {
 	 * A getter for the base argument
 	 * @since 0.5.0
 	 * @type {Argument}
+	 * @readonly
 	 * @abstract
 	 */
 	get base() {

--- a/src/lib/structures/MultiArgument.js
+++ b/src/lib/structures/MultiArgument.js
@@ -7,11 +7,11 @@ const Argument = require('./Argument');
 class MultiArgument extends Argument {
 
 	/**
-     * A getter for the base argument
+	 * A getter for the base argument
 	 * @since 0.5.0
-     * @type {Argument}
+	 * @type {Argument}
 	 * @abstract
-     */
+	 */
 	get base() {
 		throw new Error('A "base" getter must be implimented in extended classes.');
 	}

--- a/src/lib/structures/MultiArgument.js
+++ b/src/lib/structures/MultiArgument.js
@@ -1,0 +1,53 @@
+const Argument = require('./Argument');
+
+/**
+ * Base Abstracted class for Multi-Resolving D.JS and Klasa Structures.
+ * @extends Argument
+ */
+class MultiArgument extends Argument {
+
+	/**
+     * A getter for the base argument
+	 * @since 0.5.0
+     * @type {Argument}
+	 * @abstract
+     */
+	get base() {
+		throw new Error('A "base" getter must be implimented in extended classes.');
+	}
+
+	/**
+	 * The run method for handling MultiArguments (not to be implimented in extended classes)
+	 * @since 0.5.0
+	 * @param {string} argument The string argument string to resolve
+	 * @param {Possible} possible This current usage possible
+	 * @param {KlasaMessage} message The message that triggered the command
+	 */
+	async run(argument, possible, message) {
+		const structures = [];
+		const { min, max } = possible;
+		const { args, usage: { usageDelim } } = message.prompter;
+		const index = args.indexOf(argument);
+		const rest = args.splice(index, args.length - index);
+		const { base } = this;
+		let i = 0;
+
+		for (const arg of rest) {
+			if (max && i > max) break;
+			try {
+				const structure = await base.run(arg, possible, message);
+				structures.push(structure);
+				i++;
+			} catch (err) {
+				break;
+			}
+		}
+
+		args.push(rest.splice(0, structures.length).join(usageDelim), ...rest);
+		if ((min && structures.length < min) || !structures.length) throw message.language.get(`RESOLVER_MULTI_TOO_FEW`, base.name, min);
+		return structures;
+	}
+
+}
+
+module.exports = MultiArgument;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -718,6 +718,11 @@ declare module 'klasa' {
 		public toJSON(): PieceMonitorJSON;
 	}
 
+	export abstract class MultiArgument extends Argument {
+		public abstract readonly base: Argument;
+		public run<T = any>(argument: string, possible: Possible, message: KlasaMessage): Promise<Array<T>>;
+	}
+
 	export abstract class Provider extends Piece {
 		public constructor(client: KlasaClient, store: ProviderStore, file: string, directory: string, options?: ProviderOptions);
 		public abstract create<T = any>(table: string, entry: string, data: any): Promise<T>;


### PR DESCRIPTION
### Description of the PR
This adds new argument types that can be chained together in useful ways. Such as `!ban @member1 @member2 @member3 for raiding our discord server` can with the usage `<members:...member> <reason:...string>` returning `[members: GuildMember[], reason: string]` for parameters.

Additionally, min/max usage has meaning for all of these MultiArguments, meaning you can limit members to <members:...member{2,5}> and get a max of 5 members and a min of 2. etc...

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
