### PR TITLE
allow loading of .ts files

### DIFF
--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -186,7 +186,9 @@ class Store extends Collection {
 	 * @private
 	 */
 	static async walk(store, directory = store.userDirectory) {
-		const files = await fs.scan(directory, { filter: (stats, path) => stats.isFile() && extname(path) === '.js' })
+		const extensions = ['.js'];
+		if (require.main.filename.endsWith('.ts')) extensions.push('.ts')
+		const files = await fs.scan(directory, { filter: (stats, path) => stats.isFile() && extensions.includes(extname(path)) && !path.endsWith('.d.ts') })
 			.catch(() => { if (store.client.options.createPiecesFolders) fs.ensureDir(directory).catch(err => store.client.emit('error', err)); });
 		if (!files) return true;
 

--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -187,7 +187,7 @@ class Store extends Collection {
 	 */
 	static async walk(store, directory = store.userDirectory) {
 		const extensions = ['.js'];
-		if (require.main.filename.endsWith('.ts')) extensions.push('.ts')
+		if (require.main.filename.endsWith('.ts')) extensions.push('.ts');
 		const files = await fs.scan(directory, { filter: (stats, path) => stats.isFile() && extensions.includes(extname(path)) && !path.endsWith('.d.ts') })
 			.catch(() => { if (store.client.options.createPiecesFolders) fs.ensureDir(directory).catch(err => store.client.emit('error', err)); });
 		if (!files) return true;


### PR DESCRIPTION
### Description of the PR
This allows loading of .ts files for ts-node users, but doesn't change functionality if ts-node isn't used

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Allow loading of .ts files

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
