### PR TITLE
Utilize Typedef injections in Guides

### DIFF
--- a/guides/Getting Started/GettingStarted.md
+++ b/guides/Getting Started/GettingStarted.md
@@ -32,26 +32,7 @@ new Client({
 
 ### Client Options: {@link KlasaClientOptions}
 
-| Name                       | Default                   | Type               | Description                                                                         |
-| -------------------------- | ------------------------- | ------------------ | ----------------------------------------------------------------------------------- |
-| **commandEditing**         | `false`                   | boolean            | Whether the bot should update responses if the command is edited                    |
-| **commandLogging**         | `false`                   | boolean            | Whether the bot should log command usage                                            |
-| **commandMessageLifetime** | `1800`                    | number             | The threshold for when command messages should be swept in seconds since last edit  |
-| **ignoreBots**             | `true`                    | boolean            | Whether or not this bot should ignore other bots                                    |
-| **ignoreSelf**             | `client.user.bot`         | boolean            | Whether or not this bot should ignore itself (true for bots, false for selfbots)    |
-| **language**               | `en-US`                   | string             | The default language Klasa should opt-in for the commands                           |
-| **noPrefixDM**             | `false`                   | boolean            | Whether the bot should allow prefixless messages in DMs                             |
-| **ownerID**                | see below¹                | string             | The Discord ID for the user the bot should respect as the owner                     |
-| **permissionLevels**       | `defaultPermissionLevels` | PermissionLevels   | The permission levels to use with this bot                                          |
-| **prefix**                 | `undefined`               | string/array       | The default prefix(es) when the bot first boots up.²                                |
-| **providers.default**      | `json`                    | string             | The default provider to use in Klasa                                                |
-| **quotedStringSupport**    | `false`                   | boolean            | Whether the bot should default to using quoted string support³                      |
-| **readyMessage**           | see below⁴                | string/function    | readyMessage to be passed through to Klasa's ready event.                           |
-| **regexPrefix**            | `null`                    | regex              | The regular expression prefix if one is provided                                    |
-| **slowmode**               | `0`                       | number             | The number of ms when the bot should respond to a users command.                    |
-| **slowmodeAggressive**     | `false`                   | boolean            | If the slowmode time should reset if a user spams the command over and over again   |
-| **typing**                 | `false`                   | boolean            | Whether the bot should type while processing commands.                              |
-| **prefixCaseInsensitive**  | `false`                   | boolean            | Whether the bot should respond if the prefix is incase sensitive or not             |
+{@typedef KlasaClientOptions}
 
 >1. ID acquired from the Discord API if not provided: `client.application.owner.id`
 >1. You can pass an array to accept multiple prefixes.

--- a/guides/Piece Basics/CreatingCommands.md
+++ b/guides/Piece Basics/CreatingCommands.md
@@ -44,26 +44,7 @@ module.exports = class extends Command {
 
 ## Options
 
-| Name                    | Default                          | Type    | Description                                                                 |
-| ----------------------- | -------------------------------- | ------- | --------------------------------------------------------------------------- |
-| **name**                | `theFileName`                    | string  | The name of the command                                                     |
-| **enabled**             | `true`                           | boolean | Whether the command is enabled or not                                       |
-| **runIn**               | `['text', 'dm', 'group']`        | Array   | What channel types the command should run in                                |
-| **cooldown**            | `0`                              | number  | The amount of time before the user can run the command again in seconds     |
-| **deletable**           | `false`                          | boolean | If the responses should be deleted if the triggering message is deleted     |
-| **bucket**              | `1`                              | number  | The amount of successful command runs required before applying ratelimits   |
-| **aliases**             | `[]`                             | Array   | Any command aliases                                                         |
-| **permissionLevel**     | `0`                              | number  | The required permission level to use the command                            |
-| **guarded**             | `false`                          | boolean | If the command can be disabled on a guild level                             |
-| **nsfw**                | `false`                          | boolean | If the command should only run in nsfw channels                             |
-| **requiredPermissions** | `[]`                             | Array   | The required Discord permissions for the bot to use this command            |
-| **requiredSettings**     | `[]`                             | Array   | The required guild settings to use this command                              |
-| **subcommands**         | `false`                          | boolean | Whether to enable sub commands or not                                       |
-| **description**         | `''`                             | string  | The help description for the command                                        |
-| **usage**               | `''`                             | string  | The usage string for the command - See {@tutorial UnderstandingUsageStrings}|
-| **usageDelim**          | `''`                             | string  | The string to deliminate the command input for usage                        |
-| **quotedStringSupport** | `false`                          | boolean | Whether args for this command should not deliminated inside quotes          |
-| **extendedHelp**        | `'No extended help available.'`  | string  | Extended help strings                                                       |
+{@typedef CommandOptions}
 
 > All commands are required to return an [Object Promise](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) you can do that by adding the `async` keyword to the function, there's no need to change anything else.
 

--- a/guides/Piece Basics/CreatingEvents.md
+++ b/guides/Piece Basics/CreatingEvents.md
@@ -35,13 +35,7 @@ Where `...params` are arguments you would *normally* get from those events. For 
 
 ## Options
 
-| Name        | Default       | Type         | Description                         |
-| ----------- | ------------- | ------------ | ----------------------------------- |
-| **name**    | `theFileName` | string       | The name of the event               |
-| **enabled** | `true`        | boolean      | Whether the event is enabled or not |
-| **event**   | `theFileName` | string       | The event to listen to              |
-| **emitter** | `this.client` | EventEmitter | The emitter the event belongs to    |
-| **once**    | `false`       | boolean      | If the event should only run once   |
+{@typedef EventOptions}
 
 ## Further Reading:
 

--- a/guides/Piece Basics/CreatingExtendables.md
+++ b/guides/Piece Basics/CreatingExtendables.md
@@ -70,11 +70,7 @@ module.exports = class extends Extendable {
 };
 ```
 
-| Name          | Default       | Type    | Description                          |
-| ------------- | ------------- | ------- | ------------------------------------ |
-| **name**      | `theFileName` | string  | The name of the method/property.     |
-| **enabled**   | `true`        | boolean | If the extendable is enabled or not. |
-| **appliesTo** | `[]`          | class[] | An array of classes to extend.       |
+{@typedef ExtendableOptions}
 
 ## Understanding extendables
 

--- a/guides/Piece Basics/CreatingFinalizers.md
+++ b/guides/Piece Basics/CreatingFinalizers.md
@@ -31,10 +31,7 @@ module.exports = class extends Finalizer {
 
 ## Options
 
-| Name        | Default       | Type    | Description                             |
-| ----------- | ------------- | ------- | --------------------------------------- |
-| **name**    | `theFileName` | string  | The name of the finalizer               |
-| **enabled** | `true`        | boolean | Whether the finalizer is enabled or not |
+{@typedef PieceOptions}
 
 ## Arguments:
 

--- a/guides/Piece Basics/CreatingInhibitors.md
+++ b/guides/Piece Basics/CreatingInhibitors.md
@@ -38,11 +38,7 @@ module.exports = class extends Inhibitor {
 
 ## Options
 
-| Name               | Default       | Type    | Description                                                                                  |
-| ------------------ | ------------- | ------- | -------------------------------------------------------------------------------------------- |
-| **name**           | `theFileName` | string  | The name of the inhibitor                                                                    |
-| **enabled**        | `true`        | boolean | Whether the inhibitor is enabled or not                                                      |
-| **spamProtection** | `false`       | boolean | If this inhibitor is meant for spamProtection (disables the inhibitor while generating help) |
+{@typedef InhibitorOptions}
 
 ## Further Reading:
 

--- a/guides/Piece Basics/CreatingLanguages.md
+++ b/guides/Piece Basics/CreatingLanguages.md
@@ -37,10 +37,7 @@ module.exports = class extends Language {
 
 ## Options
 
-| Name        | Default       | Type    | Description                            |
-| ----------- | ------------- | ------- | -------------------------------------- |
-| **name**    | `theFileName` | string  | The name of the language               |
-| **enabled** | `true`        | boolean | Whether the language is enabled or not |
+{@typedef PieceOptions}
 
 ## Using Languages:
 

--- a/guides/Piece Basics/CreatingMonitors.md
+++ b/guides/Piece Basics/CreatingMonitors.md
@@ -43,17 +43,7 @@ module.exports = class extends Monitor {
 
 ## Options
 
-| Name                        | Default       | Type    | Description                                           |
-| --------------------------- | ------------- | ------- | ----------------------------------------------------- |
-| **name**                    | `theFileName` | string  | The name of the monitor                               |
-| **enabled**                 | `true`        | boolean | Whether the monitor is enabled or not                 |
-| **ignoreBots**              | `true`        | boolean | Whether the monitor ignores bots or not               |
-| **ignoreSelf**              | `true`        | boolean | Whether the monitor ignores itself or not             |
-| **ignoreOthers**            | `true`        | boolean | Whether the monitor ignores others or not             |
-| **ignoreWebhooks**          | `true`        | boolean | Whether the monitor ignores webhooks or not           |
-| **ignoreEdits**             | `true`        | boolean | Whether the monitor ignores edits or not              |
-| **ignoreBlacklistedUsers**  | `true`        | boolean | Whether the monitor ignores blacklisted users or not  |
-| **ignoreBlacklistedGuilds** | `true`        | boolean | Whether the monitor ignores blacklisted guilds or not |
+{@typedef MonitorOptions}
 
 >As with all other pieces, you can omit any optional option that match the default values.
 

--- a/guides/Piece Basics/CreatingProviders.md
+++ b/guides/Piece Basics/CreatingProviders.md
@@ -89,10 +89,7 @@ The example above is the JSON provider used in klasa, and interfacing with the {
 
 ## Options
 
-| Name            | Default       | Type    | Description                                  |
-| --------------- | ------------- | ------- | -------------------------------------------- |
-| **name**        | `theFileName` | string  | The name of the provider                     |
-| **enabled**     | `true`        | boolean | Whether the provider is enabled or not       |
+{@typedef PieceOptions}
 
 ## Accessing Providers
 

--- a/guides/Piece Basics/CreatingTasks.md
+++ b/guides/Piece Basics/CreatingTasks.md
@@ -76,10 +76,7 @@ The pattern above is a **Crontab pattern** that runs every Tuesday and Friday at
 
 ## Options
 
-| Name        | Default       | Type    | Description                        |
-| ----------- | ------------- | ------- | ---------------------------------- |
-| **name**    | `theFileName` | string  | The name of the task               |
-| **enabled** | `true`        | boolean | Whether the task is enabled or not |
+{@typedef PieceOptions}
 
 ## Further Reading:
 


### PR DESCRIPTION
### Description of the PR
Uses a new feature of the site to inject typedefs into guide bodies. Additionally, another pr pointing to this branch includes some cleanup which makes this pr easier to read on the website.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
