### PR TITLE
Fix prefix reminder bug

### DIFF
--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -14,7 +14,7 @@ module.exports = class extends Monitor {
 	async run(message) {
 		if (message.guild && !message.guild.me) await message.guild.members.fetch(this.client.user);
 		if (!message.channel.postable) return undefined;
-		if (this.mentionOnly.test(message.content)) return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix || undefined]);
+		if (this.mentionOnly.test(message.content)) return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length > 0 ? message.guildSettings.prefix : undefined]);
 
 		const { commandText, prefix, prefixLength } = this.parseCommand(message);
 		if (!commandText) return undefined;

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -14,7 +14,7 @@ module.exports = class extends Monitor {
 	async run(message) {
 		if (message.guild && !message.guild.me) await message.guild.members.fetch(this.client.user);
 		if (!message.channel.postable) return undefined;
-		if (this.mentionOnly.test(message.content)) return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length > 0 ? message.guildSettings.prefix : undefined]);
+		if (this.mentionOnly.test(message.content)) return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length ? message.guildSettings.prefix : undefined]);
 
 		const { commandText, prefix, prefixLength } = this.parseCommand(message);
 		if (!commandText) return undefined;


### PR DESCRIPTION
### Description of the PR
The "PREFIX_REMINDER" language string's `prefix` argument has a default of "@" + the bot's tag. However, this never gets used because the situation where it would come into play, when a guild has removed the default prefixes (only when there are multiple), causes an empty array to be passed to the function, and default params don't overwrite empty arrays, of course.

I changed the commandHandler monitor to pass `undefined` when the guild prefix is an empty array, instead of when it's falsey, which I don't believe it ever can be. (Correct me if I'm wrong, but guildSettings.prefix can never be null or undefined, which is why I'm not checking for that case.)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- changed commandHandler to use ternary, checking length, instead of logical OR

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [X] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
