### PR TITLE
src: Add GatewayStorage#sync so they can be registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Added
 
+- [[#525](https://github.com/dirigeants/klasa/pull/525)] Add GatewayStorage#sync so they can be registered. (kyranet)
 - [[#487](https://github.com/dirigeants/klasa/pull/487)] Added Settings#resolve(...paths) (UnseenFaith)
 - [[#477](https://github.com/dirigeants/klasa/pull/477)] Added core `KlasaClient#settingsDelete` event handler to destroy instances in other shards. (kyranet)
 - [[#475](https://github.com/dirigeants/klasa/pull/475)] Added `KlasaClient#settingsSync` event. (kyranet)

--- a/src/inhibitors/disabled.js
+++ b/src/inhibitors/disabled.js
@@ -4,7 +4,7 @@ module.exports = class extends Inhibitor {
 
 	run(message, command) {
 		if (!command.enabled) throw message.language.get('INHIBITOR_DISABLED_GLOBAL');
-		if (message.guildSettings.disabledCommands.includes(command.name)) throw message.language.get('INHIBITOR_DISABLED_GUILD');
+		if (message.guildSettings.get('disabledCommands').includes(command.name)) throw message.language.get('INHIBITOR_DISABLED_GUILD');
 	}
 
 };

--- a/src/lib/settings/gateway/Gateway.js
+++ b/src/lib/settings/gateway/Gateway.js
@@ -4,9 +4,6 @@ const Schema = require('../schema/Schema');
 const { Collection } = require('discord.js');
 
 /**
- * <danger>You should never create a Gateway instance by yourself.
- * Please check {@link UnderstandingSettingsGateway} about how to construct your own Gateway.</danger>
- * The Gateway class that manages the data input, parsing, and output, of an entire database, while keeping a cache system sync with the changes.
  * @extends GatewayStorage
  */
 class Gateway extends GatewayStorage {
@@ -19,8 +16,8 @@ class Gateway extends GatewayStorage {
 	 * @param {Schema} [options.schema = new Schema()] The schema for this gateway
 	 * @param {string} [options.provider = this.client.options.providers.default] The provider's name for this gateway
 	 */
-	constructor(client, name, { schema = new Schema(), provider = client.options.providers.default } = {}) {
-		super(client, name, schema, provider);
+	constructor(client, name, options) {
+		super(client, name, options);
 
 		/**
 		 * The cached entries for this Gateway or the external datastore to get the settings from

--- a/src/lib/settings/gateway/Gateway.js
+++ b/src/lib/settings/gateway/Gateway.js
@@ -1,6 +1,5 @@
 const GatewayStorage = require('./GatewayStorage');
 const Settings = require('../Settings');
-const Schema = require('../schema/Schema');
 const { Collection } = require('discord.js');
 
 /**

--- a/src/lib/settings/gateway/Gateway.js
+++ b/src/lib/settings/gateway/Gateway.js
@@ -11,9 +11,7 @@ class Gateway extends GatewayStorage {
 	 * @since 0.0.1
 	 * @param {KlasaClient} client The KlasaClient instance which initiated this instance
 	 * @param {string} name The name of this Gateway
-	 * @param {Object} [options = {}] The options for this gateway
-	 * @param {Schema} [options.schema = new Schema()] The schema for this gateway
-	 * @param {string} [options.provider = this.client.options.providers.default] The provider's name for this gateway
+	 * @param {GatewayOptions} [options = {}] The options for this gateway
 	 */
 	constructor(client, name, options) {
 		super(client, name, options);

--- a/src/lib/settings/gateway/GatewayStorage.js
+++ b/src/lib/settings/gateway/GatewayStorage.js
@@ -70,6 +70,15 @@ class GatewayStorage {
 	}
 
 	/**
+	 * Sync placeholder to allow GatewayStorage to be registered
+	 * @since 0.5.0
+	 * @returns {this}
+	 */
+	async sync() {
+		return this;
+	}
+
+	/**
 	 * Inits the current Gateway.
 	 * @since 0.5.0
 	 */

--- a/src/lib/settings/gateway/GatewayStorage.js
+++ b/src/lib/settings/gateway/GatewayStorage.js
@@ -10,13 +10,16 @@ class GatewayStorage {
 	 */
 
 	/**
+	 * @typedef {Object} GatewayOptions
+	 * @property {Schema} [schema = new Schema()] The schema for this gateway
+	 * @property {string} [provider = client.options.providers.default] The provider's name for this gateway
+	 */
+
+	/**
 	 * @since 0.5.0
 	 * @param {KlasaClient} client The client this GatewayStorage was created with
 	 * @param {string} name The name of this GatewayStorage
-	 * @param {Object} [options = {}] The options for this gateway
-	 * @param {Schema} [options.schema = new Schema()] The schema for this gateway
-	 * @param {string} [options.provider = this.client.options.providers.default] The provider's name for this gateway
-	 * @private
+	 * @param {GatewayOptions} [options = {}] The options for this gateway
 	 */
 	constructor(client, name, { schema = new Schema(), provider = client.options.providers.default }) {
 		/**

--- a/src/lib/settings/gateway/GatewayStorage.js
+++ b/src/lib/settings/gateway/GatewayStorage.js
@@ -21,7 +21,7 @@ class GatewayStorage {
 	 * @param {string} name The name of this GatewayStorage
 	 * @param {GatewayOptions} [options = {}] The options for this gateway
 	 */
-	constructor(client, name, { schema = new Schema(), provider = client.options.providers.default }) {
+	constructor(client, name, { schema = new Schema(), provider = client.options.providers.default } = {}) {
 		/**
 		 * The client this GatewayStorage was created with.
 		 * @since 0.5.0

--- a/src/lib/settings/gateway/GatewayStorage.js
+++ b/src/lib/settings/gateway/GatewayStorage.js
@@ -46,6 +46,7 @@ class GatewayStorage {
 		 * @name GatewayStorage#_provider
 		 * @type {string}
 		 * @readonly
+		 * @private
 		 */
 		Object.defineProperty(this, '_provider', { value: provider });
 

--- a/src/lib/settings/gateway/GatewayStorage.js
+++ b/src/lib/settings/gateway/GatewayStorage.js
@@ -1,3 +1,5 @@
+const Schema = require('../schema/Schema');
+
 class GatewayStorage {
 
 	/**
@@ -8,15 +10,15 @@ class GatewayStorage {
 	 */
 
 	/**
-	 * <warning>You should never create an instance of this class as it's abstract.</warning>
 	 * @since 0.5.0
 	 * @param {KlasaClient} client The client this GatewayStorage was created with
 	 * @param {string} name The name of this GatewayStorage
-	 * @param {Schema} schema The schema for this gateway
-	 * @param {string} [provider] The provider's name
+	 * @param {Object} [options = {}] The options for this gateway
+	 * @param {Schema} [options.schema = new Schema()] The schema for this gateway
+	 * @param {string} [options.provider = this.client.options.providers.default] The provider's name for this gateway
 	 * @private
 	 */
-	constructor(client, name, schema, provider) {
+	constructor(client, name, { schema = new Schema(), provider = client.options.providers.default }) {
 		/**
 		 * The client this GatewayStorage was created with.
 		 * @since 0.5.0
@@ -38,13 +40,14 @@ class GatewayStorage {
 		/**
 		 * The name of this instance's provider.
 		 * @since 0.5.0
-		 * @name GatewayStorage#providerName
+		 * @name GatewayStorage#_provider
 		 * @type {string}
 		 * @readonly
 		 */
-		Object.defineProperty(this, 'providerName', { value: provider });
+		Object.defineProperty(this, '_provider', { value: provider });
 
 		/**
+		 * The schema for this instance
 		 * @since 0.5.0
 		 * @name GatewayStorage#schema
 		 * @type {Schema}
@@ -53,6 +56,7 @@ class GatewayStorage {
 		Object.defineProperty(this, 'schema', { value: schema, enumerable: true });
 
 		/**
+		 * Whether or not this gateway is considered ready.
 		 * @since 0.5.0
 		 * @type {boolean}
 		 */
@@ -66,7 +70,7 @@ class GatewayStorage {
 	 * @readonly
 	 */
 	get provider() {
-		return this.client.providers.get(this.providerName) || null;
+		return this.client.providers.get(this._provider) || null;
 	}
 
 	/**

--- a/src/lib/settings/gateway/GatewayStorage.js
+++ b/src/lib/settings/gateway/GatewayStorage.js
@@ -133,7 +133,7 @@ class GatewayStorage {
 	toJSON() {
 		return {
 			name: this.name,
-			provider: this.providerName,
+			provider: this._provider,
 			schema: this.schema.toJSON()
 		};
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -286,7 +286,7 @@ declare module 'klasa' {
 		public readonly name: string;
 		public readonly schema: SchemaFolder;
 		public ready: boolean;
-
+		public sync(): Promise<this>;
 		public init(): Promise<void>;
 		public toJSON(): GatewayJSON;
 		public toString(): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -281,9 +281,9 @@ declare module 'klasa' {
 		public constructor(client: KlasaClient, name: string, options?: GatewayOptions);
 		public readonly client: KlasaClient;
 		public readonly provider: Provider | null;
-		public readonly _provider: string;
 		public readonly name: string;
 		public readonly schema: SchemaFolder;
+		private readonly _provider: string;
 		public ready: boolean;
 		public sync(): Promise<this>;
 		public init(): Promise<void>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -257,7 +257,6 @@ declare module 'klasa' {
 	}
 
 	export class Gateway extends GatewayStorage {
-		public constructor(client: KlasaClient, name: string, options?: { schema?: Schema, provider?: string });
 		protected syncQueue: WeakMap<Settings, Promise<Settings>>;
 		protected cache: Collection<string, Record<string, any> & { settings: Settings }>;
 		public acquire(target: any, id?: string | number): Settings;
@@ -279,10 +278,10 @@ declare module 'klasa' {
 	}
 
 	export class GatewayStorage {
-		public constructor(client: KlasaClient, name: string, schema?: Schema, provider?: string);
+		public constructor(client: KlasaClient, name: string, options?: GatewayOptions);
 		public readonly client: KlasaClient;
 		public readonly provider: Provider | null;
-		public readonly providerName: string;
+		public readonly _provider: string;
 		public readonly name: string;
 		public readonly schema: SchemaFolder;
 		public ready: boolean;
@@ -1317,8 +1316,6 @@ declare module 'klasa' {
 		default?: string;
 	} & ObjectLiteral;
 
-	export type KlasaGatewaysOptions = Record<string, { provider?: string; schema?: Schema }>;
-
 	// Parsers
 	export type ArgResolverCustomMethod = (arg: string, possible: Possible, message: KlasaMessage, params: string[]) => any;
 
@@ -1463,7 +1460,8 @@ declare module 'klasa' {
 	};
 
 	export type GatewayOptions = {
-		provider: string;
+		schema?: Schema;
+		provider?: string;
 	};
 
 	export type GatewayJSON = {


### PR DESCRIPTION
### Description of the PR

Allows the following pattern to ensure a table (and all columns, for SQL databases) exist with a specified schema without any extra code:

```javascript
client.gateways.register(new GatewayStorage(client, 'games', {
	schema: new Schema().add('teams', 'any', { array: true }),
	provider: 'postgres'
}));
```

Currently this throws because GatewayDriver#sync calls all the registered gateway's sync method, which GatewayStorage lacks of.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Add GatewayStorage#sync so they can be registered

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
