### PR TITLE
misc: Make Client#owner always return a user

### DIFF
--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -340,13 +340,13 @@ class KlasaClient extends Discord.Client {
 	}
 
 	/**
-	 * The owner for this bot
+	 * The owner for this bot, or a partial object if they aren't in the cache
 	 * @since 0.1.1
-	 * @type {?KlasaUser}
+	 * @type {KlasaUser}
 	 * @readonly
 	 */
 	get owner() {
-		return this.users.get(this.options.ownerID) || null;
+		return this.users.get(this.options.ownerID) || this.users.add({ id: this.options.ownerID });
 	}
 
 	/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1648,7 +1648,7 @@ declare module 'discord.js' {
 	export interface Client {
 		constructor: typeof KlasaClient;
 		readonly invite: string;
-		readonly owner: User | null;
+		readonly owner: User;
 		options: Required<KlasaClientOptions>;
 		userBaseDirectory: string;
 		console: KlasaConsole;


### PR DESCRIPTION
### Description of the PR

This PR makes Client#owner always be a user, since partials are now a thing in discord.js.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] ? This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
