### PR TITLE
make options in schedules.create() optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -169,7 +169,7 @@ declare module 'klasa' {
 		public init(): Promise<void>;
 		public execute(): Promise<void>;
 		public next(): ScheduledTask;
-		public create(taskName: string, time: Date | number | string, options: ScheduledTaskOptions): Promise<ScheduledTask>;
+		public create(taskName: string, time: Date | number | string, options?: ScheduledTaskOptions): Promise<ScheduledTask>;
 		public get(id: string): ScheduledTask | void;
 		public delete(id: string): Promise<this>;
 		public clear(): Promise<void>;


### PR DESCRIPTION
### Description of the PR
This PR adds a typing to allow this.client.schedules.create accept only 2 parameters.
![image](https://user-images.githubusercontent.com/23035000/49551385-0dde9b00-f8bd-11e8-9fc6-8948999b1131.png)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- schedules.create() options should be optional

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
