### PR TITLE
fix: illegal return

### DIFF
--- a/src/events/settingsUpdateEntry.js
+++ b/src/events/settingsUpdateEntry.js
@@ -6,11 +6,12 @@ module.exports = class extends Event {
 	run(settings) {
 		if (gateways.includes(settings.gateway.type)) {
 			this.client.shard.broadcastEval(`
-				if (String(this.shard.id) === '${this.client.shard.id}') return;
-				const entry = this.gateways.${settings.gateway.type}.get('${settings.id}');
-				if (entry) {
-					entry._patch(${JSON.stringify(settings)});
-					entry._existsInDB = true;
+				if (String(this.shard.id)) !== '${this.client.shard.id}') {
+					const entry = this.gateways.${settings.gateway.type}.get('${settings.id}');
+					if (entry) {
+						entry._patch(${JSON.stringify(settings)});
+						entry._existsInDB = true;
+					}
 				}
 			`);
 		}


### PR DESCRIPTION
### Description of the PR
Fixes issue with illegal return in broadcast eval when updating settings across shards.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
