### PR TITLE
rename event files that have core klasa functionality

### DIFF
--- a/src/events/coreGuildCreate.js
+++ b/src/events/coreGuildCreate.js
@@ -2,6 +2,10 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
+	constructor(...args) {
+		super(...args, { event: 'guildCreate' });
+	}
+
 	run(guild) {
 		if (!guild.available) return;
 		if (this.client.settings.guildBlacklist.includes(guild.id)) {

--- a/src/events/coreGuildDelete.js
+++ b/src/events/coreGuildDelete.js
@@ -2,6 +2,10 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
+	constructor(...args) {
+		super(...args, { event: 'guildDelete' });
+	}
+
 	run(guild) {
 		if (this.client.ready && guild.available && !this.client.options.preserveSettings) guild.settings.destroy().catch(() => null);
 	}

--- a/src/events/coreMessage.js
+++ b/src/events/coreMessage.js
@@ -2,6 +2,10 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
+	constructor(...args) {
+		super(...args, { event: 'message' });
+	}
+
 	run(message) {
 		if (this.client.ready) this.client.monitors.run(message);
 	}

--- a/src/events/coreMessageDelete.js
+++ b/src/events/coreMessageDelete.js
@@ -2,6 +2,10 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
+	constructor(...args) {
+		super(...args, { event: 'messageDelete' });
+	}
+
 	run(message) {
 		if (message.command && message.command.deletable) {
 			for (const msg of message.responses) {

--- a/src/events/coreMessageDeleteBulk.js
+++ b/src/events/coreMessageDeleteBulk.js
@@ -2,6 +2,10 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
+	constructor(...args) {
+		super(...args, { event: 'messageDeleteBulk' });
+	}
+
 	run(messages) {
 		for (const message of messages.values()) {
 			if (message.command && message.command.deletable) {

--- a/src/events/coreMessageUpdate.js
+++ b/src/events/coreMessageUpdate.js
@@ -2,6 +2,10 @@ const { Event } = require('klasa');
 
 module.exports = class extends Event {
 
+	constructor(...args) {
+		super(...args, { event: 'messageUpdate' });
+	}
+
 	async run(old, message) {
 		if (this.client.ready && !old.partial && old.content !== message.content) this.client.monitors.run(message);
 	}

--- a/src/events/coreSettingsUpdateEntry.js
+++ b/src/events/coreSettingsUpdateEntry.js
@@ -3,6 +3,10 @@ const gateways = ['users', 'clientStorage'];
 
 module.exports = class extends Event {
 
+	constructor(...args) {
+		super(...args, { event: 'settingsUpdateEntry' });
+	}
+
 	run(settings) {
 		if (gateways.includes(settings.gateway.type)) {
 			this.client.shard.broadcastEval(`


### PR DESCRIPTION
### Description of the PR
#432 Breaking, renames event files with core Klasa functionality to include a core prefix.

The decision if `core` or not came down to if a Klasa feature would break if the file was overridden with a blank event. Defining Klasa feature as command editing, guild blacklist, etc; and not logging/error handling. The idea being if someone is making their own debug event they want to overwrite the debug functionality. But if you make a message event, all monitors must still function.

If you disagree with any of the event files being renamed or not renamed, please comment your reasoning why said event should or shouldn't be prefixed.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
