### PR TITLE
use `Array.isArray(prefix)` instead of `prefix instanceof Array`

### DIFF
--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -44,7 +44,7 @@ module.exports = class extends Monitor {
 	getPrefix(msg) {
 		if (this.prefixMention.test(msg.content)) return { length: this.nick.test(msg.content) ? this.prefixMentionLength + 1 : this.prefixMentionLength, regex: this.prefixMention };
 		const prefix = msg.guildSettings.prefix || this.client.config.prefix;
-		if (prefix instanceof Array) {
+		if (Array.isArray(prefix)) {
 			for (let i = prefix.length - 1; i >= 0; i--) {
 				const testingPrefix = this.prefixes.get(prefix[i]) || this.generateNewPrefix(prefix[i]);
 				if (testingPrefix.regex.test(msg.content)) return testingPrefix;


### PR DESCRIPTION
### Description of the PR
 
use `Array.isArray(prefix)` instead of `prefix instanceof Array`

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
