### PR TITLE
feature: Hidden Commands

### DIFF
--- a/src/inhibitors/hidden.js
+++ b/src/inhibitors/hidden.js
@@ -2,8 +2,8 @@ const { Inhibitor } = require('klasa');
 
 module.exports = class extends Inhibitor {
 
-	async run(message, command) {
-		if (command.hidden && message.command !== command && message.author !== this.client.owner) throw true;
+	run(message, command) {
+		return command.hidden && message.command !== command && message.author !== this.client.owner;
 	}
 
 };

--- a/src/inhibitors/hidden.js
+++ b/src/inhibitors/hidden.js
@@ -1,0 +1,9 @@
+const { Inhibitor } = require('klasa');
+
+module.exports = class extends Inhibitor {
+
+	async run(message, command) {
+		if (command.hidden && message.command !== command && message.author !== this.client.owner) throw true;
+	}
+
+};

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -29,6 +29,7 @@ class Command extends AliasPiece {
 	 * @property {(string|Function)} [description=''] The help description for the command
 	 * @property {ExtendedHelp} [extendedHelp] Extended help strings
 	 * @property {boolean} [guarded=false] If the command can be disabled on a guild level (does not effect global disable)
+	 * @property {boolean} [hidden=false] If the command should be hidden
 	 * @property {boolean} [nsfw=false] If the command should only run in nsfw channels
 	 * @property {number} [permissionLevel=0] The required permission level to use the command
 	 * @property {number} [promptLimit=0] The number or attempts allowed for re-prompting an argument
@@ -109,6 +110,13 @@ class Command extends AliasPiece {
 		 * @type {boolean}
 		 */
 		this.guarded = options.guarded;
+
+		/**
+		 * Whether this command is hidden or not
+		 * @since 0.5.0
+		 * @type {boolean}
+		 */
+		this.hidden = options.hidden;
 
 		/**
 		 * Whether this command should only run in NSFW channels or not
@@ -322,6 +330,7 @@ class Command extends AliasPiece {
 			extendedHelp: isFunction(this.extendedHelp) ? this.extendedHelp() : this.extendedHelp,
 			fullCategory: this.fullCategory,
 			guarded: this.guarded,
+			hidden: this.hidden,
 			nsfw: this.nsfw,
 			permissionLevel: this.permissionLevel,
 			promptLimit: this.promptLimit,

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -58,6 +58,7 @@ exports.DEFAULTS = {
 				extendedHelp: language => language.get('COMMAND_HELP_NO_EXTENDED'),
 				enabled: true,
 				guarded: false,
+				hidden: false,
 				nsfw: false,
 				permissionLevel: 0,
 				promptLimit: 0,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -394,6 +394,7 @@ declare module 'klasa' {
 		public extendedHelp: string | ((language: Language) => string);
 		public fullCategory: string[];
 		public guarded: boolean;
+		public hidden: boolean;
 		public nsfw: boolean;
 		public permissionLevel: number;
 		public promptLimit: number;
@@ -1549,6 +1550,7 @@ declare module 'klasa' {
 		description?: string | string[] | ((language: Language) => string | string[]);
 		extendedHelp?: string | string[] | ((language: Language) => string | string[]);
 		guarded?: boolean;
+		hidden?: boolean;
 		nsfw?: boolean;
 		permissionLevel?: number;
 		promptLimit?: number;
@@ -1624,6 +1626,7 @@ declare module 'klasa' {
 		extendedHelp: string | ((language: Language) => string);
 		fullCategory: string[];
 		guarded: boolean;
+		hidden: boolean;
 		nsfw: boolean;
 		permissionLevel: number;
 		promptLimit: number;


### PR DESCRIPTION
### Description of the PR
This is an alternate design of #536. This is the way the feature has been planned for months, in fact I had thought I had already added it to Klasa. Oops

This method is the more correct way of implimenting the feature, since it doesn't rely on hardcoding the help command, and additionally works for KlasaMessage#usableCommands(). This method also does not prevent help from displaying the command if you know the command exists, unlike #536. This is the correct behavior for core, if that's not prefered the help command should be transferred and altered.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
