### PR TITLE
typings: Fixed an error, lowered strictness for Command#run's return

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -408,7 +408,7 @@ declare module 'klasa' {
 		public createCustomResolver(type: string, resolver: ArgResolverCustomMethod): this;
 		public customizeResponse(name: string, response: string | ((message: KlasaMessage, possible: Possible) => string)): this;
 		public definePrompt(usageString: string, usageDelim?: string): Usage;
-		public run(message: KlasaMessage, params: any[]): Promise<any> | any;
+		public run(message: KlasaMessage, params: any[]): any;
 		public toJSON(): PieceCommandJSON;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1172,7 +1172,7 @@ declare module 'klasa' {
 	}
 
 	export interface ScheduledTaskUpdateOptions extends Filter<ScheduledTaskOptions, 'id'> {
-		id: never;
+		id?: never;
 		repeat?: string;
 		time?: TimeResolvable;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -408,7 +408,7 @@ declare module 'klasa' {
 		public createCustomResolver(type: string, resolver: ArgResolverCustomMethod): this;
 		public customizeResponse(name: string, response: string | ((message: KlasaMessage, possible: Possible) => string)): this;
 		public definePrompt(usageString: string, usageDelim?: string): Usage;
-		public run(message: KlasaMessage, params: any[]): Promise<KlasaMessage | KlasaMessage[] | null>;
+		public run(message: KlasaMessage, params: any[]): Promise<any> | any;
 		public toJSON(): PieceCommandJSON;
 	}
 
@@ -439,9 +439,9 @@ declare module 'klasa' {
 
 	export abstract class Finalizer extends Piece {
 		public constructor(client: KlasaClient, store: FinalizerStore, file: string[], directory: string, options?: FinalizerOptions);
-		public abstract run(message: KlasaMessage, command: Command, response: KlasaMessage | KlasaMessage[] | null, runTime: Stopwatch): void;
+		public abstract run(message: KlasaMessage, command: Command, response: any, runTime: Stopwatch): void;
 		public toJSON(): PieceFinalizerJSON;
-		protected _run(message: KlasaMessage, command: Command, response: KlasaMessage | KlasaMessage[] | null, runTime: Stopwatch): Promise<void>;
+		protected _run(message: KlasaMessage, command: Command, response: any, runTime: Stopwatch): Promise<void>;
 	}
 
 	export abstract class Inhibitor extends Piece {
@@ -1302,7 +1302,7 @@ declare module 'klasa' {
 	}
 
 	export interface ExtendableOptions extends PieceOptions {
-		appliesTo: Array<Constructor<any>>;
+		appliesTo: any[];
 	}
 
 	export interface InhibitorOptions extends PieceOptions {


### PR DESCRIPTION
### Description of the PR

What the title says. `Constructable<any>` works, but only for non-abstract classes (so if we wanted to extend klasa's structures, which are abstract, we would get an error).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed an error, lowered strictness for Command#run's return in typings

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
