### PR TITLE
Fix wrong error message for guild serializer

### DIFF
--- a/src/serializers/guild.js
+++ b/src/serializers/guild.js
@@ -7,7 +7,7 @@ module.exports = class extends Serializer {
 		if (data instanceof Guild) return data;
 		const guild = this.constructor.regex.channel.test(data) ? this.client.guilds.get(data) : null;
 		if (guild) return guild;
-		throw language.get('RESOLVER_INVALID_CHANNEL', piece.key);
+		throw language.get('RESOLVER_INVALID_GUILD', piece.key);
 	}
 
 	serialize(value) {


### PR DESCRIPTION
### Description of the PR
Noticed the guild serializer threw the wrong message while I was looking at the default ones to learn to implement my own. Not sure it really warrants its own PR, but here I am anyway 🤷‍♂️

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change the error message index thrown from the guild serializer from `RESOLVER _INVALID_CHANNEL` to `RESOLVER_INVALID_GUILD`.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
