### PR TITLE
fix: Settings delete core event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
-- [[#476](https://github.com/dirigeants/klasa/pull/476)] Added core `KlasaClient#settingsDelete` event handler to destroy instances in other shards. (kyranet)
+- [[#477](https://github.com/dirigeants/klasa/pull/477)] Added core `KlasaClient#settingsDelete` event handler to destroy instances in other shards. (kyranet)
 - [[#475](https://github.com/dirigeants/klasa/pull/475)] Added `KlasaClient#settingsSync` event. (kyranet)
 - [[#471](https://github.com/dirigeants/klasa/pull/471)] Added `Gateway#create` and `Gateway#acquire`. (kyranet)
 - [[#471](https://github.com/dirigeants/klasa/pull/471)] Added `SETTING_GATEWAY_CHOOSE_KEY` and `SETTING_GATEWAY_UNCONFIGURABLE_FOLDER` i18n keys into en-US. (kyranet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#476](https://github.com/dirigeants/klasa/pull/476)] Added core `KlasaClient#settingsDelete` event handler to destroy instances in other shards. (kyranet)
 - [[#475](https://github.com/dirigeants/klasa/pull/475)] Added `KlasaClient#settingsSync` event. (kyranet)
 - [[#471](https://github.com/dirigeants/klasa/pull/471)] Added `Gateway#create` and `Gateway#acquire`. (kyranet)
 - [[#471](https://github.com/dirigeants/klasa/pull/471)] Added `SETTING_GATEWAY_CHOOSE_KEY` and `SETTING_GATEWAY_UNCONFIGURABLE_FOLDER` i18n keys into en-US. (kyranet)

--- a/guides/Included Pieces/IncludedEvents.md
+++ b/guides/Included Pieces/IncludedEvents.md
@@ -14,9 +14,17 @@ Replies with the reason why the command was inhibited.
 
 [events/commandInhibited.js](https://github.com/dirigeants/klasa/blob/master/src/events/commandInhibited.js)
 
+## settingsDelete
+
+Deletes settings in all shards, if the bot is sharded.
+
+**Source:**
+
+[events/coreSettingsDelete.js](https://github.com/dirigeants/klasa/blob/master/src/events/coreSettingsDelete.js)
+
 ## settingsUpdate
 
-Synchronises the user settings between all shards, if the bot is sharded.
+Synchronises settings between all shards, if the bot is sharded.
 
 **Source:**
 

--- a/src/events/coreSettingsDelete.js
+++ b/src/events/coreSettingsDelete.js
@@ -1,0 +1,29 @@
+const { Event } = require('klasa');
+const gateways = ['users', 'clientStorage'];
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { event: 'settingsDelete' });
+	}
+
+	run(settings) {
+		if (this.client.shard && gateways.includes(settings.gateway.name)) {
+			this.client.shard.broadcastEval(`
+				if (this.shard.id !== ${this.client.shard.id}) {
+					const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');
+					if (entry && entry.existenceStatus) {
+						this.emit('settingsDelete', settings);
+						entry.init(entry, entry.schema);
+						entry.existenceStatus = false;
+					}
+				}
+			`);
+		}
+	}
+
+	init() {
+		if (!this.client.shard) this.disable();
+	}
+
+};

--- a/src/events/coreSettingsDelete.js
+++ b/src/events/coreSettingsDelete.js
@@ -10,7 +10,7 @@ module.exports = class extends Event {
 	run(settings) {
 		if (gateways.includes(settings.gateway.name)) {
 			this.client.shard.broadcastEval(`
-				if (Array.isArray(this.shard.id) ? this.shard.id.includes(${this.client.shard.id}) : this.shard.id === ${this.client.shard.id}) return;
+				if (String(this.shard.id) === '${this.client.shard.id}') return;
 				const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');
 				if (entry && entry.existenceStatus) {
 					this.emit('settingsDelete', settings);

--- a/src/events/coreSettingsDelete.js
+++ b/src/events/coreSettingsDelete.js
@@ -10,13 +10,12 @@ module.exports = class extends Event {
 	run(settings) {
 		if (gateways.includes(settings.gateway.name)) {
 			this.client.shard.broadcastEval(`
-				if (this.shard.id !== ${this.client.shard.id}) {
-					const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');
-					if (entry && entry.existenceStatus) {
-						this.emit('settingsDelete', settings);
-						entry.init(entry, entry.schema);
-						entry.existenceStatus = false;
-					}
+				if (Array.isArray(this.shard.id) ? this.shard.id.includes(${this.client.shard.id}) : this.shard.id === ${this.client.shard.id}) return;
+				const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');
+				if (entry && entry.existenceStatus) {
+					this.emit('settingsDelete', settings);
+					entry.init(entry, entry.schema);
+					entry.existenceStatus = false;
 				}
 			`);
 		}

--- a/src/events/coreSettingsDelete.js
+++ b/src/events/coreSettingsDelete.js
@@ -8,7 +8,7 @@ module.exports = class extends Event {
 	}
 
 	run(settings) {
-		if (this.client.shard && gateways.includes(settings.gateway.name)) {
+		if (gateways.includes(settings.gateway.name)) {
 			this.client.shard.broadcastEval(`
 				if (this.shard.id !== ${this.client.shard.id}) {
 					const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');

--- a/src/events/coreSettingsUpdate.js
+++ b/src/events/coreSettingsUpdate.js
@@ -10,7 +10,7 @@ module.exports = class extends Event {
 	run(settings) {
 		if (gateways.includes(settings.gateway.name)) {
 			this.client.shard.broadcastEval(`
-				if (Array.isArray(this.shard.id) ? this.shard.id.includes(${this.client.shard.id}) : this.shard.id === ${this.client.shard.id}) return;
+				if (String(this.shard.id) === '${this.client.shard.id}') return;
 				const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');
 				if (entry) {
 					entry._patch(${JSON.stringify(settings)});

--- a/src/events/coreSettingsUpdate.js
+++ b/src/events/coreSettingsUpdate.js
@@ -10,13 +10,12 @@ module.exports = class extends Event {
 	run(settings) {
 		if (gateways.includes(settings.gateway.name)) {
 			this.client.shard.broadcastEval(`
-				if (this.shard.id !== ${this.client.shard.id}) {
-					const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');
-					if (entry) {
-						entry._patch(${JSON.stringify(settings)});
-						entry.existenceStatus = true;
-						this.emit('settingsSync', settings);
-					}
+				if (Array.isArray(this.shard.id) ? this.shard.id.includes(${this.client.shard.id}) : this.shard.id === ${this.client.shard.id}) return;
+				const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');
+				if (entry) {
+					entry._patch(${JSON.stringify(settings)});
+					entry.existenceStatus = true;
+					this.emit('settingsSync', settings);
 				}
 			`);
 		}

--- a/src/events/coreSettingsUpdate.js
+++ b/src/events/coreSettingsUpdate.js
@@ -8,7 +8,7 @@ module.exports = class extends Event {
 	}
 
 	run(settings) {
-		if (this.client.shard && gateways.includes(settings.gateway.name)) {
+		if (gateways.includes(settings.gateway.name)) {
 			this.client.shard.broadcastEval(`
 				if (this.shard.id !== ${this.client.shard.id}) {
 					const entry = this.gateways.get('${settings.gateway.name}').get('${settings.id}');

--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -105,7 +105,7 @@ class Settings extends SettingsFolder {
 		if (this.existenceStatus) {
 			await this.gateway.provider.delete(this.gateway.name, this.id);
 			this.gateway.client.emit('settingsDelete', this);
-			this.init();
+			this.init(this, this.schema);
 		}
 		return this;
 	}


### PR DESCRIPTION
### Description of the PR

When sharding, `Settings` instances are synchronized when they're updated, but not when they're deleted. This PR fixes that by adding a core `settingsDelete` event listener.

Also fixes `Settings#destroy()` calling this.init with no arguments (2 expected).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

**Added**:

- Added core `KlasaClient#settingsDelete` event handler to destroy instances in other shards.

**Fixed**:

- Settings not being synchronized in all shards when they're destroyed.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
