### PR TITLE
misc: Remove duplicate cancel prompt options

### DIFF
--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -54,8 +54,6 @@ module.exports = class extends Language {
 			// eslint-disable-next-line max-len
 			MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT: (tag, name, time, cancelOptions) => `${tag} | **${name}** is a repeating argument | You have **${time}** seconds to respond to this prompt with additional valid arguments. Type **${cancelOptions.join('**, **')}** to cancel this prompt.`,
 			MONITOR_COMMAND_HANDLER_ABORTED: 'Aborted',
-			MONITOR_COMMAND_HANDLER_POSSIBILITIES: ['abort', 'stop'],
-			MONITOR_COMMAND_HANDLER_REPEATING_POSSIBLITIES: ['cancel'],
 			INHIBITOR_COOLDOWN: (remaining) => `You have just used this command. You can use this command again in ${remaining} second${remaining === 1 ? '' : 's'}.`,
 			INHIBITOR_DISABLED_GUILD: 'This command has been disabled by an admin in this guild.',
 			INHIBITOR_DISABLED_GLOBAL: 'This command has been globally disabled by the bot owner.',
@@ -176,7 +174,8 @@ module.exports = class extends Language {
 				`• Shard      :: ${(message.guild ? message.guild.shardID : 0) + 1} / ${this.client.options.totalShardCount}`
 			],
 			COMMAND_STATS_DESCRIPTION: 'Provides some details about the bot and stats.',
-			MESSAGE_PROMPT_TIMEOUT: 'The prompt has timed out.'
+			MESSAGE_PROMPT_TIMEOUT: 'The prompt has timed out.',
+			TEXT_PROMPT_ABORT_OPTIONS: ['abort', 'stop', 'cancel']
 		};
 	}
 

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -158,7 +158,7 @@ class TextPrompt {
 	async reprompt(prompt) {
 		this._prompted++;
 		if (this.typing) this.message.channel.stopTyping();
-		const possibleAbortOptions = this.message.language.get('MONITOR_COMMAND_HANDLER_POSSIBILITIES');
+		const possibleAbortOptions = this.message.language.get('TEXT_PROMPT_ABORT_OPTIONS');
 		const message = await this.message.prompt(
 			this.message.language.get('MONITOR_COMMAND_HANDLER_REPROMPT', `<@!${this.message.author.id}>`, prompt, this.time / 1000, possibleAbortOptions),
 			this.time
@@ -166,9 +166,7 @@ class TextPrompt {
 
 		this.responses.set(message.id, message);
 
-		if (possibleAbortOptions.includes(message.content.toLowerCase())) {
-			throw this.message.language.get('MONITOR_COMMAND_HANDLER_ABORTED');
-		}
+		if (possibleAbortOptions.includes(message.content.toLowerCase())) throw this.message.language.get('MONITOR_COMMAND_HANDLER_ABORTED');
 
 		if (this.typing) this.message.channel.startTyping();
 		this.args[this.args.lastIndexOf(null)] = message.content;
@@ -187,7 +185,7 @@ class TextPrompt {
 	async repeatingPrompt() {
 		if (this.typing) this.message.channel.stopTyping();
 		let message;
-		const possibleCancelOptions = this.message.language.get('MONITOR_COMMAND_HANDLER_REPEATING_POSSIBLITIES');
+		const possibleCancelOptions = this.message.language.get('TEXT_PROMPT_ABORT_OPTIONS');
 		try {
 			message = await this.message.prompt(
 				this.message.language.get('MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT', `<@!${this.message.author.id}>`, this._currentUsage.possibles[0].name, this.time / 1000, possibleCancelOptions),


### PR DESCRIPTION
### Description of the PR

This PR merges two different language options into one, keeping them consistent. They were used in TextPrompts as the possible cancel options, but weren't consistent or equal (different options made no sense)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
