### PR TITLE
pass command to the finalizer

### DIFF
--- a/guides/Piece Basics/CreatingFinalizers.md
+++ b/guides/Piece Basics/CreatingFinalizers.md
@@ -15,7 +15,7 @@ module.exports = class extends Finalizer {
 		});
 	}
 
-	run(message, response, runTime) {
+	run(message, command, response, runTime) {
 		// This is where you place the code you want to run for your finalizer
 	}
 
@@ -39,12 +39,13 @@ module.exports = class extends Finalizer {
 ## Arguments:
 
 - **message**: The message object.
+- **command**: The command used (may not be the same as message.command).
 - **response**: The value the command returns.
 - **runTime**: The time it took to run the command.
 
 ## Existing finalizers
 
-Klasa has two preinstalled finalizers: `commandCooldown` and `commandlogging`.
+Klasa has two pre-installed finalizers: `commandCooldown` and `commandlogging`.
 
 ### commandCooldown
 

--- a/src/finalizers/commandLogging.js
+++ b/src/finalizers/commandLogging.js
@@ -13,10 +13,10 @@ module.exports = class extends Finalizer {
 		};
 	}
 
-	run(message, response, timer) {
+	run(message, command, response, timer) {
 		const { type } = message.channel;
 		this.client.emit('log', [
-			`${message.command.name}(${message.args.join(', ')})`,
+			`${command.name}(${message.args ? '' : message.args.join(', ')})`,
 			this.reprompted[Number(message.reprompted)].format(`[${timer.stop()}]`),
 			this.user.format(`${message.author.username}[${message.author.id}]`),
 			this.channel[type].format(this[type](message))

--- a/src/lib/structures/Finalizer.js
+++ b/src/lib/structures/Finalizer.js
@@ -12,6 +12,7 @@ class Finalizer extends Piece {
 	 * The run method to be overwritten in actual finalizers
 	 * @since 0.0.1
 	 * @param {KlasaMessage} message The message used to trigger this finalizer
+	 * @param {Command} command The command this finalizer is for (may be different than message.command)
 	 * @param {KlasaMessage|KlasaMessage[]} response The bot's response message, if one is returned
 	 * @param {Stopwatch} runTime The time it took to generate the command
 	 * @returns {void}

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -75,7 +75,7 @@ module.exports = class extends Monitor {
 				const commandRun = subcommand ? message.command[subcommand](message, message.params) : message.command.run(message, message.params);
 				timer.stop();
 				const response = await commandRun;
-				this.client.finalizers.run(message, response, timer);
+				this.client.finalizers.run(message, message.command, response, timer);
 				this.client.emit('commandSuccess', message, message.command, message.params, response);
 			} catch (error) {
 				this.client.emit('commandError', message, message.command, message.params, error);


### PR DESCRIPTION
### Description of the PR
for custom implementations of command handlers. For instance, usage of commandUnknown to run a tag command/other custom implementation of a command handler.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Adds the command run as the second argument of Finalizer#run()

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
