### PR TITLE
fix: Replace process.binding usage with native v8

### DIFF
--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -4,7 +4,7 @@ const util = require('./util');
 
 setFlagsFromString('--allow-natives-syntax');
 
-const getPromiseDetails = runInThisContext('p => p instanceof Promise ? { status: %PromiseStatus(p), result: %PromiseResult(p) } : []');
+const getPromiseDetails = runInThisContext('p => p instanceof Promise ? { status: %PromiseStatus(p), result: %PromiseResult(p) } : null');
 
 /**
  * The class for deep checking Types

--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -1,5 +1,10 @@
+const { runInThisContext } = require('vm');
+const { setFlagsFromString } = require('v8');
 const util = require('./util');
-const { getPromiseDetails } = process.binding('util');
+
+setFlagsFromString('--allow-natives-syntax');
+
+const getPromiseDetails = runInThisContext('p => p instanceof Promise ? [%PromiseStatus(p), %PromiseResult(p)] : []');
 
 /**
  * The class for deep checking Types

--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -1,9 +1,5 @@
-const { runInThisContext } = require('vm');
-const { setFlagsFromString } = require('v8');
-
-setFlagsFromString('--allow-natives-syntax');
-
-const getPromiseDetails = runInThisContext('p => p instanceof Promise ? { status: %PromiseStatus(p), result: %PromiseResult(p) } : null');
+require('v8').setFlagsFromString('--allow-natives-syntax');
+const getPromiseDetails = require('vm').runInThisContext('p => p instanceof Promise ? { status: %PromiseStatus(p), result: %PromiseResult(p) } : null');
 
 /**
  * The class for deep checking Types

--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -1,6 +1,5 @@
 const { runInThisContext } = require('vm');
 const { setFlagsFromString } = require('v8');
-const util = require('./util');
 
 setFlagsFromString('--allow-natives-syntax');
 
@@ -120,7 +119,7 @@ class Type {
 	 */
 	check() {
 		if (Object.isFrozen(this)) return;
-		const promise = util.isThenable(this.value) && getPromiseDetails(this.value);
+		const promise = getPromiseDetails(this.value);
 		if (typeof this.value === 'object' && this.isCircular()) this.is = `[Circular:${this.is}]`;
 		else if (promise && promise.status) this.addValue(promise.result);
 		else if (this.value instanceof Map) for (const entry of this.value) this.addEntry(entry);

--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -1,5 +1,6 @@
 require('v8').setFlagsFromString('--allow-natives-syntax');
-const getPromiseDetails = require('vm').runInThisContext('p => p instanceof Promise ? { status: %PromiseStatus(p), result: %PromiseResult(p) } : null');
+const getPromiseDetails = require('vm').runInThisContext(
+	'p => p instanceof Promise ? { status: %PromiseStatus(p), result: %PromiseResult(p) } : null;');
 
 /**
  * The class for deep checking Types

--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -4,7 +4,7 @@ const util = require('./util');
 
 setFlagsFromString('--allow-natives-syntax');
 
-const getPromiseDetails = runInThisContext('p => p instanceof Promise ? [%PromiseStatus(p), %PromiseResult(p)] : []');
+const getPromiseDetails = runInThisContext('p => p instanceof Promise ? { status: %PromiseStatus(p), result: %PromiseResult(p) } : []');
 
 /**
  * The class for deep checking Types
@@ -122,7 +122,7 @@ class Type {
 		if (Object.isFrozen(this)) return;
 		const promise = util.isThenable(this.value) && getPromiseDetails(this.value);
 		if (typeof this.value === 'object' && this.isCircular()) this.is = `[Circular:${this.is}]`;
-		else if (promise && promise[0]) this.addValue(promise[1]);
+		else if (promise && promise.status) this.addValue(promise.result);
 		else if (this.value instanceof Map) for (const entry of this.value) this.addEntry(entry);
 		else if (Array.isArray(this.value) || this.value instanceof Set) for (const value of this.value) this.addValue(value);
 		else if (this.is === 'Object') this.is = 'any';


### PR DESCRIPTION
### Description of the PR

Node.JS is deprecating `process.binding`, which was used in Type to fetch info about a Promise. 
This PR replaces it with native v8 calls because v8.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
