### PR TITLE
Fix potentially duplicated plugins from being loaded

### DIFF
--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -315,7 +315,7 @@ class KlasaClient extends Discord.Client {
 		this.ready = false;
 
 		// Run all plugin functions in this context
-		for (const plugin of plugins) plugin[this.constructor.plugin].call(this);
+		for (const plugin of plugins) plugin.call(this);
 	}
 
 	/**
@@ -459,7 +459,9 @@ class KlasaClient extends Discord.Client {
 	 * @chainable
 	 */
 	static use(mod) {
-		plugins.add(mod);
+		const plugin = mod[this.plugin];
+		if (!plugin || typeof plugin !== 'function') throw new TypeError('The provided module does not include a plugin function');
+		plugins.add(plugin);
 		return this;
 	}
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -460,7 +460,7 @@ class KlasaClient extends Discord.Client {
 	 */
 	static use(mod) {
 		const plugin = mod[this.plugin];
-		if (!plugin || typeof plugin !== 'function') throw new TypeError('The provided module does not include a plugin function');
+		if (typeof plugin !== 'function') throw new TypeError('The provided module does not include a plugin function');
 		plugins.add(plugin);
 		return this;
 	}


### PR DESCRIPTION
### Description of the PR
Plugin functions could be used via require(pluginPackage) or the client of said package. Because the index object and the client class are two different objects, the same plugin could be loaded twice. Not particularly good chance you would do that yourself, but if a plugin uses a dependent plugin to load it before it is loaded, this would prevent that possible duplicate behavior.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
