### PR TITLE
docs: Fixed ReactionHandler time descriptions

### DIFF
--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -33,7 +33,6 @@ class ReactionHandler extends ReactionCollector {
 	 * @param {Emoji[]} emojis The emojis which should be used in this handler
 	 */
 	constructor(message, filter, options, display, emojis) {
-		if (!options.time) options.time = 30000;
 		super(message, filter, options);
 
 		/**
@@ -51,13 +50,6 @@ class ReactionHandler extends ReactionCollector {
 		this.methodMap = new Map(Object.entries(this.display.emojis).map(([key, value]) => [value, key]));
 
 		/**
-		 * The time until the reaction collector closes automatically
-		 * @since 0.4.0
-		 * @type {number}
-		 */
-		this.time = this.options.time;
-
-		/**
 		 * The current page the display is on
 		 * @since 0.4.0
 		 * @type {number}
@@ -70,6 +62,13 @@ class ReactionHandler extends ReactionCollector {
 		 * @type {string}
 		 */
 		this.prompt = this.options.prompt || message.language.get('REACTIONHANDLER_PROMPT');
+
+		/**
+		 * The time until the reaction collector closes automatically
+		 * @since 0.4.0
+		 * @type {number}
+		 */
+		this.time = typeof this.options.time === 'number' ? this.options.time : 30000;
 
 		/**
 		 * Whether the menu is awaiting a response of a prompt, to block all other jump reactions

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -20,7 +20,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @property {number} [max] The maximum total amount of reactions to collect
 	 * @property {number} [maxEmojis] The maximum number of emojis to collect
 	 * @property {number} [maxUsers] The maximum number of users to react
-	 * @property {number} [time=30000] The maximum amount of time before this RichMenu should expire
+	 * @property {number} [time=30000] The maximum amount of time before the RichMenu should expire
 	 */
 
 	/**
@@ -64,7 +64,7 @@ class ReactionHandler extends ReactionCollector {
 		this.prompt = this.options.prompt || message.language.get('REACTIONHANDLER_PROMPT');
 
 		/**
-		 * The time until the reaction collector closes automatically
+		 * The maximum amount of time before the RichMenu should expire
 		 * @since 0.4.0
 		 * @type {number}
 		 */

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -51,6 +51,13 @@ class ReactionHandler extends ReactionCollector {
 		this.methodMap = new Map(Object.entries(this.display.emojis).map(([key, value]) => [value, key]));
 
 		/**
+		 * The time until the reaction collector closes automatically
+		 * @since 0.4.0
+		 * @type {number}
+		 */
+		this.time = this.options.time;
+
+		/**
 		 * The current page the display is on
 		 * @since 0.4.0
 		 * @type {number}

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -20,7 +20,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @property {number} [max] The maximum total amount of reactions to collect
 	 * @property {number} [maxEmojis] The maximum number of emojis to collect
 	 * @property {number} [maxUsers] The maximum number of users to react
-	 * @property {number} [time] The maximum amount of time before this RichMenu should expire
+	 * @property {number} [time=30000] The maximum amount of time before this RichMenu should expire
 	 */
 
 	/**
@@ -33,6 +33,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @param {Emoji[]} emojis The emojis which should be used in this handler
 	 */
 	constructor(message, filter, options, display, emojis) {
+		if (!options.time) options.time = 30000;
 		super(message, filter, options);
 
 		/**
@@ -62,13 +63,6 @@ class ReactionHandler extends ReactionCollector {
 		 * @type {string}
 		 */
 		this.prompt = this.options.prompt || message.language.get('REACTIONHANDLER_PROMPT');
-
-		/**
-		 * The time until the reaction collector closes automatically
-		 * @since 0.4.0
-		 * @type {number}
-		 */
-		this.time = typeof this.options.time === 'number' ? this.options.time : 30000;
 
 		/**
 		 * Whether the menu is awaiting a response of a prompt, to block all other jump reactions

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -20,7 +20,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @property {number} [max] The maximum total amount of reactions to collect
 	 * @property {number} [maxEmojis] The maximum number of emojis to collect
 	 * @property {number} [maxUsers] The maximum number of users to react
-	 * @property {number} [time=30000] The maximum amount of time before the RichMenu should expire
+	 * @property {number} [time=30000] The amount of time before the jump menu should close
 	 */
 
 	/**
@@ -64,7 +64,7 @@ class ReactionHandler extends ReactionCollector {
 		this.prompt = this.options.prompt || message.language.get('REACTIONHANDLER_PROMPT');
 
 		/**
-		 * The maximum amount of time before the RichMenu should expire
+		 * The amount of time before the jump menu should close
 		 * @since 0.4.0
 		 * @type {number}
 		 */


### PR DESCRIPTION
### Description of the PR
~Collector, which ReactionCollector extends, which ReactionHandler extends, has a `time` option, but it doesn't set it as a property. ReactionHandler sets this as a property, and attempts to set a default time, but it won't do any good after `super()` has already run, since Collector has already set the timeout based on `options.time` and not a property. In addition, this (attempted) default was not documented. This PR corrects these things.~

I fix doc.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fix doc

### Semver Classification

- [X] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
