### PR TITLE
Making Help Great Again!

### DIFF
--- a/src/commands/Admin/blacklist.js
+++ b/src/commands/Admin/blacklist.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			permissionLevel: 10,
-			description: language => language.get('COMMAND_BLACKLIST_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_BLACKLIST_DESCRIPTION'),
 			usage: '<User:user|Guild:guild|guild:str> [...]',
 			usageDelim: ' ',
 			guarded: true

--- a/src/commands/Admin/conf.js
+++ b/src/commands/Admin/conf.js
@@ -8,7 +8,7 @@ module.exports = class extends Command {
 			permissionLevel: 6,
 			guarded: true,
 			subcommands: true,
-			description: language => language.get('COMMAND_CONF_SERVER_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_CONF_SERVER_DESCRIPTION'),
 			usage: '<set|show|remove|reset> (key:key) (value:value) [...]',
 			usageDelim: ' '
 		});

--- a/src/commands/Admin/disable.js
+++ b/src/commands/Admin/disable.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 		super(...args, {
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_DISABLE_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_DISABLE_DESCRIPTION'),
 			usage: '<Piece:piece>'
 		});
 	}

--- a/src/commands/Admin/enable.js
+++ b/src/commands/Admin/enable.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 		super(...args, {
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_ENABLE_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_ENABLE_DESCRIPTION'),
 			usage: '<Piece:piece>'
 		});
 	}

--- a/src/commands/Admin/eval.js
+++ b/src/commands/Admin/eval.js
@@ -8,8 +8,8 @@ module.exports = class extends Command {
 			aliases: ['ev'],
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_EVAL_DESCRIPTION'),
-			extendedHelp: language => language.get('COMMAND_EVAL_EXTENDEDHELP'),
+			description: ({ language }) => language.get('COMMAND_EVAL_DESCRIPTION'),
+			extendedHelp: ({ language }) => language.get('COMMAND_EVAL_EXTENDEDHELP'),
 			usage: '<expression:str>'
 		});
 	}

--- a/src/commands/Admin/load.js
+++ b/src/commands/Admin/load.js
@@ -9,7 +9,7 @@ module.exports = class extends Command {
 			aliases: ['l'],
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_LOAD_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_LOAD_DESCRIPTION'),
 			usage: '[core] <Store:store> <path:...string>',
 			usageDelim: ' '
 		});

--- a/src/commands/Admin/reboot.js
+++ b/src/commands/Admin/reboot.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 		super(...args, {
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_REBOOT_DESCRIPTION')
+			description: ({ language }) => language.get('COMMAND_REBOOT_DESCRIPTION')
 		});
 	}
 

--- a/src/commands/Admin/reload.js
+++ b/src/commands/Admin/reload.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 			aliases: ['r'],
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_RELOAD_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_RELOAD_DESCRIPTION'),
 			usage: '<Store:store|Piece:piece|everything:default>'
 		});
 	}

--- a/src/commands/Admin/transfer.js
+++ b/src/commands/Admin/transfer.js
@@ -8,7 +8,7 @@ module.exports = class extends Command {
 		super(...args, {
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_TRANSFER_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_TRANSFER_DESCRIPTION'),
 			usage: '<Piece:piece>'
 		});
 	}

--- a/src/commands/Admin/unload.js
+++ b/src/commands/Admin/unload.js
@@ -7,7 +7,7 @@ module.exports = class extends Command {
 			aliases: ['u'],
 			permissionLevel: 10,
 			guarded: true,
-			description: language => language.get('COMMAND_UNLOAD_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_UNLOAD_DESCRIPTION'),
 			usage: '<Piece:piece>'
 		});
 	}

--- a/src/commands/General/Chat Bot Info/help.js
+++ b/src/commands/General/Chat Bot Info/help.js
@@ -20,7 +20,7 @@ module.exports = class extends Command {
 		if (command) {
 			const info = [
 				`= ${command.name} = `,
-				isFunction(command.description) ? command.description(message.language) : command.description,
+				isFunction(command.description) ? command.description(message) : command.description,
 				message.language.get('COMMAND_HELP_USAGE', command.usage.fullUsage(message)),
 				message.language.get('COMMAND_HELP_EXTENDED'),
 				isFunction(command.extendedHelp) ? command.extendedHelp(message) : command.extendedHelp

--- a/src/commands/General/Chat Bot Info/help.js
+++ b/src/commands/General/Chat Bot Info/help.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 		super(...args, {
 			aliases: ['commands'],
 			guarded: true,
-			description: language => language.get('COMMAND_HELP_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_HELP_DESCRIPTION'),
 			usage: '(Command:command)'
 		});
 
@@ -23,7 +23,7 @@ module.exports = class extends Command {
 				isFunction(command.description) ? command.description(message.language) : command.description,
 				message.language.get('COMMAND_HELP_USAGE', command.usage.fullUsage(message)),
 				message.language.get('COMMAND_HELP_EXTENDED'),
-				isFunction(command.extendedHelp) ? command.extendedHelp(message.language) : command.extendedHelp
+				isFunction(command.extendedHelp) ? command.extendedHelp(message) : command.extendedHelp
 			].join('\n');
 			return message.sendMessage(info, { code: 'asciidoc' });
 		}

--- a/src/commands/General/Chat Bot Info/info.js
+++ b/src/commands/General/Chat Bot Info/info.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 		super(...args, {
 			aliases: ['details', 'what'],
 			guarded: true,
-			description: language => language.get('COMMAND_INFO_DESCRIPTION')
+			description: ({ language }) => language.get('COMMAND_INFO_DESCRIPTION')
 		});
 	}
 

--- a/src/commands/General/Chat Bot Info/invite.js
+++ b/src/commands/General/Chat Bot Info/invite.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 		super(...args, {
 			runIn: ['text'],
 			guarded: true,
-			description: language => language.get('COMMAND_INVITE_DESCRIPTION')
+			description: ({ language }) => language.get('COMMAND_INVITE_DESCRIPTION')
 		});
 	}
 

--- a/src/commands/General/Chat Bot Info/ping.js
+++ b/src/commands/General/Chat Bot Info/ping.js
@@ -5,7 +5,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			guarded: true,
-			description: language => language.get('COMMAND_PING_DESCRIPTION')
+			description: ({ language }) => language.get('COMMAND_PING_DESCRIPTION')
 		});
 	}
 

--- a/src/commands/General/Chat Bot Info/stats.js
+++ b/src/commands/General/Chat Bot Info/stats.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 	constructor(...args) {
 		super(...args, {
 			guarded: true,
-			description: language => language.get('COMMAND_STATS_DESCRIPTION')
+			description: ({ language }) => language.get('COMMAND_STATS_DESCRIPTION')
 		});
 	}
 

--- a/src/commands/General/User Settings/userconf.js
+++ b/src/commands/General/User Settings/userconf.js
@@ -6,7 +6,7 @@ module.exports = class extends Command {
 		super(...args, {
 			guarded: true,
 			subcommands: true,
-			description: language => language.get('COMMAND_CONF_USER_DESCRIPTION'),
+			description: ({ language }) => language.get('COMMAND_CONF_USER_DESCRIPTION'),
 			usage: '<set|show|remove|reset> (key:key) (value:value) [...]',
 			usageDelim: ' '
 		});


### PR DESCRIPTION
### Description of the PR
This PR allows any developer to be able to use anything on the message object inside the help functions. Currently, the only thing being passed in is the `message.language` however that is incredibly limiting. This makes it almost impossible to do some really useful things in help command.

As an example if I wanted to show the users how to use a command by showing examples:

`**.command x y z** Will do xyz`
`**.command a b c*** Will do abc`

This doesn't actually work because you are unable to get the prefix to show the user. But wait, there is more!

- Try using guild settings. IMPOSSIBLE
- Try using user settings. IMPOSSIBLE.

**.command x y z** This will change your current XYZ to xyz

The list of things that are not possible with this current implementation just keep going. It is extremely limiting and not flexible whatsoever. 

This PR allows passing the entire message object which can be deconstructed to provide the variables you wish or just message itself if you wish.

```js
description: ({ language }) => language.......
extendedHelp: ({ language, guild, guildSettings, client, user }) => language.......

description: message => message.language......
extendedHelp: message => message.language.....
```

The amount of flexibility that this provides is so much more than only providing a language.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Passes in `message` instead of `language` to help description and extendedHelp

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
