### PR TITLE
Allow Managers to dynamically update child RateLimits

### DIFF
--- a/src/lib/util/RateLimitManager.js
+++ b/src/lib/util/RateLimitManager.js
@@ -23,24 +23,38 @@ class RateLimitManager extends Collection {
 		 * @private
 		 */
 		Object.defineProperty(this, 'sweepInterval', { value: null, writable: true });
+		Object.defineProperty(this, '_bucket', { value: bucket, writable: true });
+		Object.defineProperty(this, '_cooldown', { value: cooldown, writable: true });
+	}
 
-		/**
-		 * The amount of times a RateLimit from this manager can drip before it's limited
-		 * @since 0.5.0
-		 * @name RateLimitManager#bucket
-		 * @type {number}
-		 * @readonly
-		 */
-		Object.defineProperty(this, 'bucket', { value: bucket });
+	/**
+	 * The amount of times a RateLimit from this manager can drip before it's limited
+	 * @since 0.5.0
+	 * @type {number}
+	 */
+	get bucket() {
+		return this._bucket;
+	}
 
-		/**
-		 * The amount of time in ms for a RateLimit from this manager to reset
-		 * @since 0.5.0
-		 * @name RateLimitManager#cooldown
-		 * @type {number}
-		 * @readonly
-		 */
-		Object.defineProperty(this, 'cooldown', { value: cooldown });
+	set bucket(value) {
+		for (const ratelimit of this.values()) ratelimit.bucket = value;
+		this._bucket = value;
+		return value;
+	}
+
+	/**
+	 * The amount of time in ms for a RateLimit from this manager to reset
+	 * @since 0.5.0
+	 * @type {number}
+	 */
+	get cooldown() {
+		return this._cooldown;
+	}
+
+	set cooldown(value) {
+		for (const ratelimit of this.values()) ratelimit.cooldown = value;
+		this._cooldown = value;
+		return value;
 	}
 
 	/**
@@ -60,7 +74,7 @@ class RateLimitManager extends Collection {
 	 * @returns {RateLimit}
 	 */
 	create(id) {
-		const rateLimit = new RateLimit(this.bucket, this.cooldown);
+		const rateLimit = new RateLimit(this._bucket, this._cooldown);
 		this.set(id, rateLimit);
 		return rateLimit;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1057,7 +1057,7 @@ declare module 'klasa' {
 		public resetTime(): this;
 	}
 
-	export class RateLimitManager<K> extends Collection<K, RateLimit> {
+	export class RateLimitManager<K = Snowflake> extends Collection<K, RateLimit> {
 		public constructor(bucket: number, cooldown: number);
 		public bucket: number;
 		public cooldown: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1057,15 +1057,15 @@ declare module 'klasa' {
 		public resetTime(): this;
 	}
 
-	export class RateLimitManager extends Collection<Snowflake, RateLimit> {
+	export class RateLimitManager<K> extends Collection<K, RateLimit> {
 		public constructor(bucket: number, cooldown: number);
 		public bucket: number;
 		public cooldown: number;
 		private _bucket: number;
 		private _cooldown: number;
 		private sweepInterval: NodeJS.Timer | null;
-		public acquire(id: Snowflake): RateLimit;
-		public create(id: Snowflake): RateLimit;
+		public acquire(id: K): RateLimit;
+		public create(id: K): RateLimit;
 	}
 
 	export class ReactionHandler extends ReactionCollector {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1059,10 +1059,12 @@ declare module 'klasa' {
 
 	export class RateLimitManager extends Collection<Snowflake, RateLimit> {
 		public constructor(bucket: number, cooldown: number);
-		public readonly bucket: number;
-		public readonly cooldown: number;
+		public bucket: number;
+		public cooldown: number;
+		private _bucket: number;
+		private _cooldown: number;
 		private sweepInterval: NodeJS.Timer | null;
-		public acquire(id: string): RateLimit;
+		public acquire(id: Snowflake): RateLimit;
 		public create(id: Snowflake): RateLimit;
 	}
 


### PR DESCRIPTION
### Description of the PR
Allows updating rate limits manager wide without impacting individual RateLimit usage (without a manager)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
