### PR TITLE
enhancement: Disable the built-in log events in the constructor

### DIFF
--- a/src/events/debug.js
+++ b/src/events/debug.js
@@ -2,12 +2,13 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
-	run(warning) {
-		if (this.client.ready) this.client.console.debug(warning);
+	constructor(...args) {
+		super(...args);
+		if (!this.client.options.consoleEvents.debug) this.disable();
 	}
 
-	init() {
-		if (!this.client.options.consoleEvents.debug) this.disable();
+	run(data) {
+		this.client.console.debug(data);
 	}
 
 };

--- a/src/events/error.js
+++ b/src/events/error.js
@@ -2,12 +2,13 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
-	run(err) {
-		this.client.console.error(err);
+	constructor(...args) {
+		super(...args);
+		if (!this.client.options.consoleEvents.error) this.disable();
 	}
 
-	init() {
-		if (!this.client.options.consoleEvents.error) this.disable();
+	run(error) {
+		this.client.console.error(error);
 	}
 
 };

--- a/src/events/log.js
+++ b/src/events/log.js
@@ -2,12 +2,13 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
-	run(data) {
-		this.client.console.log(data);
+	constructor(...args) {
+		super(...args);
+		if (!this.client.options.consoleEvents.log) this.disable();
 	}
 
-	init() {
-		if (!this.client.options.consoleEvents.log) this.disable();
+	run(data) {
+		this.client.console.log(data);
 	}
 
 };

--- a/src/events/unhandledRejection.js
+++ b/src/events/unhandledRejection.js
@@ -4,15 +4,12 @@ module.exports = class extends Event {
 
 	constructor(...args) {
 		super(...args, { emitter: process });
-	}
-
-	run(err) {
-		if (!err) return;
-		this.client.emit('error', `Uncaught Promise Error: \n${err.stack || err}`);
-	}
-
-	init() {
 		if (this.client.options.production) this.disable();
+	}
+
+	run(error) {
+		if (!error) return;
+		this.client.emit('error', `Uncaught Promise Error: \n${error.stack || error}`);
 	}
 
 };

--- a/src/events/verbose.js
+++ b/src/events/verbose.js
@@ -2,12 +2,13 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
-	run(log) {
-		this.client.console.verbose(log);
+	constructor(...args) {
+		super(...args);
+		if (!this.client.options.consoleEvents.verbose) this.disable();
 	}
 
-	init() {
-		if (!this.client.options.consoleEvents.verbose) this.disable();
+	run(data) {
+		this.client.console.verbose(data);
 	}
 
 };

--- a/src/events/warn.js
+++ b/src/events/warn.js
@@ -2,12 +2,13 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
-	run(warning) {
-		this.client.console.warn(warning);
+	constructor(...args) {
+		super(...args);
+		if (!this.client.options.consoleEvents.warn) this.disable();
 	}
 
-	init() {
-		if (!this.client.options.consoleEvents.warn) this.disable();
+	run(warning) {
+		this.client.console.warn(warning);
 	}
 
 };

--- a/src/events/wtf.js
+++ b/src/events/wtf.js
@@ -2,12 +2,13 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
-	run(failure) {
-		this.client.console.wtf(failure);
+	constructor(...args) {
+		super(...args);
+		if (!this.client.options.consoleEvents.wtf) this.disable();
 	}
 
-	init() {
-		if (!this.client.options.consoleEvents.wtf) this.disable();
+	run(failure) {
+		this.client.console.wtf(failure);
 	}
 
 };


### PR DESCRIPTION
### Description of the PR

And disable the client.ready check in the debug event, so it logs the first connection with the gateway

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
