### PR TITLE
more descriptive msg for nsfw cmds inhibited

### DIFF
--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -57,7 +57,7 @@ module.exports = class extends Language {
 			INHIBITOR_COOLDOWN: (remaining) => `You have just used this command. You can use this command again in ${remaining} second${remaining === 1 ? '' : 's'}.`,
 			INHIBITOR_DISABLED: 'This command is currently disabled.',
 			INHIBITOR_MISSING_BOT_PERMS: (missing) => `Insufficient permissions, missing: **${missing}**`,
-			INHIBITOR_NSFW: 'You may not use NSFW commands in this channel.',
+			INHIBITOR_NSFW: 'This command might post NSFW content, please mark this channel as NSFW to use it here.',
 			INHIBITOR_PERMISSIONS: 'You do not have permission to use this command.',
 			INHIBITOR_REQUIRED_SETTINGS: (settings) => `The guild is missing the **${settings.join(', ')}** guild setting${settings.length !== 1 ? 's' : ''} and thus the command cannot run.`,
 			INHIBITOR_RUNIN: (types) => `This command is only available in ${types} channels.`,


### PR DESCRIPTION
### Description of the PR

"You may not use NSFW commands in this channel." doesn't tell the user why they cannot use the command and/or how to fix the issue so they can use it in this channel

"This command might post NSFW content, please mark this channel as NSFW to use it here." - tells the user that it might output NSFW content, and that they can mark the channel as NSFW to use it there.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [X] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
