### PR TITLE
fix: messageDeleteBulk not sweeping

### DIFF
--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -5,7 +5,7 @@ module.exports = class extends Event {
 	run(message) {
 		if (message.command && message.command.deletable) {
 			for (const msg of message.responses) {
-				if (!msg.deleted) msg.delete();
+				msg.delete();
 			}
 		}
 	}

--- a/src/events/messageDeleteBulk.js
+++ b/src/events/messageDeleteBulk.js
@@ -5,8 +5,8 @@ module.exports = class extends Event {
 	run(messages) {
 		for (const message of messages.values()) {
 			if (message.command && message.command.deletable) {
-				for (const msg of message.responses.values()) {
-					if (!msg.deleted) msg.delete();
+				for (const msg of message.responses) {
+					msg.delete();
 				}
 			}
 		}

--- a/src/events/messageDeleteBulk.js
+++ b/src/events/messageDeleteBulk.js
@@ -3,9 +3,9 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(messages) {
-		for (const message of messages) {
+		for (const message of messages.values()) {
 			if (message.command && message.command.deletable) {
-				for (const msg of message.responses) {
+				for (const msg of message.responses.values()) {
 					if (!msg.deleted) msg.delete();
 				}
 			}


### PR DESCRIPTION
### Description of the PR

Array#command is now a thing, causing the sweeper to always fail.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixes messageDeleteBulk not sweeping

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
