### PR TITLE
fix some partials related things with Arguments

### DIFF
--- a/src/arguments/channel.js
+++ b/src/arguments/channel.js
@@ -4,10 +4,10 @@ module.exports = class extends Argument {
 
 	async run(arg, possible, message) {
 		// DM Channel support
-		const user = this.constructor.regex.userOrMember.test(arg) ? await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]) : null;
+		const user = this.constructor.regex.userOrMember.test(arg) ? await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]).catch(() => null) : null;
 		if (user) return user.createDM();
 		// Regular Channel support
-		const channel = this.constructor.regex.channel.test(arg) ? await this.client.channels.fetch(this.constructor.regex.channel.exec(arg)[1]) : null;
+		const channel = this.constructor.regex.channel.test(arg) ? await this.client.channels.fetch(this.constructor.regex.channel.exec(arg)[1]).catch(() => null) : null;
 		if (channel) return channel;
 		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
 	}

--- a/src/arguments/channel.js
+++ b/src/arguments/channel.js
@@ -3,12 +3,12 @@ const { Argument } = require('klasa');
 module.exports = class extends Argument {
 
 	async run(arg, possible, message) {
-		// DM Channel support
-		const user = this.constructor.regex.userOrMember.test(arg) ? await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]).catch(() => null) : null;
-		if (user) return user.createDM();
 		// Regular Channel support
 		const channel = this.constructor.regex.channel.test(arg) ? await this.client.channels.fetch(this.constructor.regex.channel.exec(arg)[1]).catch(() => null) : null;
 		if (channel) return channel;
+		// DM Channel support
+		const user = this.constructor.regex.userOrMember.test(arg) ? await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]).catch(() => null) : null;
+		if (user) return user.createDM();
 		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
 	}
 

--- a/src/arguments/channel.js
+++ b/src/arguments/channel.js
@@ -2,8 +2,12 @@ const { Argument } = require('klasa');
 
 module.exports = class extends Argument {
 
-	run(arg, possible, message) {
-		const channel = this.constructor.regex.channel.test(arg) ? this.client.channels.get(this.constructor.regex.channel.exec(arg)[1]) : null;
+	async run(arg, possible, message) {
+		// DM Channel support
+		const user = this.constructor.regex.userOrMember.test(arg) ? await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]) : null;
+		if (user) return user.createDM();
+		// Regular Channel support
+		const channel = this.constructor.regex.channel.test(arg) ? await this.client.channels.fetch(this.constructor.regex.channel.exec(arg)[1]) : null;
 		if (channel) return channel;
 		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
 	}

--- a/src/arguments/dmChannel.js
+++ b/src/arguments/dmChannel.js
@@ -3,8 +3,8 @@ const { Argument } = require('klasa');
 module.exports = class extends Argument {
 
 	async run(arg, possible, message) {
-		const channel = await this.store.get('channel').run(arg, possible, message);
-		if (channel && channel.type === 'dm') return channel;
+		const user = this.constructor.regex.userOrMember.test(arg) ? await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]).catch(() => null) : null;
+		if (user) return user.createDM();
 		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
 	}
 

--- a/src/arguments/dmChannel.js
+++ b/src/arguments/dmChannel.js
@@ -1,0 +1,11 @@
+const { Argument } = require('klasa');
+
+module.exports = class extends Argument {
+
+	async run(arg, possible, message) {
+		const channel = await this.store.get('channel').run(arg, possible, message);
+		if (channel && channel.type === 'dm') return channel;
+		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
+	}
+
+};

--- a/src/arguments/dmChannels.js
+++ b/src/arguments/dmChannels.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: ['...dmChannel'] });
+	}
+
+	get base() {
+		return this.store.get('dmChannel');
+	}
+
+};

--- a/src/arguments/member.js
+++ b/src/arguments/member.js
@@ -3,15 +3,8 @@ const { Argument } = require('klasa');
 module.exports = class extends Argument {
 
 	async run(arg, possible, message) {
-		let member = message.guild.members.resolve(arg);
+		const member = this.constructor.regex.userOrMember.test(arg) ? await message.guild.members.fetch(this.constructor.regex.userOrMember.exec(arg)[1]).catch(() => null) : null;
 		if (member) return member;
-		if (this.constructor.regex.userOrMember.test(arg)) {
-			const user = await this.client.users.fetch(this.constructor.regex.userOrMember.exec(arg)[1]).catch(() => null);
-			if (user) {
-				member = await message.guild.members.fetch(user).catch(() => null);
-				if (member) return member;
-			}
-		}
 		throw message.language.get('RESOLVER_INVALID_MEMBER', possible.name);
 	}
 

--- a/src/arguments/textChannel.js
+++ b/src/arguments/textChannel.js
@@ -1,0 +1,11 @@
+const { Argument } = require('klasa');
+
+module.exports = class extends Argument {
+
+	async run(arg, possible, message) {
+		const channel = await this.store.get('channel').run(arg, possible, message);
+		if (channel && channel.type === 'text') return channel;
+		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
+	}
+
+};

--- a/src/arguments/textChannel.js
+++ b/src/arguments/textChannel.js
@@ -3,7 +3,7 @@ const { Argument } = require('klasa');
 module.exports = class extends Argument {
 
 	async run(arg, possible, message) {
-		const channel = await this.store.get('channel').run(arg, possible, message);
+		const channel = this.constructor.regex.channel.test(arg) ? await this.client.channels.fetch(this.constructor.regex.channel.exec(arg)[1]).catch(() => null) : null;
 		if (channel && channel.type === 'text') return channel;
 		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
 	}

--- a/src/arguments/textChannels.js
+++ b/src/arguments/textChannels.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: ['...textChannel'] });
+	}
+
+	get base() {
+		return this.store.get('textChannel');
+	}
+
+};

--- a/src/arguments/voiceChannel.js
+++ b/src/arguments/voiceChannel.js
@@ -3,7 +3,7 @@ const { Argument } = require('klasa');
 module.exports = class extends Argument {
 
 	async run(arg, possible, message) {
-		const channel = await this.store.get('channel').run(arg, possible, message);
+		const channel = this.constructor.regex.channel.test(arg) ? await this.client.channels.fetch(this.constructor.regex.channel.exec(arg)[1]).catch(() => null) : null;
 		if (channel && channel.type === 'voice') return channel;
 		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
 	}

--- a/src/arguments/voiceChannel.js
+++ b/src/arguments/voiceChannel.js
@@ -1,0 +1,11 @@
+const { Argument } = require('klasa');
+
+module.exports = class extends Argument {
+
+	async run(arg, possible, message) {
+		const channel = await this.store.get('channel').run(arg, possible, message);
+		if (channel && channel.type === 'voice') return channel;
+		throw message.language.get('RESOLVER_INVALID_CHANNEL', possible.name);
+	}
+
+};

--- a/src/arguments/voiceChannels.js
+++ b/src/arguments/voiceChannels.js
@@ -1,0 +1,13 @@
+const { MultiArgument } = require('klasa');
+
+module.exports = class extends MultiArgument {
+
+	constructor(...args) {
+		super(...args, { aliases: ['...voiceChannel'] });
+	}
+
+	get base() {
+		return this.store.get('voiceChannel');
+	}
+
+};


### PR DESCRIPTION
### Description of the PR
Fixes the Member argument's behavior if the cached member is a partial. Adds actual fetching capability to the Channel argument (to auto-resolve any partials issues), and supports DM Channels even if they aren't cached or if you use a user mention.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
