### PR TITLE
ReactionHandler check if message.deleted

### DIFF
--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -115,7 +115,7 @@ class ReactionHandler extends ReactionCollector {
 			this[this.methodMap.get(reaction.emoji.name)](user);
 		});
 		this.on('end', () => {
-			if (this.reactionsDone && this.message) this.message.reactions.removeAll();
+			if (this.reactionsDone && !this.message.deleted) this.message.reactions.removeAll();
 		});
 	}
 
@@ -329,7 +329,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @private
 	 */
 	async _queueEmojiReactions(emojis) {
-		if (!this.message) this.stop();
+		if (this.message.deleted) this.stop();
 		if (this.ended) return this.message.reactions.removeAll();
 		await this.message.react(emojis.shift());
 		if (emojis.length) return this._queueEmojiReactions(emojis);

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -329,7 +329,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @private
 	 */
 	async _queueEmojiReactions(emojis) {
-		if (this.message.deleted) this.stop();
+		if (this.message.deleted) return this.stop();
 		if (this.ended) return this.message.reactions.removeAll();
 		await this.message.react(emojis.shift());
 		if (emojis.length) return this._queueEmojiReactions(emojis);

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -115,7 +115,7 @@ class ReactionHandler extends ReactionCollector {
 			this[this.methodMap.get(reaction.emoji.name)](user);
 		});
 		this.on('end', () => {
-			if (this.reactionsDone) this.message.reactions.removeAll();
+			if (this.reactionsDone && this.message) this.message.reactions.removeAll();
 		});
 	}
 
@@ -329,6 +329,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @private
 	 */
 	async _queueEmojiReactions(emojis) {
+		if (!this.message) this.stop();
 		if (this.ended) return this.message.reactions.removeAll();
 		await this.message.react(emojis.shift());
 		if (emojis.length) return this._queueEmojiReactions(emojis);


### PR DESCRIPTION
### Description of the PR

Adds some safety to the ReactionHandler with messages that are deleted/inaccesable.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Check for message deletes in the ReactionHandler

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
