### PR TITLE
refactor: Convert GatewayDriver into a Collection<string, Gateway>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Changed
 
+- [[#467](https://github.com/dirigeants/klasa/pull/467)] **[BREAKING]** Changed `GatewayDriver` to extend `Collection<string, Gateway>` as opposed to being a dictionary type. (kyranet)
 - [[#392](https://github.com/dirigeants/klasa/pull/392)] Changed default prefix from `'!'` to `''`. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed SchemaFolder to extend Schema, which extends Map. All keys are now stored inside the map as opposed to being properties. (Unseenfaith)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] **[BREAKING]** Changed `Schema#add` and `Schema#remove` to be synchronous. They must be called before ready. (Unseenfaith)

--- a/guides/Getting Started/UnderstandingSettingsGateway.md
+++ b/guides/Getting Started/UnderstandingSettingsGateway.md
@@ -60,7 +60,7 @@ client.login('A_BEAUTIFUL_TOKEN_AINT_IT?');
 And then, you can access to it by:
 
 ```javascript
-client.gateways.channels;
+client.gateways.get('channels');
 ```
 
 ## Customizing the options for each built-in gateway

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -25,7 +25,7 @@ module.exports = class extends Command {
 	}
 
 	show(message, [key]) {
-		const path = this.client.gateways.guilds.getPath(key, { avoidUnconfigurable: true, errors: false, piece: null });
+		const path = this.client.gateways.get('guilds').getPath(key, { avoidUnconfigurable: true, errors: false, piece: null });
 		if (!path) return message.sendLocale('COMMAND_CONF_GET_NOEXT', [key]);
 		if (path.piece.type === 'Folder') {
 			return message.sendLocale('COMMAND_CONF_SERVER', [

--- a/src/commands/General/User Settings/userconf.js
+++ b/src/commands/General/User Settings/userconf.js
@@ -23,7 +23,7 @@ module.exports = class extends Command {
 	}
 
 	show(message, [key]) {
-		const path = this.client.gateways.users.getPath(key, { avoidUnconfigurable: true, errors: false, piece: null });
+		const path = this.client.gateways.get('users').getPath(key, { avoidUnconfigurable: true, errors: false, piece: null });
 		if (!path) return message.sendLocale('COMMAND_CONF_GET_NOEXT', [key]);
 		if (path.piece.type === 'Folder') {
 			return message.sendLocale('COMMAND_CONF_USER', [

--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -13,9 +13,9 @@ module.exports = class extends Event {
 		await this.client.fetchApplication();
 		if (!this.client.options.ownerID) this.client.options.ownerID = this.client.application.owner.id;
 
-		this.client.settings = this.client.gateways.clientStorage.get(this.client.user.id, true);
+		this.client.settings = this.client.gateways.get('clientStorage').get(this.client.user.id, true);
 		// Added for consistency with other datastores, Client#clients does not exist
-		this.client.gateways.clientStorage.cache.set(this.client.user.id, this.client);
+		this.client.gateways.get('clientStorage').cache.set(this.client.user.id, this.client);
 		await this.client.gateways.sync();
 
 		// Init all the pieces

--- a/src/events/settingsUpdateEntry.js
+++ b/src/events/settingsUpdateEntry.js
@@ -7,7 +7,7 @@ module.exports = class extends Event {
 		if (this.client.shard && gateways.includes(settings.gateway.type)) {
 			this.client.shard.broadcastEval(`
 				if (this.shard.id !== ${this.client.shard.id}) {
-					const entry = this.gateways.${settings.gateway.type}.get('${settings.id}');
+					const entry = this.gateways.get('${settings.gateway.type}').get('${settings.id}');
 					if (entry) entry._patch(${JSON.stringify(settings)});
 				}
 			`);

--- a/src/lib/extensions/KlasaGuild.js
+++ b/src/lib/extensions/KlasaGuild.js
@@ -23,7 +23,7 @@ module.exports = Structures.extend('Guild', Guild => {
 			 * @since 0.5.0
 			 * @type {Settings}
 			 */
-			this.settings = this.client.gateways.guilds.get(this.id, true);
+			this.settings = this.client.gateways.get('guilds').get(this.id, true);
 		}
 
 		/**

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -18,7 +18,7 @@ module.exports = Structures.extend('Message', Message => {
 			 * @since 0.5.0
 			 * @type {Settings}
 			 */
-			this.guildSettings = this.guild ? this.guild.settings : this.client.gateways.guilds.defaults;
+			this.guildSettings = this.guild ? this.guild.settings : this.client.gateways.get('guilds').defaults;
 
 			/**
 			 * The command being run

--- a/src/lib/extensions/KlasaUser.js
+++ b/src/lib/extensions/KlasaUser.js
@@ -23,7 +23,7 @@ module.exports = Structures.extend('User', User => {
 			 * @since 0.5.0
 			 * @type {Settings}
 			 */
-			this.settings = this.client.gateways.users.get(this.id, true);
+			this.settings = this.client.gateways.get('users').get(this.id, true);
 		}
 
 		/**

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -61,7 +61,7 @@ class GatewayDriver extends Collection {
 	register(name, { provider = this.client.options.providers.default, schema = new Schema() } = {}) {
 		if (typeof name !== 'string') throw new TypeError('You must pass a name for your new gateway and it must be a string.');
 		if (!(schema instanceof Schema)) throw new TypeError('Schema must be a valid Schema instance.');
-		if (this.has(name)) throw new Error(`The key '${name}' is either taken by another Gateway or reserved for GatewayDriver's functionality.`);
+		if (this.has(name)) throw new Error(`The key '${name}' is taken by another Gateway.`);
 
 		if (!(name in this.client.options.gateways)) this.client.options.gateways[name] = {};
 		const gateway = new Gateway(this, name, schema, provider);

--- a/src/lib/settings/GatewayDriver.js
+++ b/src/lib/settings/GatewayDriver.js
@@ -1,11 +1,12 @@
 const Gateway = require('./Gateway');
 const Schema = require('./schema/Schema');
+const Collection = require('discord.js');
 
 /**
  * <warning>GatewayDriver is a singleton, use {@link KlasaClient#gateways} instead.</warning>
  * Gateway's driver to make new instances of it, with the purpose to handle different databases simultaneously.
  */
-class GatewayDriver {
+class GatewayDriver extends Collection {
 
 	/**
 	 * @typedef {Object} GatewayDriverRegisterOptions
@@ -36,6 +37,8 @@ class GatewayDriver {
 	 * @param {KlasaClient} client The Klasa client
 	 */
 	constructor(client) {
+		super();
+
 		/**
 		 * The client this GatewayDriver was created with.
 		 * @since 0.3.0
@@ -44,40 +47,6 @@ class GatewayDriver {
 		 * @readonly
 		 */
 		Object.defineProperty(this, 'client', { value: client });
-
-		/**
-		 * The register creation queue.
-		 * @since 0.5.0
-		 * @name GatewayDriver#_queue
-		 * @type {Array<Function>}
-		 * @readonly
-		 * @private
-		 */
-		Object.defineProperty(this, '_queue', { value: [] });
-
-		/**
-		 * All the gateways added
-		 * @type {Set<string>}
-		 */
-		this.keys = new Set();
-
-		/**
-		 * The Gateway that manages per-guild data
-		 * @type {?Gateway}
-		 */
-		this.guilds = null;
-
-		/**
-		 * The Gateway that manages per-user data
-		 * @type {?Gateway}
-		 */
-		this.users = null;
-
-		/**
-		 * The Gateway that manages per-client data
-		 * @type {?Gateway}
-		 */
-		this.clientStorage = null;
 	}
 
 
@@ -92,13 +61,11 @@ class GatewayDriver {
 	register(name, { provider = this.client.options.providers.default, schema = new Schema() } = {}) {
 		if (typeof name !== 'string') throw new TypeError('You must pass a name for your new gateway and it must be a string.');
 		if (!(schema instanceof Schema)) throw new TypeError('Schema must be a valid Schema instance.');
-		if (this.name !== undefined && this.name !== null) throw new Error(`The key '${name}' is either taken by another Gateway or reserved for GatewayDriver's functionality.`);
+		if (this.has(name)) throw new Error(`The key '${name}' is either taken by another Gateway or reserved for GatewayDriver's functionality.`);
 
-		const gateway = new Gateway(this, name, schema, provider);
-		this.keys.add(name);
-		this[name] = gateway;
-		this._queue.push(gateway.init.bind(gateway));
 		if (!(name in this.client.options.gateways)) this.client.options.gateways[name] = {};
+		const gateway = new Gateway(this, name, schema, provider);
+		this.set(name, gateway);
 		return this;
 	}
 
@@ -107,33 +74,17 @@ class GatewayDriver {
 	 * @since 0.5.0
 	 */
 	async init() {
-		await Promise.all([...this._queue].map(fn => fn()));
-		this._queue.length = 0;
+		await Promise.all([...this.values()].map(gateway => gateway.init()));
 	}
 
 	/**
 	 * Sync all gateways
 	 * @since 0.5.0
-	 * @param {(string|string[])} input The arguments to pass to each Gateway#sync
+	 * @param {(string|string[])} [input] The arguments to pass to each Gateway#sync
 	 * @returns {Promise<Array<Gateway>>}
 	 */
 	sync(input) {
 		return Promise.all([...this].map(([key, gateway]) => gateway.sync(typeof input === 'undefined' ? this.client.options.gateways[key].syncArg : input)));
-	}
-
-	/**
-	 * Returns a new Iterator object that contains the values for each gateway contained in this driver.
-	 * @name @@iterator
-	 * @since 0.5.0
-	 * @method
-	 * @instance
-	 * @generator
-	 * @returns {Iterator<Array<string | Gateway>>}
-	 * @memberof GatewayDriver
-	 */
-
-	*[Symbol.iterator]() {
-		for (const key of this.keys) yield [key, this[key]];
 	}
 
 	/**
@@ -143,7 +94,6 @@ class GatewayDriver {
 	 */
 	toJSON() {
 		return {
-			keys: [...this.keys],
 			ready: this.ready,
 			...Object.assign({}, [...this].map(([key, value]) => ({ [key]: value.toJSON() })))
 		};
@@ -155,7 +105,7 @@ class GatewayDriver {
 	 * @returns {string}
 	 */
 	toString() {
-		return `GatewayDriver(${[...this.keys].join(', ')})`;
+		return `GatewayDriver(${[...this.keys()].join(', ')})`;
 	}
 
 }

--- a/src/lib/util/QueryBuilder.js
+++ b/src/lib/util/QueryBuilder.js
@@ -90,7 +90,7 @@ class QueryBuilder {
 	 * @param {schemaPiece} schemaPiece The SchemaPiece to process
 	 * @returns {string}
 	 * @example
-	 * this.qb.parse(this.client.gateways.guilds.schema.prefix);
+	 * this.qb.parse(this.client.gateways.get('guilds').schema.prefix);
 	 * // type: 'string', array: true, max: 10
 	 * // -> prefix VARCHAR(10)[]
 	 */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -513,20 +513,14 @@ declare module 'klasa' {
 		private readonly _datatypes: ObjectLiteral<QueryBuilderDatatype>;
 	}
 
-	export class GatewayDriver {
+	export class GatewayDriver extends Collection<string, Gateway> {
 		private constructor(client: KlasaClient);
 		public readonly client: KlasaClient;
-		public keys: Set<string>;
 		public ready: boolean;
-		public guilds: Gateway;
-		public users: Gateway;
-		public clientStorage: Gateway;
-		private _queue: Array<(() => Gateway)>;
 
-		public [Symbol.iterator](): Iterator<[string, Gateway]>;
 		public register(name: string, options?: GatewayDriverRegisterOptions): this;
 		public init(): Promise<void>;
-		public sync(input?: string[]): Promise<Array<Gateway>>;
+		public sync(input?: string[] | string): Promise<Array<Gateway>>;
 
 		public toJSON(): GatewayDriverJSON;
 		public toString(): string;


### PR DESCRIPTION
### Description of the PR

Dictionary-type classes are a bad practise in JavaScript, even though Settings is a dictionary class too (with the difference it doesn't change its properties on runtime but are created on instantiation). This PR refactors GatewayDriver to follow JavaScript's best practises.

This is a large breaking change for anybody using SG, with the only change:

```javascript
this.client.gateways.guilds;
```

Becomes:

```javascript
this.client.gateways.get('guilds');
```

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- **[BREAKING]** Changed `GatewayDriver` to extend `Collection<string, Gateway>` as opposed to being a dictionary type.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
