### PR TITLE
add .emit() typing on KlasaClient

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -60,6 +60,7 @@ declare module 'klasa' {
 		public static defaultPermissionLevels: PermissionLevels;
 		public static plugin: symbol;
 		public static use(mod: any): typeof KlasaClient;
+		public emit(type: string, value: any): any;
 	}
 
 	export { KlasaClient as Client };


### PR DESCRIPTION
### Description of the PR
This PR adds a typing to have this.client.emit() on the KlasaClient.

![image](https://user-images.githubusercontent.com/23035000/49550721-90b22680-f8ba-11e8-96da-a6d742740aa0.png)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Adds .emit() typing on KlasaClient

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
