### PR TITLE
fix: Settings cross-shard sync not setting existence flag to true

### DIFF
--- a/src/events/settingsUpdateEntry.js
+++ b/src/events/settingsUpdateEntry.js
@@ -8,7 +8,10 @@ module.exports = class extends Event {
 			this.client.shard.broadcastEval(`
 				if (this.shard.id !== ${this.client.shard.id}) {
 					const entry = this.gateways.${settings.gateway.type}.get('${settings.id}');
-					if (entry) entry._patch(${JSON.stringify(settings)});
+					if (entry) {
+						entry._patch(${JSON.stringify(settings)});
+						entry._existsInDB = true;
+					}
 				}
 			`);
 		}


### PR DESCRIPTION
### Description of the PR

This is a critical bugfix that fixes Senpai's (<25k guilds) largest and most prevalent issue, this is a backport from the settings rewrite in #475 

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed Settings cross-shard synchronization

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
