### PR TITLE
Discordlog event

### DIFF
--- a/src/events/commandError.js
+++ b/src/events/commandError.js
@@ -3,7 +3,11 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(message, command, params, error) {
-		if (error instanceof Error) this.client.emit('wtf', `[COMMAND] ${command.path}\n${error.stack || error}`);
+		if (error instanceof Error) {
+			const errorMessage = `[COMMAND] ${command.path}\n${error.stack || error}`;
+			this.client.emit('wtf', errorMessage);
+			this.client.emit('discordLog', errorMessage);
+		}
 		if (error.message) message.sendCode('JSON', error.message).catch(err => this.client.emit('wtf', err));
 		else message.sendMessage(error).catch(err => this.client.emit('wtf', err));
 	}

--- a/src/events/error.js
+++ b/src/events/error.js
@@ -4,6 +4,7 @@ module.exports = class extends Event {
 
 	run(err) {
 		this.client.console.error(err);
+		this.client.emit('discordLog', err);
 	}
 
 	init() {

--- a/src/events/eventError.js
+++ b/src/events/eventError.js
@@ -3,8 +3,10 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(event, args, error) {
-		this.client.emit('wtf', `[EVENT] ${event.path}\n${error ?
-			error.stack ? error.stack : error : 'Unknown error'}`);
+		const errorMessage = `[EVENT] ${event.path}\n${error ?
+			error.stack ? error.stack : error : 'Unknown error'}`
+		this.client.emit('wtf', errorMessage);
+		this.client.emit('discordLog', errorMessage);
 	}
 
 };

--- a/src/events/eventError.js
+++ b/src/events/eventError.js
@@ -4,7 +4,7 @@ module.exports = class extends Event {
 
 	run(event, args, error) {
 		const errorMessage = `[EVENT] ${event.path}\n${error ?
-			error.stack ? error.stack : error : 'Unknown error'}`
+			error.stack ? error.stack : error : 'Unknown error'}`;
 		this.client.emit('wtf', errorMessage);
 		this.client.emit('discordLog', errorMessage);
 	}

--- a/src/events/finalizerError.js
+++ b/src/events/finalizerError.js
@@ -3,8 +3,10 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(message, command, response, timer, finalizer, error) {
-		this.client.emit('wtf', `[FINALIZER] ${finalizer.path}\n${error ?
-			error.stack ? error.stack : error : 'Unknown error'}`);
+		const errorMessage = `[FINALIZER] ${finalizer.path}\n${error ?
+			error.stack ? error.stack : error : 'Unknown error'}`;
+		this.client.emit('wtf', errorMessage);
+		this.client.emit('discordLog', errorMessage);
 	}
 
 };

--- a/src/events/taskError.js
+++ b/src/events/taskError.js
@@ -3,8 +3,10 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(scheduledTask, task, error) {
-		this.client.emit('wtf', `[TASK] ${task.path}\n${error ?
-			error.stack ? error.stack : error : 'Unknown error'}`);
+		const errorMessage = `[TASK] ${task.path}\n${error ?
+			error.stack ? error.stack : error : 'Unknown error'}`;
+		this.client.emit('wtf', errorMessage);
+		this.client.emit('discordLog', errorMessage);
 	}
 
 };


### PR DESCRIPTION
### Description of the PR
This PR adds a this.client.emit('discordLog') to all the `error` events such as commandError, eventsError, taskError etc....

The reason for this change is to help decrease the number of files needed to transfer and maintain when a developer wishes to get errors/logs posted to a discord channel. The only thing that needs to be done is to create a discordLog event in the bots code to receive all error events. 

**Suggestion**: If a klasa-piece is created that handles the discord log event and posts the errors it would go really well with this and allow new developers to just use that piece and get all errors reported to their discord channel of choice because lets be honest trying to watch a console for errors is impossible.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Add this.client.emit('discordLog', errorMessage) to all error events

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
