### PR TITLE
feat: add resolve method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#487](https://github.com/dirigeants/klasa/pull/487)] Added Settings#resolve(...paths) (UnseenFaith)
 - [[#477](https://github.com/dirigeants/klasa/pull/477)] Added core `KlasaClient#settingsDelete` event handler to destroy instances in other shards. (kyranet)
 - [[#475](https://github.com/dirigeants/klasa/pull/475)] Added `KlasaClient#settingsSync` event. (kyranet)
 - [[#471](https://github.com/dirigeants/klasa/pull/471)] Added `Gateway#create` and `Gateway#acquire`. (kyranet)
@@ -321,6 +322,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [[#487](https://github.com/dirigeants/klasa/pull/487)] Fixed role deserializer (UnseenFaith)
 - [[#426](https://github.com/dirigeants/klasa/pull/426)] Fixed typings for QueryBuilder. (kyranet)
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Fixed abstract `SQLProvider#qb` property being missing in typings. (kyranet)
 - [[#362](https://github.com/dirigeants/klasa/pull/362)] Fixed object mutation in `GatewayDriver#toJSON()`. (kyranet)

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -110,7 +110,7 @@ class SettingsFolder extends Map {
 	async resolve(...paths) {
 		const resolved = {};
 		const guild = resolveGuild(this.base.gateway.client, this.base.target);
-		const language = guild.language || this.client.languages.default;
+		const language = guild ? guild.language : this.client.languages.default;
 		for (const path of paths) {
 			const piece = this.schema.get(path);
 			resolved[piece.key] = await piece.resolve(this, language, guild);

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -102,26 +102,18 @@ class SettingsFolder extends Map {
 	}
 
 	/**
- * Resolves paths into their full objects or values depending on current set value
+ * Resolves paths into their full objects or values depending on the current set value
  * @since 0.5.0
  * @param  {...string} paths The paths to resolve
  * @returns {*}
  */
 	async resolve(...paths) {
-		const plucked = this.pluck(...paths);
 		const resolved = {};
-		const guild = resolveGuild(this.client, this.id);
+		const guild = resolveGuild(this.base.gateway.client, this.base.target);
 		const language = guild.language || this.client.languages.default;
-		for (const [path, value] of Object.entries(plucked)) {
+		for (const path of paths) {
 			const piece = this.schema.get(path);
-			try {
-				if (!piece.resolve) resolved[piece.key] = value;
-				else if (piece.type === 'Folder') Object.assign(resolved, ...await this.resolve(piece.path));
-				else if (piece.array) resolved[piece.key] = value.map(async data => await piece.serializer.deserialize(data, piece, language, guild));
-				else resolved[piece.key] = await value.serializer.deserialize(value, piece, language, guild);
-			} catch (__) {
-				resolved[piece.key] = null;
-			}
+			resolved[piece.key] = await piece.resolve(this, language, guild);
 		}
 		return resolved;
 	}

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -102,11 +102,11 @@ class SettingsFolder extends Map {
 	}
 
 	/**
- * Resolves paths into their full objects or values depending on the current set value
- * @since 0.5.0
- * @param  {...string} paths The paths to resolve
- * @returns {*}
- */
+ 	 * Resolves paths into their full objects or values depending on the current set value
+ 	 * @since 0.5.0
+ 	 * @param  {...string} paths The paths to resolve
+ 	 * @returns {*}
+ 	 */
 	async resolve(...paths) {
 		const resolved = {};
 		const guild = resolveGuild(this.base.gateway.client, this.base.target);

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -108,14 +108,14 @@ class SettingsFolder extends Map {
  	 * @returns {*}
  	 */
 	async resolve(...paths) {
-		const resolved = {};
 		const guild = resolveGuild(this.base.gateway.client, this.base.target);
 		const language = guild ? guild.language : this.client.languages.default;
+		const promises = [];
 		for (const path of paths) {
 			const piece = this.schema.get(this.relative(path));
-			resolved[piece.key] = await piece.resolve(this, language, guild);
+			promises.push(piece.resolve(this, language, guild).then(res => ({ [piece.key]: res })));
 		}
-		return resolved;
+		return Object.assign({}, ...await Promise.all(promises));
 	}
 
 	/**

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -112,7 +112,7 @@ class SettingsFolder extends Map {
 		const guild = resolveGuild(this.base.gateway.client, this.base.target);
 		const language = guild ? guild.language : this.client.languages.default;
 		for (const path of paths) {
-			const piece = this.schema.get(path);
+			const piece = this.schema.get(this.relative(path));
 			resolved[piece.key] = await piece.resolve(this, language, guild);
 		}
 		return resolved;

--- a/src/lib/settings/schema/Schema.js
+++ b/src/lib/settings/schema/Schema.js
@@ -178,9 +178,9 @@ class Schema extends Map {
 	 * @returns {*}
 	 */
 	async resolve(settings, language, guild) {
-		const resolved = {};
-		for (const piece of this.values(true)) resolved[piece.key] = await piece.resolve(settings, language, guild);
-		return resolved;
+		const promises = [];
+		for (const piece of this.values(true)) promises.push(piece.resolve(settings, language, guild).then(parsed => ({ [piece.key]: parsed })));
+		return Object.assign({}, ...await Promise.all(promises));
 	}
 
 

--- a/src/lib/settings/schema/Schema.js
+++ b/src/lib/settings/schema/Schema.js
@@ -168,6 +168,22 @@ class Schema extends Map {
 		return path.split('.').reduce((folder, key) => Map.prototype.get.call(folder, key), this);
 	}
 
+
+	/**
+	 * Resolves this schema into it's deserialized objects.
+	 * @since 0.5.0
+	 * @param {Settings} settings The settings object we're resolving for
+	 * @param {Language} language The language to use for this resolve operation
+	 * @param {Guild} guild The guild to use for this resolve operation
+	 * @returns {*}
+	 */
+	async resolve(settings, language, guild) {
+		const resolved = {};
+		for (const piece of this.values(true)) resolved[piece.key] = await piece.resolve(settings, language, guild);
+		return resolved;
+	}
+
+
 	/**
 	 * Returns a new Iterator object that contains the keys for each element contained in this folder.
 	 * Identical to [Map.keys()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys)

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -116,7 +116,7 @@ class SchemaPiece {
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
-		this.resolve = 'resolve' in options ? options.resolve : true;
+		this.shouldResolve = 'resolve' in options ? options.resolve : true;
 	}
 
 	/**
@@ -182,6 +182,24 @@ class SchemaPiece {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Resolves this schemapice into it's deserialized object(s).
+	 * @param {Settings} settings The settings object we're resolving for
+	 * @param {Language} language The language to use for this resolve operation
+	 * @param {Guild} guild The guild to use for this resolve operation
+	 * @returns {*}
+	 */
+	async resolve(settings, language, guild) {
+		const value = settings.get(this.path);
+		if (!this.shouldResolve) return value;
+		try {
+			if (this.array) return Promise.all(value.map(data => this.serializer.deserialize(data, this, language, guild)));
+			return this.serializer.deserialize(value, this, language, guild);
+		} catch (__) {
+			return null;
+		}
 	}
 
 	/**

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -194,12 +194,11 @@ class SchemaPiece {
 	async resolve(settings, language, guild) {
 		const value = settings.get(this.path);
 		if (!this.shouldResolve) return value;
-		try {
-			if (this.array) return Promise.all(value.map(data => this.serializer.deserialize(data, this, language, guild)));
-			return this.serializer.deserialize(value, this, language, guild);
-		} catch (__) {
-			return null;
+		if (this.array) {
+			const resolved = await Promise.all(value.map(data => this.serializer.deserialize(data, this, language, guild).catch(() => null)));
+			return resolved.filter(val => val !== null);
 		}
+		return this.serializer.deserialize(value, this, language, guild).catch(() => null);
 	}
 
 	/**

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -10,6 +10,7 @@ class SchemaPiece {
 	 * @property {boolean} [configurable] Whether the key should be configurable by the configuration command or not
 	 * @property {number} [min] The minimum value for this piece
 	 * @property {number} [max] The maximum value for this piece
+	 * @property {boolean} [resolve] Whether or not SG should resolve this value during resolve operations
 	 */
 
 	/**

--- a/src/lib/settings/schema/SchemaPiece.js
+++ b/src/lib/settings/schema/SchemaPiece.js
@@ -110,6 +110,13 @@ class SchemaPiece {
 		 * @type {Function}
 		 */
 		this.filter = 'filter' in options ? options.filter : null;
+
+		/**
+		 * Whether or not this value should be resolved when resolving values.
+		 * @since 0.5.0
+		 * @type {boolean}
+		 */
+		this.resolve = 'resolve' in options ? options.resolve : true;
 	}
 
 	/**

--- a/src/serializers/any.js
+++ b/src/serializers/any.js
@@ -2,7 +2,7 @@ const { Serializer } = require('klasa');
 
 module.exports = class extends Serializer {
 
-	deserialize(data) {
+	async deserialize(data) {
 		return data;
 	}
 

--- a/src/serializers/boolean.js
+++ b/src/serializers/boolean.js
@@ -8,7 +8,7 @@ module.exports = class extends Serializer {
 		super(...args, { aliases: ['bool'] });
 	}
 
-	deserialize(data, piece, language) {
+	async deserialize(data, piece, language) {
 		const boolean = String(data).toLowerCase();
 		if (truths.includes(boolean)) return true;
 		if (falses.includes(boolean)) return false;

--- a/src/serializers/channel.js
+++ b/src/serializers/channel.js
@@ -17,7 +17,7 @@ module.exports = class extends Serializer {
 		throw language.get('RESOLVER_INVALID_CHANNEL', piece.key);
 	}
 
-	deserialize(data, piece, language, guild) {
+	async deserialize(data, piece, language, guild) {
 		if (data instanceof Channel) return this.checkChannel(data, piece, language);
 		const channel = this.constructor.regex.channel.test(data) ? (guild || this.client).channels.get(this.constructor.regex.channel.exec(data)[1]) : null;
 		if (channel) return this.checkChannel(channel, piece, language);

--- a/src/serializers/guild.js
+++ b/src/serializers/guild.js
@@ -3,7 +3,7 @@ const { Guild } = require('discord.js');
 
 module.exports = class extends Serializer {
 
-	deserialize(data, piece, language) {
+	async deserialize(data, piece, language) {
 		if (data instanceof Guild) return data;
 		const guild = this.constructor.regex.channel.test(data) ? this.client.guilds.get(data) : null;
 		if (guild) return guild;

--- a/src/serializers/number.js
+++ b/src/serializers/number.js
@@ -6,7 +6,7 @@ module.exports = class extends Serializer {
 		super(...args, { aliases: ['integer', 'float'] });
 	}
 
-	deserialize(data, piece, language) {
+	async deserialize(data, piece, language) {
 		let number;
 		switch (piece.type) {
 			case 'integer':

--- a/src/serializers/piece.js
+++ b/src/serializers/piece.js
@@ -6,7 +6,7 @@ module.exports = class extends Serializer {
 		super(...args, { aliases: ['command', 'language'] });
 	}
 
-	deserialize(data, piece, language) {
+	async deserialize(data, piece, language) {
 		const store = this.client[`${piece.type}s`];
 		const parsed = typeof data === 'string' ? store.get(data) : data;
 		if (parsed && parsed instanceof store.holds) return parsed;

--- a/src/serializers/role.js
+++ b/src/serializers/role.js
@@ -3,7 +3,7 @@ const { Role } = require('discord.js');
 
 module.exports = class extends Serializer {
 
-	deserialize(data, piece, language, guild) {
+	async deserialize(data, piece, language, guild) {
 		if (!guild) throw this.client.languages.default.get('RESOLVER_INVALID_GUILD', piece.key);
 		if (data instanceof Role) return data;
 		const role = this.constructor.regex.role.test(data) ? guild.roles.get(this.constructor.regex.role.exec(data)[1]) : guild.roles.find(rol => rol.name === data) || null;

--- a/src/serializers/role.js
+++ b/src/serializers/role.js
@@ -6,7 +6,7 @@ module.exports = class extends Serializer {
 	deserialize(data, piece, language, guild) {
 		if (!guild) throw this.client.languages.default.get('RESOLVER_INVALID_GUILD', piece.key);
 		if (data instanceof Role) return data;
-		const role = this.constructor.regex.role.test(data) ? guild.roles.get(data) : guild.roles.find(rol => rol.name === data) || null;
+		const role = this.constructor.regex.role.test(data) ? guild.roles.get(this.constructor.regex.role.exec(data)[1]) : guild.roles.find(rol => rol.name === data) || null;
 		if (role) return role;
 		throw language.get('RESOLVER_INVALID_ROLE', piece.key);
 	}

--- a/src/serializers/string.js
+++ b/src/serializers/string.js
@@ -2,7 +2,7 @@ const { Serializer } = require('klasa');
 
 module.exports = class extends Serializer {
 
-	deserialize(data) {
+	async deserialize(data) {
 		return String(data);
 	}
 

--- a/src/serializers/url.js
+++ b/src/serializers/url.js
@@ -3,7 +3,7 @@ const URL = require('url');
 
 module.exports = class extends Serializer {
 
-	deserialize(data, piece, language) {
+	async deserialize(data, piece, language) {
 		const url = URL.parse(data);
 		if (url.protocol && url.hostname) return data;
 		throw language.get('RESOLVER_INVALID_URL', piece.key);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -474,6 +474,7 @@ declare module 'klasa' {
 		public update(object: Record<string, any>, options?: SettingsFolderUpdateOptions): Promise<SettingsFolderUpdateResult>;
 		public display(message: KlasaMessage, path?: string | Schema | SchemaFolder): string;
 		public pluck<T extends string>(...paths: T[]): Partial<Record<T, any>>;
+		public resolve<T extends string>(...paths: T[]): Partial<Record<T, any>>;
 		public toJSON(): any;
 		public toString(): string;
 		private relative(pathOrPiece: string | Schema | SchemaPiece): string;
@@ -555,6 +556,7 @@ declare module 'klasa' {
 		public add(key: string, callback: (folder: SchemaFolder) => any): this;
 		public remove(key: string): this;
 		public get<T = Schema | SchemaPiece | SchemaFolder>(key: string | Array<string>): T;
+		public resolve(settings: Settings, language: Language, guild: KlasaGuild): Promise<Record<string, any>>;
 		public toJSON(): ObjectLiteral;
 	}
 
@@ -578,8 +580,10 @@ declare module 'klasa' {
 		public min: number | null;
 		public max: number | null;
 		public filter: ((client: KlasaClient, value: any, guild?: KlasaGuild) => boolean) | null;
+		public shouldResolve: boolean;
 		public parse<T>(value: any, guild?: KlasaGuild): T;
 		public edit(options?: SchemaPieceEditOptions): this;
+		public resolve(settings: Settings, language: Language, guild: KlasaGuild): Promise<any>;
 		public toJSON(): SchemaPieceOptions;
 
 		private isValid(): boolean;
@@ -1476,6 +1480,7 @@ declare module 'klasa' {
 		min?: number;
 		max?: number;
 		filter?: (value: any, guild?: KlasaGuild) => void;
+		resolve?: boolean;
 	};
 
 	export type SchemaPieceEditOptions = {


### PR DESCRIPTION
### Description of the PR
Adds an async resolve method that will return full objects where possible. The interface follows the same pattern as Settings#pluck()

All settings will automatically resolve by default, you can change this behavior by passing `resolve: false`  in SchemaPiece options

```js
// { moderation : { role, channel } }
const { role } = await message.guild.settings.resolve('moderation');
if (role) await role.setColor('#FF0000');
role.color; // '#FF0000'
```

Also fixes a bug in the role serializer, where the role ID of a mentioned role wasn't properly being stripped from the formatted string

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Settings#resolve(...paths);
- Fix bug in Role serializer

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
