### PR TITLE
Added a hidden property to command options.

### DIFF
--- a/guides/Piece Basics/CreatingCommands.md
+++ b/guides/Piece Basics/CreatingCommands.md
@@ -16,6 +16,7 @@ module.exports = class extends Command {
 			aliases: [],
 			guarded: false,
 			nsfw: false,
+			hidden: false,
 			permissionLevel: 0,
 			requiredPermissions: [],
 			requiredSettings: [],

--- a/src/commands/General/Chat Bot Info/help.js
+++ b/src/commands/General/Chat Bot Info/help.js
@@ -18,6 +18,7 @@ module.exports = class extends Command {
 
 	async run(message, [command]) {
 		if (command) {
+			if (message.author != this.client.owner && command.hidden) return;
 			const info = [
 				`= ${command.name} = `,
 				isFunction(command.description) ? command.description(message.language) : command.description,
@@ -50,7 +51,7 @@ module.exports = class extends Command {
 		const longest = commandNames.reduce((long, str) => Math.max(long, str.length), 0);
 
 		await Promise.all(this.client.commands.map((command) =>
-			this.client.inhibitors.run(message, command, true)
+			!command.hidden && this.client.inhibitors.run(message, command, true)
 				.then(() => {
 					if (!help.hasOwnProperty(command.category)) help[command.category] = {};
 					if (!help[command.category].hasOwnProperty(command.subCategory)) help[command.category][command.subCategory] = [];

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -19,7 +19,7 @@ module.exports = class extends Language {
 			SETTING_GATEWAY_KEY_NOEXT: (key) => `The key ${key} does not exist in the current data schema.`,
 			SETTING_GATEWAY_INVALID_TYPE: 'The type parameter must be either add or remove.',
 			SETTING_GATEWAY_INVALID_FILTERED_VALUE: (piece, value) => `${piece.key} doesn't accept the value: ${value}`,
-			RESOLVER_MULTI_TOO_FEW: (name, min = 1) => `Provided too few ${name}s. Atleast ${min} ${min === 1 ? 'is' : 'are'} required.`,
+			RESOLVER_MULTI_TOO_FEW: (name, min = 1) => `Provided too few ${name}s. At least ${min} ${min === 1 ? 'is' : 'are'} required.`,
 			RESOLVER_INVALID_BOOL: (name) => `${name} must be true or false.`,
 			RESOLVER_INVALID_CHANNEL: (name) => `${name} must be a channel tag or valid channel id.`,
 			RESOLVER_INVALID_CUSTOM: (name, type) => `${name} must be a valid ${type}.`,

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -30,6 +30,7 @@ class Command extends AliasPiece {
 	 * @property {ExtendedHelp} [extendedHelp] Extended help strings
 	 * @property {boolean} [guarded=false] If the command can be disabled on a guild level (does not effect global disable)
 	 * @property {boolean} [nsfw=false] If the command should only run in nsfw channels
+	 * @property {boolean} [hidden=false] If the command should be hidden.
 	 * @property {number} [permissionLevel=0] The required permission level to use the command
 	 * @property {number} [promptLimit=0] The number or attempts allowed for re-prompting an argument
 	 * @property {number} [promptTime=30000] The time allowed for re-prompting of this command
@@ -116,6 +117,13 @@ class Command extends AliasPiece {
 		 * @type {boolean}
 		 */
 		this.nsfw = options.nsfw;
+
+		/**
+		 * Whether this command should be hidden or not
+		 * @since 0.5.0
+		 * @type {boolean}
+		 */
+		this.hidden = options.hidden;
 
 		/**
 		 * The required permissionLevel to run this command
@@ -323,6 +331,7 @@ class Command extends AliasPiece {
 			fullCategory: this.fullCategory,
 			guarded: this.guarded,
 			nsfw: this.nsfw,
+			hidden: this.hidden,
 			permissionLevel: this.permissionLevel,
 			promptLimit: this.promptLimit,
 			promptTime: this.promptTime,

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -59,6 +59,7 @@ exports.DEFAULTS = {
 				enabled: true,
 				guarded: false,
 				nsfw: false,
+				hidden: false,
 				permissionLevel: 0,
 				promptLimit: 0,
 				promptTime: 30000,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -395,6 +395,7 @@ declare module 'klasa' {
 		public fullCategory: string[];
 		public guarded: boolean;
 		public nsfw: boolean;
+		public hidden: boolean;
 		public permissionLevel: number;
 		public promptLimit: number;
 		public promptTime: number;
@@ -1549,6 +1550,7 @@ declare module 'klasa' {
 		extendedHelp?: string | string[] | ((language: Language) => string | string[]);
 		guarded?: boolean;
 		nsfw?: boolean;
+		hidden?: boolean;
 		permissionLevel?: number;
 		promptLimit?: number;
 		promptTime?: number;
@@ -1624,6 +1626,7 @@ declare module 'klasa' {
 		fullCategory: string[];
 		guarded: boolean;
 		nsfw: boolean;
+		hidden: boolean;
 		permissionLevel: number;
 		promptLimit: number;
 		promptTime: number;


### PR DESCRIPTION
### Description of the PR
I added a hidden property for the command options. Which can be used to hide commands. Like, if you don't want them to show in the command list while a user is viewing the bots commands list.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added a new command property, `hidden`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
