### PR TITLE
Text prompt arbitrary user channel

### DIFF
--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -132,20 +132,6 @@ module.exports = Structures.extend('Message', Message => {
 		}
 
 		/**
-		 * Awaits a response from the author.
-		 * @param {string} text The text to prompt the author
-		 * @param {number} [time=30000] The time to wait before giving up
-		 * @returns {KlasaMessage}
-		 */
-		async prompt(text, time = 30000) {
-			const message = await this.channel.send(text);
-			const responses = await this.channel.awaitMessages(msg => msg.author === this.author, { time, max: 1 });
-			message.delete();
-			if (responses.size === 0) throw this.language.get('MESSAGE_PROMPT_TIMEOUT');
-			return responses.first();
-		}
-
-		/**
 		 * The usable commands by the author in this message's context
 		 * @since 0.0.1
 		 * @returns {Collection<string, Command>} The filtered CommandStore

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -173,7 +173,7 @@ class TextPrompt {
 	async prompt(text) {
 		const message = await this.channel.send(text);
 		const responses = await this.channel.awaitMessages(msg => msg.author === this.target, { time: this.time, max: 1 });
-		message.delete().catch(() => undefined);
+		message.delete();
 		if (responses.size === 0) throw this.language.get('MESSAGE_PROMPT_TIMEOUT');
 		return responses.first();
 	}

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -190,7 +190,7 @@ class TextPrompt {
 		if (this.typing) this.message.channel.stopTyping();
 		const possibleAbortOptions = this.message.language.get('TEXT_PROMPT_ABORT_OPTIONS');
 		const message = await this.prompt(
-			this.message.language.get('MONITOR_COMMAND_HANDLER_REPROMPT', `<@!${this.message.author.id}>`, prompt, this.time / 1000, possibleAbortOptions)
+			this.message.language.get('MONITOR_COMMAND_HANDLER_REPROMPT', `<@!${this.target.id}>`, prompt, this.time / 1000, possibleAbortOptions)
 		);
 
 		this.responses.set(message.id, message);
@@ -216,7 +216,7 @@ class TextPrompt {
 		let message;
 		const possibleCancelOptions = this.message.language.get('TEXT_PROMPT_ABORT_OPTIONS');
 		try {
-			message = await this.message.prompt(
+			message = await this.prompt(
 				this.message.language.get('MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT', `<@!${this.message.author.id}>`, this._currentUsage.possibles[0].name, this.time / 1000, possibleCancelOptions),
 				this.time
 			);

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -9,6 +9,8 @@ class TextPrompt {
 
 	/**
 	 * @typedef {Object} TextPromptOptions
+	 * @property {KlasaUser} [target=message.author] The intended target of this TextPrompt, if someone other than the author
+	 * @property {external:TextBasedChannel} [channel=message.channel] The channel to prompt in, if other than this channel
 	 * @property {number} [limit=Infinity] The number of re-prompts before this TextPrompt gives up
 	 * @property {number} [time=30000] The time-limit for re-prompting
 	 * @property {boolean} [quotedStringSupport=false] Whether this prompt should respect quoted strings
@@ -38,6 +40,20 @@ class TextPrompt {
 		 * @type {KlasaMessage}
 		 */
 		this.message = message;
+
+		/**
+		 * The target this prompt is for
+		 * @since 0.5.0
+		 * @type {KlasaUser}
+		 */
+		this.target = options.target || message.author;
+
+		/**
+		 * The channel to prompt in
+		 * @since 0.5.0
+		 * @type {external:TextBasedChannel}
+		 */
+		this.channel = options.channel || message.channel;
 
 		/**
 		 * The usage for this prompt
@@ -142,10 +158,24 @@ class TextPrompt {
 	 * @returns {any[]} The parameters resolved
 	 */
 	async run(prompt) {
-		const message = await this.message.prompt(prompt, this.time);
+		const message = await this.prompt(prompt);
 		this.responses.set(message.id, message);
 		this._setup(message.content);
 		return this.validateArgs();
+	}
+
+	/**
+	 * Prompts the target for a response
+	 * @param {string} text The text to prompt
+	 * @returns {KlasaMessage}
+	 * @private
+	 */
+	async prompt(text) {
+		const message = await this.channel.send(text);
+		const responses = await this.channel.awaitMessages(msg => msg.author === this.target, { time: this.time, max: 1 });
+		message.delete().catch(() => undefined);
+		if (responses.size === 0) throw this.language.get('MESSAGE_PROMPT_TIMEOUT');
+		return responses.first();
 	}
 
 	/**
@@ -159,9 +189,8 @@ class TextPrompt {
 		this._prompted++;
 		if (this.typing) this.message.channel.stopTyping();
 		const possibleAbortOptions = this.message.language.get('TEXT_PROMPT_ABORT_OPTIONS');
-		const message = await this.message.prompt(
-			this.message.language.get('MONITOR_COMMAND_HANDLER_REPROMPT', `<@!${this.message.author.id}>`, prompt, this.time / 1000, possibleAbortOptions),
-			this.time
+		const message = await this.prompt(
+			this.message.language.get('MONITOR_COMMAND_HANDLER_REPROMPT', `<@!${this.message.author.id}>`, prompt, this.time / 1000, possibleAbortOptions)
 		);
 
 		this.responses.set(message.id, message);

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -217,8 +217,7 @@ class TextPrompt {
 		const possibleCancelOptions = this.message.language.get('TEXT_PROMPT_ABORT_OPTIONS');
 		try {
 			message = await this.prompt(
-				this.message.language.get('MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT', `<@!${this.message.author.id}>`, this._currentUsage.possibles[0].name, this.time / 1000, possibleCancelOptions),
-				this.time
+				this.message.language.get('MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT', `<@!${this.message.author.id}>`, this._currentUsage.possibles[0].name, this.time / 1000, possibleCancelOptions)
 			);
 			this.responses.set(message.id, message);
 		} catch (err) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -645,7 +645,7 @@ declare module 'klasa' {
 		public readonly client: KlasaClient;
 		public message: KlasaMessage;
 		public target: KlasaUser;
-		public channel: TextChannel | GroupDMChannel | DMChannel;
+		public channel: TextChannel | DMChannel;
 		public usage: Usage | CommandUsage;
 		public reprompted: boolean;
 		public flags: Record<string, string>;
@@ -1380,7 +1380,7 @@ declare module 'klasa' {
 
 	// Usage
 	export interface TextPromptOptions {
-		channel?: TextChannel | GroupDMChannel | DMChannel;
+		channel?: TextChannel | DMChannel;
 		limit?: number;
 		quotedStringSupport?: boolean;
 		target?: KlasaUser;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1756,7 +1756,6 @@ declare module 'discord.js' {
 		readonly reprompted: boolean;
 		readonly reactable: boolean;
 		send(content?: StringResolvable, options?: MessageOptions): Promise<KlasaMessage | KlasaMessage[]>;
-		prompt(text: string, time?: number): Promise<KlasaMessage>;
 		usableCommands(): Promise<Collection<string, Command>>;
 		hasAtLeastPermissionLevel(min: number): Promise<boolean>;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -641,9 +641,11 @@ declare module 'klasa' {
 	}
 
 	export class TextPrompt {
-		public constructor(message: KlasaMessage, usage: Usage, options: TextPromptOptions);
+		public constructor(message: KlasaMessage, usage: Usage, options?: TextPromptOptions);
 		public readonly client: KlasaClient;
 		public message: KlasaMessage;
+		public target: KlasaUser;
+		public channel: TextChannel | GroupDMChannel | DMChannel;
 		public usage: Usage | CommandUsage;
 		public reprompted: boolean;
 		public flags: Record<string, string>;
@@ -659,6 +661,7 @@ declare module 'klasa' {
 		private _currentUsage: Tag;
 
 		public run<T = any[]>(prompt: string): Promise<T>;
+		private prompt(text: string): Promise<KlasaMessage>;
 		private reprompt(prompt: string): Promise<any[]>;
 		private repeatingPrompt(): Promise<any[]>;
 		private validateArgs(): Promise<any[]>;
@@ -1377,7 +1380,10 @@ declare module 'klasa' {
 
 	// Usage
 	export interface TextPromptOptions {
+		channel?: TextChannel | GroupDMChannel | DMChannel;
 		limit?: number;
+		quotedStringSupport?: boolean;
+		target?: KlasaUser;
 		time?: number;
 		quotedStringSupport?: boolean;
 	}


### PR DESCRIPTION
### Description of the PR
This is the fabled TextPrompt rework to prompt arbitrary users in an arbitrary channel.

This removes Message#prompt since it's no-longer-used in core, as it paints us into a limited corner.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
