### PR TITLE
docs: Move ExecOptions to an external link to Node.js docs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,3 +209,7 @@ module.exports = {
  * @external Snowflake
  * @see {@link https://discord.js.org/#/docs/main/stable/typedef/Snowflake}
  */
+/**
+ * @external ExecOptions
+ * @see {@link https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback}
+ */

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -321,23 +321,10 @@ class Util {
 }
 
 /**
- * @typedef {Object} ExecOptions
- * @property {string} [cwd=process.cwd()] Current working directory of the child process
- * @property {Object} [env={}] Environment key-value pairs
- * @property {string} [encoding='utf8'] encoding to use
- * @property {string} [shell=os === unix ? '/bin/sh' : process.env.ComSpec] Shell to execute the command with
- * @property {number} [timeout=0] The maximum execution time
- * @property {number} [maxBuffer=200*1024] Largest amount of data in bytes allowed on stdout or stderr. If exceeded, the child process is terminated
- * @property {string|number} [killSignal='SIGTERM'] The kill signal
- * @property {number} [uid] Sets the user identity of the process
- * @property {number} [gid] Sets the group identity of the process
- */
-
-/**
  * Promisified version of child_process.exec for use with await
  * @since 0.3.0
  * @param {string} command The command to run
- * @param {ExecOptions} [options] The options to pass to exec
+ * @param {external:ExecOptions} [options] The options to pass to exec
  * @returns {Promise<{ stdout: string, stderr: string }>}
  * @method
  * @static


### PR DESCRIPTION
### Description of the PR

^

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- docs: Move ExecOptions to an external link to Node.js docs

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
