### PR TITLE
Text Prompt Rework

### DIFF
--- a/src/events/argumentError.js
+++ b/src/events/argumentError.js
@@ -1,0 +1,9 @@
+const { Event } = require('klasa');
+
+module.exports = class extends Event {
+
+	run(message, command, params, error) {
+		message.sendMessage(error).catch(err => this.client.emit('wtf', err));
+	}
+
+};

--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -13,6 +13,8 @@ module.exports = class extends Event {
 		await this.client.fetchApplication();
 		if (!this.client.options.ownerID) this.client.options.ownerID = this.client.application.owner.id;
 
+		this.client.mentionPrefix = new RegExp(`^<@!?${this.client.user.id}>`);
+
 		this.client.settings = this.client.gateways.clientStorage.get(this.client.user.id, true);
 		// Added for consistency with other datastores, Client#clients does not exist
 		this.client.gateways.clientStorage.cache.set(this.client.user.id, this.client);

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -324,6 +324,13 @@ class KlasaClient extends Discord.Client {
 		 */
 		this.ready = false;
 
+		/**
+		 * The regexp for a prefix mention
+		 * @since 0.5.0
+		 * @type {RegExp}
+		 */
+		this.mentionPrefix = null;
+
 		// Run all plugin functions in this context
 		for (const plugin of plugins) plugin.call(this);
 	}

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -617,7 +617,17 @@ KlasaClient.defaultClientSchema = new Schema()
  * @param {KlasaMessage} message The message that triggered the command
  * @param {Command} command The command run
  * @param {any[]} params The resolved parameters of the command
- * @param {(string|Object)} error The command error
+ * @param {Object} error The command error
+ */
+
+/**
+ * Emitted when an invlaid argument is passed to a command.
+ * @event KlasaClient#argumentError
+ * @since 0.5.0
+ * @param {KlasaMessage} message The message that triggered the command
+ * @param {Command} command The command run
+ * @param {any[]} params The resolved parameters of the command
+ * @param {string} error The argument error
  */
 
 /**

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -66,16 +66,6 @@ module.exports = Structures.extend('Message', Message => {
 		}
 
 		/**
-		 * The guild level settings for this context (guild || default)
-		 * @since 0.5.0
-		 * @type {Settings}
-		 * @readonly
-		 */
-		get guildSettings() {
-			return this.guild ? this.guild.settings : this.client.gateways.guilds.defaults;
-		}
-
-		/**
 		 * The previous responses to this message
 		 * @since 0.5.0
 		 * @type {KlasaMessage[]}
@@ -289,6 +279,13 @@ module.exports = Structures.extend('Message', Message => {
 			 * @type {Language}
 			 */
 			this.language = this.guild ? this.guild.language : this.client.languages.default;
+
+			/**
+			 * The guild level settings for this context (guild || default)
+			 * @since 0.5.0
+			 * @type {Settings}
+			 */
+			this.guildSettings = this.guild ? this.guild.settings : this.client.gateways.guilds.defaults;
 
 			this._parseCommand();
 		}

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -296,22 +296,26 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_parseCommand() {
-			const prefix = this._customPrefix() || this._mentionPrefix() || this._naturalPrefix() || this._prefixLess();
+			try {
+				const prefix = this._customPrefix() || this._mentionPrefix() || this._naturalPrefix() || this._prefixLess();
 
-			if (!prefix) return;
+				if (!prefix) return;
 
-			this.prefix = prefix.regex;
-			this.prefixLength = prefix.length;
-			this.commandText = this.content.slice(prefix.length).trim().split(' ')[0].toLowerCase();
-			this.command = this.client.commands.get(this.commandText) || null;
+				this.prefix = prefix.regex;
+				this.prefixLength = prefix.length;
+				this.commandText = this.content.slice(prefix.length).trim().split(' ')[0].toLowerCase();
+				this.command = this.client.commands.get(this.commandText) || null;
 
-			if (!this.command) return;
+				if (!this.command) return;
 
-			this.prompter = this.command.usage.createPrompt(this, {
-				quotedStringSupport: this.command.quotedStringSupport,
-				time: this.command.promptTime,
-				limit: this.command.promptLimit
-			});
+				this.prompter = this.command.usage.createPrompt(this, {
+					quotedStringSupport: this.command.quotedStringSupport,
+					time: this.command.promptTime,
+					limit: this.command.promptLimit
+				});
+			} catch (error) {
+				return;
+			}
 		}
 
 		/**
@@ -336,7 +340,6 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_mentionPrefix() {
-			if (!this.client.ready) return null;
 			const mentionPrefix = this.client.mentionPrefix.exec(this.content);
 			return mentionPrefix ? { length: mentionPrefix[0].length, regex: this.client.mentionPrefix } : null;
 		}

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -132,20 +132,6 @@ module.exports = Structures.extend('Message', Message => {
 		}
 
 		/**
-		 * Awaits a response from the author.
-		 * @param {string} text The text to prompt the author
-		 * @param {number} [time=30000] The time to wait before giving up
-		 * @returns {KlasaMessage}
-		 */
-		async prompt(text, time = 30000) {
-			const message = await this.channel.send(text);
-			const responses = await this.channel.awaitMessages(msg => msg.author === this.author, { time, max: 1 });
-			message.delete();
-			if (responses.size === 0) throw this.language.get('MESSAGE_PROMPT_TIMEOUT');
-			return responses.first();
-		}
-
-		/**
 		 * The usable commands by the author in this message's context
 		 * @since 0.0.1
 		 * @returns {Collection<string, Command>} The filtered CommandStore

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -336,6 +336,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_mentionPrefix() {
+			if (!this.client.ready) return null;
 			const mentionPrefix = this.client.mentionPrefix.exec(this.content);
 			return mentionPrefix ? { length: mentionPrefix[0].length, regex: this.client.mentionPrefix } : null;
 		}

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -1,4 +1,5 @@
 const { Structures, Collection, APIMessage, Permissions: { FLAGS } } = require('discord.js');
+const { regExpEsc } = require('../util/util');
 
 module.exports = Structures.extend('Message', Message => {
 	/**
@@ -8,38 +9,44 @@ module.exports = Structures.extend('Message', Message => {
 	class KlasaMessage extends Message {
 
 		/**
+		 * @typedef {object} CachedPrefix
+		 * @property {number} length The length of the prefix
+		 * @property {RegExp | null} regex The RegExp for the prefix
+		 */
+
+		/**
 		 * @param {...*} args Normal D.JS Message args
 		 */
 		constructor(...args) {
 			super(...args);
 
 			/**
-			 * The guild level settings for this context (guild || default)
-			 * @since 0.5.0
-			 * @type {Settings}
-			 */
-			this.guildSettings = this.guild ? this.guild.settings : this.client.gateways.guilds.defaults;
-
-			/**
 			 * The command being run
 			 * @since 0.0.1
 			 * @type {?Command}
 			 */
-			this.command = null;
+			this.command = this.command || null;
+
+			/**
+			 * The name of the command being run
+			 * @since 0.5.0
+			 * @type {?string}
+			 */
+			this.commandText = this.commandText || null;
 
 			/**
 			 * The prefix used
 			 * @since 0.0.1
 			 * @type {?RegExp}
 			 */
-			this.prefix = null;
+			this.prefix = this.prefix || null;
 
 			/**
 			 * The length of the prefix used
 			 * @since 0.0.1
 			 * @type {?number}
 			 */
-			this.prefixLength = null;
+			this.prefixLength = typeof this.prefixLength === 'number' ? this.prefixLength : null;
 
 			/**
 			 * A command prompt/argument handler
@@ -47,7 +54,7 @@ module.exports = Structures.extend('Message', Message => {
 			 * @type {CommandPrompt}
 			 * @private
 			 */
-			this.prompter = null;
+			this.prompter = this.prompter || null;
 
 			/**
 			 * The responses to this message
@@ -56,6 +63,16 @@ module.exports = Structures.extend('Message', Message => {
 			 * @private
 			 */
 			this._responses = [];
+		}
+
+		/**
+		 * The guild level settings for this context (guild || default)
+		 * @since 0.5.0
+		 * @type {Settings}
+		 * @readonly
+		 */
+		get guildSettings() {
+			return this.guild ? this.guild.settings : this.client.gateways.guilds.defaults;
 		}
 
 		/**
@@ -254,6 +271,7 @@ module.exports = Structures.extend('Message', Message => {
 		patch(data) {
 			super.patch(data);
 			this.language = this.guild ? this.guild.language : this.client.languages.default;
+			this._parseCommand();
 		}
 
 		/**
@@ -271,32 +289,105 @@ module.exports = Structures.extend('Message', Message => {
 			 * @type {Language}
 			 */
 			this.language = this.guild ? this.guild.language : this.client.languages.default;
+
+			this._parseCommand();
 		}
 
 		/**
-		 * Register's this message as a Command Message
+		 * Parses this message as a command
 		 * @since 0.5.0
-		 * @param {Object} commandInfo The info about the command and prefix used
-		 * @property {Command} command The command run
-		 * @property {RegExp} prefix The prefix used
-		 * @property {number} prefixLength The length of the prefix used
-		 * @returns {this}
 		 * @private
 		 */
-		_registerCommand({ command, prefix, prefixLength }) {
-			this.command = command;
-			this.prefix = prefix;
-			this.prefixLength = prefixLength;
+		_parseCommand() {
+			const prefix = this._customPrefix() || this._mentionPrefix() || this._naturalPrefix() || this._prefixLess();
+
+			if (!prefix) return;
+
+			this.prefix = prefix.regex;
+			this.prefixLength = prefix.length;
+			this.commandText = this.content.slice(prefix.length).trim().split(' ')[0].toLowerCase();
+			this.command = this.client.commands.get(this.commandText) || null;
+
+			if (!this.command) return;
+
 			this.prompter = this.command.usage.createPrompt(this, {
 				quotedStringSupport: this.command.quotedStringSupport,
 				time: this.command.promptTime,
 				limit: this.command.promptLimit
 			});
-			this.client.emit('commandRun', this, this.command, this.args);
-			return this;
+		}
+
+		/**
+		 * Checks if the per-guild or default prefix is used
+		 * @since 0.5.0
+		 * @returns {CachedPrefix | null}
+		 * @private
+		 */
+		_customPrefix() {
+			if (!this.guildSettings.prefix) return null;
+			for (const prf of Array.isArray(this.guildSettings.prefix) ? this.guildSettings.prefix : [this.guildSettings.prefix]) {
+				const testingPrefix = this.constructor.prefixes.get(prf) || this.constructor.generateNewPrefix(prf, this.client.options.prefixCaseInsensitive ? 'i' : '');
+				if (testingPrefix.regex.test(this.content)) return testingPrefix;
+			}
+			return null;
+		}
+
+		/**
+		 * Checks if the mention was used as a prefix
+		 * @since 0.5.0
+		 * @returns {CachedPrefix | null}
+		 * @private
+		 */
+		_mentionPrefix() {
+			const mentionPrefix = this.client.mentionPrefix.exec(this.content);
+			return mentionPrefix ? { length: mentionPrefix[0].length, regex: this.client.mentionPrefix } : null;
+		}
+
+		/**
+		 * Checks if the natural prefix is used
+		 * @since 0.5.0
+		 * @returns {CachedPrefix | null}
+		 * @private
+		 */
+		_naturalPrefix() {
+			if (this.guildSettings.disableNaturalPrefix || !this.client.options.regexPrefix) return null;
+			const results = this.client.options.regexPrefix.exec(this.content);
+			return results ? { length: results[0].length, regex: this.client.options.regexPrefix } : null;
+		}
+
+		/**
+		 * Checks if a prefixless scenario is possible
+		 * @since 0.5.0
+		 * @returns {CachedPrefix | null}
+		 * @private
+		 */
+		_prefixLess() {
+			return this.client.options.noPrefixDM && this.channel.type === 'dm' ? { length: 0, regex: null } : null;
+		}
+
+		/**
+		 * Caches a new prefix regexp
+		 * @since 0.5.0
+		 * @param {string} prefix The prefix to store
+		 * @param {string} flags The flags for the RegExp
+		 * @returns {CachedPrefix}
+		 * @private
+		 */
+		static generateNewPrefix(prefix, flags) {
+			const prefixObject = { length: prefix.length, regex: new RegExp(`^${regExpEsc(prefix)}`, flags) };
+			this.prefixes.set(prefix, prefixObject);
+			return prefixObject;
 		}
 
 	}
+
+	/**
+	 * Cache of RegExp prefixes
+	 * @since 0.5.0
+	 * @type {Map<string, CachedPrefix>}
+	 * @private
+	 */
+	KlasaMessage.prefixes = new Map();
 
 	return KlasaMessage;
 });

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -309,6 +309,7 @@ module.exports = Structures.extend('Message', Message => {
 				if (!this.command) return;
 
 				this.prompter = this.command.usage.createPrompt(this, {
+					flagSupport: this.command.flagSupport,
 					quotedStringSupport: this.command.quotedStringSupport,
 					time: this.command.promptTime,
 					limit: this.command.promptLimit

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -28,6 +28,7 @@ class Command extends AliasPiece {
 	 * @property {boolean} [deletable=false] If the responses should be deleted if the triggering message is deleted
 	 * @property {(string|Function)} [description=''] The help description for the command
 	 * @property {ExtendedHelp} [extendedHelp] Extended help strings
+	 * @property {boolean} [flagSupport=true] Whether flags should be parsed or not
 	 * @property {boolean} [guarded=false] If the command can be disabled on a guild level (does not effect global disable)
 	 * @property {boolean} [hidden=false] If the command should be hidden
 	 * @property {boolean} [nsfw=false] If the command should only run in nsfw channels
@@ -145,6 +146,13 @@ class Command extends AliasPiece {
 		 * @type {number}
 		 */
 		this.promptTime = options.promptTime;
+
+		/**
+		 * Whether to use flag support for this command or not
+		 * @since 0.2.1
+		 * @type {boolean}
+		 */
+		this.flagSupport = options.flagSupport;
 
 		/**
 		 * Whether to use quoted string support for this command or not

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -14,6 +14,7 @@ class TextPrompt {
 	 * @property {number} [limit=Infinity] The number of re-prompts before this TextPrompt gives up
 	 * @property {number} [time=30000] The time-limit for re-prompting
 	 * @property {boolean} [quotedStringSupport=false] Whether this prompt should respect quoted strings
+	 * @property {boolean} [flagSupport=true] Whether this prompt should respect flags
 	 */
 
 	/**
@@ -110,6 +111,13 @@ class TextPrompt {
 		 * @type {boolean}
 		 */
 		this.quotedStringSupport = options.quotedStringSupport;
+
+		/**
+		 * Whether this prompt should respect flags
+		 * @since 0.5.0
+		 * @type {boolean}
+		 */
+		this.flagSupport = options.flagSupport;
 
 		/**
 		 * Whether the current usage is a repeating arg
@@ -342,7 +350,7 @@ class TextPrompt {
 	 * @private
 	 */
 	_setup(original) {
-		const { content, flags } = this.constructor.getFlags(original, this.usage.usageDelim);
+		const { content, flags } = this.flagSupport ? this.constructor.getFlags(original, this.usage.usageDelim) : { content: original, flags: {} };
 		this.flags = flags;
 		this.args = this.quotedStringSupport ?
 			this.constructor.getQuotedStringArgs(content, this.usage.usageDelim).map(arg => arg.trim()) :

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -189,13 +189,13 @@ class TextPrompt {
 		this._prompted++;
 		if (this.typing) this.message.channel.stopTyping();
 		const possibleAbortOptions = this.message.language.get('TEXT_PROMPT_ABORT_OPTIONS');
+		const edits = this.message.edits.length;
 		const message = await this.prompt(
 			this.message.language.get('MONITOR_COMMAND_HANDLER_REPROMPT', `<@!${this.target.id}>`, prompt, this.time / 1000, possibleAbortOptions)
 		);
+		if (this.message.edits.length !== edits || message.prefix || possibleAbortOptions.includes(message.content.toLowerCase())) throw this.message.language.get('MONITOR_COMMAND_HANDLER_ABORTED');
 
 		this.responses.set(message.id, message);
-
-		if (possibleAbortOptions.includes(message.content.toLowerCase())) throw this.message.language.get('MONITOR_COMMAND_HANDLER_ABORTED');
 
 		if (this.typing) this.message.channel.startTyping();
 		this.args[this.args.lastIndexOf(null)] = message.content;

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -32,7 +32,8 @@ exports.DEFAULTS = {
 		customPromptDefaults: {
 			time: 30000,
 			limit: Infinity,
-			quotedStringSupport: false
+			quotedStringSupport: false,
+			flagSupport: true
 		},
 		gateways: {
 			guilds: {},
@@ -57,6 +58,7 @@ exports.DEFAULTS = {
 				description: '',
 				extendedHelp: language => language.get('COMMAND_HELP_NO_EXTENDED'),
 				enabled: true,
+				flagSupport: true,
 				guarded: false,
 				hidden: false,
 				nsfw: false,

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -27,14 +27,18 @@ module.exports = class extends Monitor {
 			await this.client.inhibitors.run(message, message.command);
 			try {
 				await message.prompter.run();
-				const subcommand = message.command.subcommands ? message.params.shift() : undefined;
-				const commandRun = subcommand ? message.command[subcommand](message, message.params) : message.command.run(message, message.params);
-				timer.stop();
-				const response = await commandRun;
-				this.client.finalizers.run(message, message.command, response, timer);
-				this.client.emit('commandSuccess', message, message.command, message.params, response);
-			} catch (error) {
-				this.client.emit('commandError', message, message.command, message.params, error);
+				try {
+					const subcommand = message.command.subcommands ? message.params.shift() : undefined;
+					const commandRun = subcommand ? message.command[subcommand](message, message.params) : message.command.run(message, message.params);
+					timer.stop();
+					const response = await commandRun;
+					this.client.finalizers.run(message, message.command, response, timer);
+					this.client.emit('commandSuccess', message, message.command, message.params, response);
+				} catch (error) {
+					this.client.emit('commandError', message, message.command, message.params, error);
+				}
+			} catch (argumentError) {
+				this.client.emit('argumentError', message, message.command, message.params, argumentError);
 			}
 		} catch (response) {
 			this.client.emit('commandInhibited', message, message.command, response);

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -1,67 +1,23 @@
-const { Monitor, Stopwatch, util: { regExpEsc } } = require('klasa');
+const { Monitor, Stopwatch } = require('klasa');
 
 module.exports = class extends Monitor {
 
 	constructor(...args) {
 		super(...args, { ignoreOthers: false });
 		this.ignoreEdits = !this.client.options.commandEditing;
-		this.prefixes = new Map();
-		this.prefixMention = null;
-		this.mentionOnly = null;
-		this.prefixFlags = this.client.options.prefixCaseInsensitive ? 'i' : '';
 	}
 
 	async run(message) {
 		if (message.guild && !message.guild.me) await message.guild.members.fetch(this.client.user);
 		if (!message.channel.postable) return undefined;
-		if (this.mentionOnly.test(message.content)) return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length ? message.guildSettings.prefix : undefined]);
-
-		const { commandText, prefix, prefixLength } = this.parseCommand(message);
-		if (!commandText) return undefined;
-
-		const command = this.client.commands.get(commandText);
-		if (!command) return this.client.emit('commandUnknown', message, commandText, prefix, prefixLength);
-
-		return this.runCommand(message._registerCommand({ command, prefix, prefixLength }));
-	}
-
-	parseCommand(message) {
-		const result = this.customPrefix(message) || this.mentionPrefix(message) || this.naturalPrefix(message) || this.prefixLess(message);
-		return result ? {
-			commandText: message.content.slice(result.length).trim().split(' ')[0].toLowerCase(),
-			prefix: result.regex,
-			prefixLength: result.length
-		} : { commandText: false };
-	}
-
-	customPrefix({ content, guildSettings: { prefix } }) {
-		if (!prefix) return null;
-		for (const prf of Array.isArray(prefix) ? prefix : [prefix]) {
-			const testingPrefix = this.prefixes.get(prf) || this.generateNewPrefix(prf);
-			if (testingPrefix.regex.test(content)) return testingPrefix;
+		if (!message.commandText && message.prefix === this.client.mentionPrefix) {
+			return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length ? message.guildSettings.prefix : undefined]);
 		}
-		return null;
-	}
+		if (!message.commandText) return undefined;
+		if (!message.command) return this.client.emit('commandUnknown', message, message.commandText, message.prefix, message.prefixLength);
+		this.client.emit('commandRun', message, message.command, message.args);
 
-	mentionPrefix({ content }) {
-		const prefixMention = this.prefixMention.exec(content);
-		return prefixMention ? { length: prefixMention[0].length, regex: this.prefixMention } : null;
-	}
-
-	naturalPrefix({ content, guildSettings: { disableNaturalPrefix } }) {
-		if (disableNaturalPrefix || !this.client.options.regexPrefix) return null;
-		const results = this.client.options.regexPrefix.exec(content);
-		return results ? { length: results[0].length, regex: this.client.options.regexPrefix } : null;
-	}
-
-	prefixLess({ channel: { type } }) {
-		return this.client.options.noPrefixDM && type === 'dm' ? { length: 0, regex: null } : null;
-	}
-
-	generateNewPrefix(prefix) {
-		const prefixObject = { length: prefix.length, regex: new RegExp(`^${regExpEsc(prefix)}`, this.prefixFlags) };
-		this.prefixes.set(prefix, prefixObject);
-		return prefixObject;
+		return this.runCommand(message);
 	}
 
 	async runCommand(message) {
@@ -84,11 +40,6 @@ module.exports = class extends Monitor {
 			this.client.emit('commandInhibited', message, message.command, response);
 		}
 		if (this.client.options.typing) message.channel.stopTyping();
-	}
-
-	init() {
-		this.prefixMention = new RegExp(`^<@!?${this.client.user.id}>`);
-		this.mentionOnly = new RegExp(`^<@!?${this.client.user.id}>$`);
 	}
 
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -403,6 +403,7 @@ declare module 'klasa' {
 		public deletable: boolean;
 		public description: string | ((language: Language) => string);
 		public extendedHelp: string | ((language: Language) => string);
+		public flagSupport: boolean;
 		public fullCategory: string[];
 		public guarded: boolean;
 		public hidden: boolean;
@@ -1302,6 +1303,7 @@ declare module 'klasa' {
 		deletable?: boolean;
 		description?: string | string[] | ((language: Language) => string | string[]);
 		extendedHelp?: string | string[] | ((language: Language) => string | string[]);
+		flagSupport?: boolean;
 		guarded?: boolean;
 		hidden?: boolean;
 		nsfw?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1693,7 +1693,8 @@ declare module 'discord.js' {
 		registerStore<K, V extends Piece, VConstructor = Constructor<V>>(store: Store<K, V, VConstructor>): KlasaClient;
 		unregisterStore<K, V extends Piece, VConstructor = Constructor<V>>(store: Store<K, V, VConstructor>): KlasaClient;
 		sweepMessages(lifetime?: number, commandLifeTime?: number): number;
-		on(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
+		on(event: 'argumentError', listener: (message: KlasaMessage, command: Command, params: any[], error: string) => void): this;
+		on(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error | string) => void): this;
 		on(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
 		on(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		on(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
@@ -1712,7 +1713,8 @@ declare module 'discord.js' {
 		on(event: 'taskError', listener: (scheduledTask: ScheduledTask, task: Task, error: Error) => void): this;
 		on(event: 'verbose', listener: (data: any) => void): this;
 		on(event: 'wtf', listener: (failure: Error) => void): this;
-		once(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
+		once(event: 'argumentError', listener: (message: KlasaMessage, command: Command, params: any[], error: string) => void): this;
+		once(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error | string) => void): this;
 		once(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
 		once(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		once(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
@@ -1731,7 +1733,8 @@ declare module 'discord.js' {
 		once(event: 'taskError', listener: (scheduledTask: ScheduledTask, task: Task, error: Error) => void): this;
 		once(event: 'verbose', listener: (data: any) => void): this;
 		once(event: 'wtf', listener: (failure: Error) => void): this;
-		off(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
+		off(event: 'argumentError', listener: (message: KlasaMessage, command: Command, params: any[], error: string) => void): this;
+		off(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error | string) => void): this;
 		off(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
 		off(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		off(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -70,12 +70,24 @@ declare module 'klasa' {
 		public readonly language: Language;
 	}
 
+	export interface CachedPrefix {
+		regex: RegExp;
+		length: number;
+	}
+
 	export class KlasaMessage extends Message {
 		private levelID: Snowflake | null;
 		private prompter: CommandPrompt | null;
 		private _responses: KlasaMessage[];
 		private _patch(data: any): void;
-		private _registerCommand(commandInfo: { command: Command, prefix: RegExp, prefixLength: number }): this;
+		private _parseCommand(): void;
+		private _customPrefix(): CachedPrefix | null;
+		private _mentionPrefix(): CachedPrefix | null;
+		private _naturalPrefix(): CachedPrefix | null;
+		private _prefixLess(): CachedPrefix | null;
+		private static generateNewPrefix(prefix: string, flags: string): CachedPrefix;
+
+		private static prefixes: Map<string, CachedPrefix>;
 	}
 
 	export class KlasaUser extends User {}
@@ -1744,11 +1756,12 @@ declare module 'discord.js' {
 	}
 
 	export interface Message extends PartialSendAliases {
-		guildSettings: Settings;
 		language: Language;
 		command: Command | null;
+		commandText: string | null;
 		prefix: RegExp | null;
 		prefixLength: number | null;
+		readonly guildSettings: Settings;
 		readonly responses: KlasaMessage[];
 		readonly args: string[];
 		readonly params: any[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -641,9 +641,11 @@ declare module 'klasa' {
 	}
 
 	export class TextPrompt {
-		public constructor(message: KlasaMessage, usage: Usage, options: TextPromptOptions);
+		public constructor(message: KlasaMessage, usage: Usage, options?: TextPromptOptions);
 		public readonly client: KlasaClient;
 		public message: KlasaMessage;
+		public target: KlasaUser;
+		public channel: TextChannel | DMChannel;
 		public usage: Usage | CommandUsage;
 		public reprompted: boolean;
 		public flags: Record<string, string>;
@@ -659,6 +661,7 @@ declare module 'klasa' {
 		private _currentUsage: Tag;
 
 		public run<T = any[]>(prompt: string): Promise<T>;
+		private prompt(text: string): Promise<KlasaMessage>;
 		private reprompt(prompt: string): Promise<any[]>;
 		private repeatingPrompt(): Promise<any[]>;
 		private validateArgs(): Promise<any[]>;
@@ -1377,7 +1380,10 @@ declare module 'klasa' {
 
 	// Usage
 	export interface TextPromptOptions {
+		channel?: TextChannel | DMChannel;
 		limit?: number;
+		quotedStringSupport?: boolean;
+		target?: KlasaUser;
 		time?: number;
 		quotedStringSupport?: boolean;
 	}
@@ -1750,7 +1756,6 @@ declare module 'discord.js' {
 		readonly reprompted: boolean;
 		readonly reactable: boolean;
 		send(content?: StringResolvable, options?: MessageOptions): Promise<KlasaMessage | KlasaMessage[]>;
-		prompt(text: string, time?: number): Promise<KlasaMessage>;
 		usableCommands(): Promise<Collection<string, Command>>;
 		hasAtLeastPermissionLevel(min: number): Promise<boolean>;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1756,12 +1756,12 @@ declare module 'discord.js' {
 	}
 
 	export interface Message extends PartialSendAliases {
+		guildSettings: Settings;
 		language: Language;
 		command: Command | null;
 		commandText: string | null;
 		prefix: RegExp | null;
 		prefixLength: number | null;
-		readonly guildSettings: Settings;
 		readonly responses: KlasaMessage[];
 		readonly args: string[];
 		readonly params: any[];


### PR DESCRIPTION
### Description of the PR
This is the rollup pr for all of the TextPrompt breaking prs. Much like the Settings branch.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- TextPrompt arbitrary User/Channel (breaks Message#prompt)
- Abort Prompt if retyped Command (breaks custom CommandHandler Monitors)
- Allow flagSupport to be turned off for both TextPrompt and Commands
- Separates argumentErrors from commandError events

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
