### PR TITLE
fix: Fixed array operations not removing element if it was the last

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -226,7 +226,7 @@ declare module 'klasa' {
 		public toString(): string;
 		private relative(pathOrPiece: string | Schema | SchemaPiece): string;
 		private _save(results: Array<SettingsFolderUpdateResultEntry>): Promise<void>;
-		private _parse(piece: SchemaPiece, key: string, value: any, options: SettingsFolderUpdateOptions): Promise<any>;
+		private _parse(piece: SchemaPiece, previous: any, next: any, options: SettingsFolderUpdateOptions): Promise<any>;
 		private _patch(data: Record<string, any>): void;
 	}
 


### PR DESCRIPTION
### Description of the PR

While testing with a bot in the `settings` branch, I noticed that if you had an array with some elements, and you remove all of them (which matches the default value), it gets ignored, not updating the array. The intended behaviour was to check if it was equals to the previous value, not if it's equals to the default value.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed array operations not removing element if it was the last

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
