### PR TITLE
feat: RateLimitManager#acquire

### DIFF
--- a/src/finalizers/commandCooldown.js
+++ b/src/finalizers/commandCooldown.js
@@ -8,7 +8,7 @@ module.exports = class extends Finalizer {
 		try {
 			message.command.cooldowns.acquire(message.levelID).drip();
 		} catch (err) {
-			this.client.emit('commandRateLimit', message, message.command, message.params);
+			this.client.emit('error', `${message.author.username}[${message.author.id}] has exceeded the RateLimit for ${message.command}`);
 		}
 	}
 

--- a/src/finalizers/commandCooldown.js
+++ b/src/finalizers/commandCooldown.js
@@ -3,15 +3,12 @@ const { Finalizer } = require('klasa');
 module.exports = class extends Finalizer {
 
 	run(message) {
-		if (message.author === this.client.owner || message.command.cooldown <= 0) return;
-
-		const id = message.levelID;
-		const rateLimit = message.command.cooldowns.get(id) || message.command.cooldowns.create(id);
+		if (message.command.cooldown <= 0 || message.author === this.client.owner) return;
 
 		try {
-			rateLimit.drip();
+			message.command.cooldowns.create(message.levelID).drip();
 		} catch (err) {
-			this.client.emit('error', `${message.author.username}[${message.author.id}] has exceeded the RateLimit for ${message.command}`);
+			this.client.emit('verbose', `${message.author.username}[${message.author.id}] has exceeded the RateLimit for ${message.command}`);
 		}
 	}
 

--- a/src/finalizers/commandCooldown.js
+++ b/src/finalizers/commandCooldown.js
@@ -6,7 +6,7 @@ module.exports = class extends Finalizer {
 		if (message.command.cooldown <= 0 || message.author === this.client.owner) return;
 
 		try {
-			message.command.cooldowns.create(message.levelID).drip();
+			message.command.cooldowns.acquire(message.levelID).drip();
 		} catch (err) {
 			this.client.emit('verbose', `${message.author.username}[${message.author.id}] has exceeded the RateLimit for ${message.command}`);
 		}

--- a/src/finalizers/commandCooldown.js
+++ b/src/finalizers/commandCooldown.js
@@ -8,7 +8,7 @@ module.exports = class extends Finalizer {
 		try {
 			message.command.cooldowns.acquire(message.levelID).drip();
 		} catch (err) {
-			this.client.emit('verbose', `${message.author.username}[${message.author.id}] has exceeded the RateLimit for ${message.command}`);
+			this.client.emit('commandRateLimit', message, message.command, message.params);
 		}
 	}
 

--- a/src/inhibitors/slowmode.js
+++ b/src/inhibitors/slowmode.js
@@ -13,7 +13,7 @@ module.exports = class extends Inhibitor {
 	async run(message) {
 		if (message.author === this.client.owner) return;
 
-		const rateLimit = this.slowmode.create(message.author.id);
+		const rateLimit = this.slowmode.acquire(message.author.id);
 
 		try {
 			rateLimit.drip();

--- a/src/inhibitors/slowmode.js
+++ b/src/inhibitors/slowmode.js
@@ -13,8 +13,7 @@ module.exports = class extends Inhibitor {
 	async run(message) {
 		if (message.author === this.client.owner) return;
 
-		const slowmodeLevel = message.author.id;
-		const rateLimit = this.slowmode.get(slowmodeLevel) || this.slowmode.create(slowmodeLevel);
+		const rateLimit = this.slowmode.create(message.author.id);
 
 		try {
 			rateLimit.drip();

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -596,15 +596,6 @@ KlasaClient.defaultClientSchema = new Schema()
  */
 
 /**
- * Emitted when a command's {@link RateLimit} has been emptied.
- * @event KlasaClient#commandRateLimit
- * @since 0.5.0
- * @param {KlasaMessage} message The message that triggered the command
- * @param {Command} command The command run
- * @param {any[]} params The resolved parameters of the command
- */
-
-/**
  * Emitted when an event has encountered an error.
  * @event KlasaClient#eventError
  * @since 0.5.0

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -596,6 +596,15 @@ KlasaClient.defaultClientSchema = new Schema()
  */
 
 /**
+ * Emitted when a command's {@link RateLimit} has been emptied.
+ * @event KlasaClient#commandRateLimit
+ * @since 0.5.0
+ * @param {KlasaMessage} message The message that triggered the command
+ * @param {Command} command The command run
+ * @param {any[]} params The resolved parameters of the command
+ */
+
+/**
  * Emitted when an event has encountered an error.
  * @event KlasaClient#eventError
  * @since 0.5.0

--- a/src/lib/util/RateLimitManager.js
+++ b/src/lib/util/RateLimitManager.js
@@ -18,24 +18,27 @@ class RateLimitManager extends Collection {
 		/**
 		 * The sweep interval for this RateLimitManager
 		 * @since 0.5.0
+		 * @name RateLimitManager#sweepInterval
 		 * @type {?NodeJS.Timer}
 		 * @private
 		 */
-		this.sweepInterval = null;
+		Object.defineProperty(this, 'sweepInterval', { value: null, writable: true });
 
 		/**
 		 * The amount of times a RateLimit from this manager can drip before it's limited
 		 * @since 0.5.0
+		 * @name RateLimitManager#bucket
 		 * @type {number}
 		 */
-		this.bucket = bucket;
+		Object.defineProperty(this, 'bucket', { value: bucket });
 
 		/**
 		 * The amount of time in ms for a RateLimit from this manager to reset
 		 * @since 0.5.0
+		 * @name RateLimitManager#cooldown
 		 * @type {number}
 		 */
-		this.cooldown = cooldown;
+		Object.defineProperty(this, 'cooldown', { value: cooldown });
 	}
 
 	/**

--- a/src/lib/util/RateLimitManager.js
+++ b/src/lib/util/RateLimitManager.js
@@ -29,6 +29,7 @@ class RateLimitManager extends Collection {
 		 * @since 0.5.0
 		 * @name RateLimitManager#bucket
 		 * @type {number}
+		 * @readonly
 		 */
 		Object.defineProperty(this, 'bucket', { value: bucket });
 
@@ -37,6 +38,7 @@ class RateLimitManager extends Collection {
 		 * @since 0.5.0
 		 * @name RateLimitManager#cooldown
 		 * @type {number}
+		 * @readonly
 		 */
 		Object.defineProperty(this, 'cooldown', { value: cooldown });
 	}

--- a/src/lib/util/RateLimitManager.js
+++ b/src/lib/util/RateLimitManager.js
@@ -45,6 +45,8 @@ class RateLimitManager extends Collection {
 	 * @returns {RateLimit}
 	 */
 	create(id) {
+		const previous = this.get(id);
+		if (previous) return previous;
 		const rateLimit = new RateLimit(this.bucket, this.cooldown);
 		this.set(id, rateLimit);
 		return rateLimit;

--- a/src/lib/util/RateLimitManager.js
+++ b/src/lib/util/RateLimitManager.js
@@ -39,14 +39,22 @@ class RateLimitManager extends Collection {
 	}
 
 	/**
+	 * Gets a {@link RateLimit} from this manager or creates it if it does not exist
+	 * @since 0.5.0
+	 * @param {string} id The id for the RateLimit
+	 * @returns {RateLimit}
+	 */
+	acquire(id) {
+		return this.get(id) || this.create(id);
+	}
+
+	/**
 	 * Creates a {@link RateLimit} for this manager
 	 * @since 0.5.0
 	 * @param {string} id The id the RateLimit belongs to
 	 * @returns {RateLimit}
 	 */
 	create(id) {
-		const previous = this.get(id);
-		if (previous) return previous;
 		const rateLimit = new RateLimit(this.bucket, this.cooldown);
 		this.set(id, rateLimit);
 		return rateLimit;
@@ -57,7 +65,7 @@ class RateLimitManager extends Collection {
 	 * @since 0.5.0
 	 * @param {string} id The id the RateLimit belongs to
 	 * @param {RateLimit} rateLimit The this for the sweep
-	 * @returns {number}
+	 * @returns {this}
 	 * @private
 	 */
 	set(id, rateLimit) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1059,8 +1059,8 @@ declare module 'klasa' {
 
 	export class RateLimitManager extends Collection<Snowflake, RateLimit> {
 		public constructor(bucket: number, cooldown: number);
-		public bucket: number;
-		public cooldown: number;
+		public readonly bucket: number;
+		public readonly cooldown: number;
 		private sweepInterval: NodeJS.Timer | null;
 		public acquire(id: string): RateLimit;
 		public create(id: Snowflake): RateLimit;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1062,6 +1062,7 @@ declare module 'klasa' {
 		public bucket: number;
 		public cooldown: number;
 		private sweepInterval: NodeJS.Timer | null;
+		public acquire(id: string): RateLimit;
 		public create(id: Snowflake): RateLimit;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -123,7 +123,6 @@ declare module 'klasa' {
 		// Klasa Command Events
 		public on(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
 		public on(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
-		public on(event: 'commandRateLimit', listener: (message: KlasaMessage, command: Command, params: any[]) => void): this;
 		public on(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public on(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public on(event: 'commandUnknown', listener: (message: KlasaMessage, command: string) => void): this;
@@ -185,7 +184,6 @@ declare module 'klasa' {
 		// Klasa Command Events
 		public once(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
 		public once(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
-		public once(event: 'commandRateLimit', listener: (message: KlasaMessage, command: Command, params: any[]) => void): this;
 		public once(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public once(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public once(event: 'commandUnknown', listener: (message: KlasaMessage, command: string) => void): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -123,6 +123,7 @@ declare module 'klasa' {
 		// Klasa Command Events
 		public on(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
 		public on(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
+		public on(event: 'commandRateLimit', listener: (message: KlasaMessage, command: Command, params: any[]) => void): this;
 		public on(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public on(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public on(event: 'commandUnknown', listener: (message: KlasaMessage, command: string) => void): this;
@@ -184,6 +185,7 @@ declare module 'klasa' {
 		// Klasa Command Events
 		public once(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
 		public once(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
+		public once(event: 'commandRateLimit', listener: (message: KlasaMessage, command: Command, params: any[]) => void): this;
 		public once(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public once(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		public once(event: 'commandUnknown', listener: (message: KlasaMessage, command: string) => void): this;


### PR DESCRIPTION
### Description of the PR

This PR cleans up some code by adding `RateLimitManager#acquire`, which returns the previous instance if it existed, or creates a new one, allowing the following pattern:

```javascript
(this.ratelimits.get(message.author.id) || this.ratelimits.create(message.author.id)).drip();
```

To be reduced to:

```javascript
this.ratelimits.acquire(message.author.id).drip();
```

~~Although we could consider overloading `RateLimitManager#get` to accept a second argument being `create`, likewise SettingsGateway's methods (this is up for discussion).~~

~~Additionally, I have swapped the order of the checks in the commandCooldown finalizer: numeric comparison is far much faster than running a getter and then compare it. And changed the event from error to verbose (could be renamed to `commandRatelimit` to let developers handle it at their wish, similar to the `rateLimit` event from discord.js, also up for discussion).~~

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added `RateLimitManager#acquire`, which returns the entry from cache if it exists, or creates one otherwise.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
