### PR TITLE
Various typo and grammar fixes Attempt 2

### DIFF
--- a/guides/Advanced Commands/CommandsArguments.md
+++ b/guides/Advanced Commands/CommandsArguments.md
@@ -1,4 +1,4 @@
-This is an in-depth tutorial for the **Klasa's Usage**. Unlike many other frameworks, Klasa and Komada use a system called **usage string** to improve simplicity, in the next three pages, you will learn how to use it correctly.
+This is an in-depth tutorial for **Klasa's Usage**. Unlike many other frameworks, Klasa and Komada use a system called **usage string** to improve simplicity, in the next three pages, you will learn how to use it correctly.
 
 ## Command Arguments
 

--- a/guides/Advanced Commands/CommandsSubcommands.md
+++ b/guides/Advanced Commands/CommandsSubcommands.md
@@ -2,7 +2,7 @@
 
 It is called **subcommand** to the special behaviour when a command takes multiple **Possible**s of literals as the first parameter, and the command has {@link CommandOptions.subcommands} set to true. An example is the [built-in conf](https://github.com/dirigeants/klasa/blob/master/src/commands/Admin/conf.js) command, which unlike any other command, it does not have a `Command#run` method.
 
-How do subcommands work? The concept may be quite hard to *get* but it's very powerful. We will take the conf command as an example:
+How do subcommands work? The concept may be quite hard to *understand* however it's very powerful. We will take the conf command as an example:
 
 ```javascript
 const { Command } = require('klasa');
@@ -25,7 +25,7 @@ module.exports = class extends Command {
 };
 ```
 
-As you may notice it, the command does not have a `Command#run` method, but it has one method for each literal that is taken as first parameter, all of them lowercased. That is, to simplify the following pattern used in many commands:
+As you may notice it, the command does not have a `Command#run` method, but it has one method for each literal that is taken as the first parameter, all of them lowercased. That is, to simplify the following pattern used in many commands:
 
 ```javascript
 module.exports = class extends Command {

--- a/guides/Advanced Commands/CommandsSubcommands.md
+++ b/guides/Advanced Commands/CommandsSubcommands.md
@@ -2,7 +2,7 @@
 
 It is called **subcommand** to the special behaviour when a command takes multiple **Possible**s of literals as the first parameter, and the command has {@link CommandOptions.subcommands} set to true. An example is the [built-in conf](https://github.com/dirigeants/klasa/blob/master/src/commands/Admin/conf.js) command, which unlike any other command, it does not have a `Command#run` method.
 
-How do subcommands work? The concept may be quite hard to *understand* however it's very powerful. We will take the conf command as an example:
+How do subcommands work? The concept may be quite hard to *understand*, however it's very powerful. We will take the conf command as an example:
 
 ```javascript
 const { Command } = require('klasa');

--- a/guides/Advanced Commands/CommandsSubcommands.md
+++ b/guides/Advanced Commands/CommandsSubcommands.md
@@ -2,7 +2,7 @@
 
 It is called **subcommand** to the special behaviour when a command takes multiple **Possible**s of literals as the first parameter, and the command has {@link CommandOptions.subcommands} set to true. An example is the [built-in conf](https://github.com/dirigeants/klasa/blob/master/src/commands/Admin/conf.js) command, which unlike any other command, it does not have a `Command#run` method.
 
-How do subcommands work? The concept may be quite hard to *understand*, however it's very powerful. We will take the conf command as an example:
+How do subcommands work? The concept may be quite hard to *understand* however, it's also very powerful. We will take the conf command as an example:
 
 ```javascript
 const { Command } = require('klasa');

--- a/guides/Advanced Commands/CommandsSubcommands.md
+++ b/guides/Advanced Commands/CommandsSubcommands.md
@@ -2,7 +2,7 @@
 
 It is called **subcommand** to the special behaviour when a command takes multiple **Possible**s of literals as the first parameter, and the command has {@link CommandOptions.subcommands} set to true. An example is the [built-in conf](https://github.com/dirigeants/klasa/blob/master/src/commands/Admin/conf.js) command, which unlike any other command, it does not have a `Command#run` method.
 
-How do subcommands work? The concept may be quite hard to *understand* however, it's also very powerful. We will take the conf command as an example:
+How do subcommands work? The concept may be quite hard to *understand*; however, it's also very powerful. We will take the conf command as an example:
 
 ```javascript
 const { Command } = require('klasa');

--- a/guides/Advanced SettingsGateway/SettingsGatewaySettingsUpdate.md
+++ b/guides/Advanced SettingsGateway/SettingsGatewaySettingsUpdate.md
@@ -1,6 +1,6 @@
 # Updating your configuration
 
-Once we have our schema done with all the keys, folders and types needed, we may want to update our configuration via SettingsGateway, all of this is done via {@link Settings#update}. However, how can I update it? Use any of the following code snippets:
+Once we have our schema completed with all the keys, folders and types needed, we may want to update our configuration via SettingsGateway, all of this is done via {@link Settings#update}. However, how can I update it? Use any of the following code snippets:
 
 ```javascript
 // Updating the value of a key

--- a/guides/Building Your Bot/CreatingPointsSystems.md
+++ b/guides/Building Your Bot/CreatingPointsSystems.md
@@ -43,7 +43,7 @@ module.exports = class extends Monitor {
 
 Some social bots have level up messages. How do we set it up? There are two ways to achieve this:
 
-1. We calculate the current level and the next level on the fly. This system is, however, harder to implement and it requires more arithmatic calculations, but it's also RAM friendly for massive bots. We won't cover this in the guide.
+1. We calculate the current level and the next level on the fly. This system is, however, harder to implement and it requires more arithmetic calculations, but it's also RAM friendly for massive bots. We won't cover this in the guide.
 1. We add a level field. This makes the configuration update slower by nature as it will need to update two values. First, we will create the key:
 
 ```javascript

--- a/guides/Building Your Bot/CreatingPointsSystems.md
+++ b/guides/Building Your Bot/CreatingPointsSystems.md
@@ -43,7 +43,7 @@ module.exports = class extends Monitor {
 
 Some social bots have level up messages. How do we set it up? There are two ways to achieve this:
 
-1. We calculate the current level and the next level on the fly. This system is, however, harder to implement and it processes a lot of maths, but it's also RAM friendly for massive bots. We won't cover this in the guide.
+1. We calculate the current level and the next level on the fly. This system is, however, harder to implement and it requires more arithmatic calculations, but it's also RAM friendly for massive bots. We won't cover this in the guide.
 1. We add a level field. This makes the configuration update slower by nature as it will need to update two values. First, we will create the key:
 
 ```javascript

--- a/guides/Building Your Bot/CreatingPointsSystems.md
+++ b/guides/Building Your Bot/CreatingPointsSystems.md
@@ -43,7 +43,7 @@ module.exports = class extends Monitor {
 
 Some social bots have level up messages. How do we set it up? There are two ways to achieve this:
 
-1. We calculate the current level and the next level on the fly. This system is, however, harder to implement and it requires more arithmetic calculations, but it's also RAM friendly for massive bots. We won't cover this in the guide.
+1. We calculate the current level and the next level on the fly. However, this system is harder to implement and is more expensive to execute, but it's also RAM friendly for massive bots. We won't cover this in the guide.
 1. We add a level field. This makes the configuration update slower by nature as it will need to update two values. First, we will create the key:
 
 ```javascript

--- a/guides/Getting Started/GettingStarted.md
+++ b/guides/Getting Started/GettingStarted.md
@@ -8,7 +8,7 @@ Time to take the plunge! Klasa is on NPM and can be easily installed.
 npm install --save discordjs/discord.js klasa
 ```
 
-optionally if you want to use the bleeding edge development version (not guaranteed to be stable):
+Optionally if you want to use the bleeding edge development version (not guaranteed to be stable):
 
 ```sh
 npm install --save discordjs/discord.js dirigeants/klasa
@@ -50,7 +50,7 @@ new Client({
 | **regexPrefix**            | `null`                    | regex              | The regular expression prefix if one is provided                                    |
 | **typing**                 | `false`                   | boolean            | Whether the bot should type while processing commands.                              |
 
->1. ID gotten from the Discord API if not provided: `client.application.owner.id`
+>1. ID acquired from the Discord API if not provided: `client.application.owner.id`
 >1. You can pass an array to accept multiple prefixes.
 >1. quotedStringSupport is overridable per command.
 >1. `Successfully initialized. Ready to serve ${client.guilds.size} guilds.`

--- a/guides/Piece Basics/CreatingFinalizers.md
+++ b/guides/Piece Basics/CreatingFinalizers.md
@@ -52,7 +52,7 @@ This finalizer applies the cooldown from the commands' `Command.cooldown` (if ex
 
 ### commandlogging
 
-This finalizer, unlike commandCooldown, it's only run if the property `commandLogging` of
+This finalizer, unlike commandCooldown, is only run if the property `commandLogging` of
 your Klasa's client settings is set to `true`. It prints in the command prompt the command run, where,
 the user who ran it, and the time it took to process the command.
 


### PR DESCRIPTION
### Description of the PR
Changes the wording of some guides as well as fix some grammar issues.

Force revert of #441 occurred due to accidental push to `dirigeants/klasa#master` instead of `cyberiumshadow/klasa#master`

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- N/A

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
