### PR TITLE
Fix `directory` arg name and documentation

### DIFF
--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -41,11 +41,11 @@ class Command extends AliasPiece {
 	 * @param {KlasaClient} client The Klasa Client
 	 * @param {CommandStore} store The Command store
 	 * @param {Array} file The path from the pieces folder to the command file
-	 * @param {boolean} core If the piece is in the core directory or not
+	 * @param {string} directory The base directory to the pieces folder
 	 * @param {CommandOptions} [options={}] Optional Command settings
 	 */
-	constructor(client, store, file, core, options = {}) {
-		super(client, store, file, core, options);
+	constructor(client, store, file, directory, options = {}) {
+		super(client, store, file, directory, options);
 
 		this.name = this.name.toLowerCase();
 

--- a/src/lib/structures/Event.js
+++ b/src/lib/structures/Event.js
@@ -20,11 +20,11 @@ class Event extends Piece {
 	 * @param {KlasaClient} client The Klasa client
 	 * @param {EventStore} store The Event Store
 	 * @param {string} file The path from the pieces folder to the event file
-	 * @param {boolean} core If the piece is in the core directory or not
+	 * @param {string} directory The base directory to the pieces folder
 	 * @param {EventOptions} [options={}] Optional Event settings
 	 */
-	constructor(client, store, file, core, options = {}) {
-		super(client, store, file, core, options);
+	constructor(client, store, file, directory, options = {}) {
+		super(client, store, file, directory, options);
 
 		/**
 		 * If this event should only be run once and then unloaded

--- a/src/lib/structures/Inhibitor.js
+++ b/src/lib/structures/Inhibitor.js
@@ -18,11 +18,11 @@ class Inhibitor extends Piece {
 	 * @param {KlasaClient} client The Klasa client
 	 * @param {InhibitorStore} store The Inhibitor Store
 	 * @param {string} file The path from the pieces folder to the inhibitor file
-	 * @param {boolean} core If the piece is in the core directory or not
+	 * @param {string} directory The base directory to the pieces folder
 	 * @param {InhibitorOptions} [options={}] Optional Inhibitor settings
 	 */
-	constructor(client, store, file, core, options = {}) {
-		super(client, store, file, core, options);
+	constructor(client, store, file, directory, options = {}) {
+		super(client, store, file, directory, options);
 
 		/**
 		 * If this inhibitor is meant for spamProtection (disables the inhibitor while generating help)

--- a/src/lib/structures/Monitor.js
+++ b/src/lib/structures/Monitor.js
@@ -24,11 +24,11 @@ class Monitor extends Piece {
 	 * @param {KlasaClient} client The Klasa client
 	 * @param {MonitorStore} store The Monitor Store
 	 * @param {string} file The path from the pieces folder to the monitor file
-	 * @param {boolean} core If the piece is in the core directory or not
+	 * @param {string} directory The base directory to the pieces folder
 	 * @param {MonitorOptions} [options={}] Optional Monitor settings
 	 */
-	constructor(client, store, file, core, options = {}) {
-		super(client, store, file, core, options);
+	constructor(client, store, file, directory, options = {}) {
+		super(client, store, file, directory, options);
 
 		/**
 		 * Whether the monitor ignores bots or not


### PR DESCRIPTION
### Description of the PR
In several classes extending Piece, the constructor's `directory` argument was still mistakenly called `core`, incorrectly identified as a boolean. I updated the name and documentation of this argument to be accurate to the base class.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change in name and doc for ~core~ directory arg in piece constructors

### Semver Classification

- [X] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
