### PR TITLE
typings: Added Message#send back

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1238,6 +1238,7 @@ declare module 'klasa' {
 			readonly flags: ObjectLiteral<string>;
 			readonly reprompted: boolean;
 			readonly reactable: boolean;
+			send(content?: StringResolvable, options?: MessageOptions): Promise<KlasaMessage | KlasaMessage[]>;
 			prompt(text: string, time?: number): Promise<KlasaMessage>;
 			usableCommands(): Promise<Collection<string, Command>>;
 			hasAtLeastPermissionLevel(min: number): Promise<boolean>;


### PR DESCRIPTION
### Description of the PR

The interfaces `PartialSendAliases` and `SendAliases` do not include `send` because TextChannel, DMChannel, and GroupDMChannel implement them, and since module augmentation does not allow overrides, it was removed. However, Message does not implement it.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Typings: Add Message#send

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
