### PR TITLE
fix: Stringify errors

### DIFF
--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -52,7 +52,7 @@ module.exports = class extends Command {
 	}
 
 	check(message, key, { errors, updated }) {
-		if (errors.length) return message.sendMessage(errors[0]);
+		if (errors.length) return message.sendMessage(String(errors[0]));
 		if (!updated.length) return message.sendLocale('COMMAND_CONF_NOCHANGE', [key]);
 		return null;
 	}


### PR DESCRIPTION
### Description of the PR

Fixes the "Cannot send an empty message", as Discord.js does not stringify objects but threat them as options.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed conf command not stringifying the error

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
