### PR TITLE
initial teams support

### DIFF
--- a/guides/Getting Started/UnderstandingPermissionLevels.md
+++ b/guides/Getting Started/UnderstandingPermissionLevels.md
@@ -31,10 +31,10 @@ function permissionLevel(message) {
 			if (message.guild && message.member === message.guild.owner) return true;
 		case 8:
 		case 9:
-			if (message.author === message.client.owner) return true;
+			if (message.client.owners.has(author)) return true;
 			break;
 		case 10:
-			if (message.author === message.client.owner) return true;
+			if (message.client.owners.has(author)) return true;
 			return false;
 	}
 	throw 'You don\'t have permission';
@@ -74,9 +74,9 @@ config.permissionLevels = new PermissionLevels()
 	 * Allows the Bot Owner to use any lower commands
 	 * and causes any command with a permission level 9 or lower to return an error if no check passes.
 	 */
-	.add(9, ({ author, client }) => author === client.owner, { break: true })
+	.add(9, ({ author, client }) => client.owners.has(author), { break: true })
 	// Allows the bot owner to use Bot Owner only commands, which silently fail for other users.
-	.add(10, ({ author, client }) => author === client.owner);
+	.add(10, ({ author, client }) => client.owners.has(author));
 
 new Client(config).login(config.token);
 ```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "discord.js": "github:discordjs/discord.js#master"
   },
   "devDependencies": {
-    "@types/node": "^11.9.0",
+    "@types/node": "^12.0.2",
     "docgen": "github:dirigeants/docsgen",
     "eslint": "^5.0.1",
     "eslint-config-klasa": "github:dirigeants/klasa-lint",

--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -11,7 +11,9 @@ module.exports = class extends Event {
 
 	async run() {
 		await this.client.fetchApplication();
-		if (!this.client.options.ownerID) this.client.options.ownerID = this.client.application.owner.id;
+
+		// Single owner for now until Teams Support is truly added
+		if (!this.client.options.owners.length) this.client.options.owners.push(this.client.application.owner.id);
 
 		this.client.settings = this.client.gateways.clientStorage.get(this.client.user.id, true);
 		// Added for consistency with other datastores, Client#clients does not exist

--- a/src/finalizers/commandCooldown.js
+++ b/src/finalizers/commandCooldown.js
@@ -3,7 +3,7 @@ const { Finalizer } = require('klasa');
 module.exports = class extends Finalizer {
 
 	run(message, command) {
-		if (command.cooldown <= 0 || message.author === this.client.owner) return;
+		if (command.cooldown <= 0 || this.client.owners.has(message.author)) return;
 
 		try {
 			command.cooldowns.acquire(message.levelID).drip();

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -7,7 +7,7 @@ module.exports = class extends Inhibitor {
 	}
 
 	run(message, command) {
-		if (message.author === this.client.owner || command.cooldown <= 0) return;
+		if (this.client.owners.has(message.author) || command.cooldown <= 0) return;
 
 		const existing = command.cooldowns.get(message.levelID);
 

--- a/src/inhibitors/hidden.js
+++ b/src/inhibitors/hidden.js
@@ -3,7 +3,7 @@ const { Inhibitor } = require('klasa');
 module.exports = class extends Inhibitor {
 
 	run(message, command) {
-		return command.hidden && message.command !== command && message.author !== this.client.owner;
+		return command.hidden && message.command !== command && !this.client.owners.has(message.author);
 	}
 
 };

--- a/src/inhibitors/slowmode.js
+++ b/src/inhibitors/slowmode.js
@@ -11,7 +11,7 @@ module.exports = class extends Inhibitor {
 	}
 
 	run(message) {
-		if (message.author === this.client.owner) return;
+		if (this.client.owners.has(message.author)) return;
 
 		const rateLimit = this.slowmode.acquire(message.author.id);
 

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -347,7 +347,7 @@ class KlasaClient extends Discord.Client {
 	 */
 	get owners() {
 		const owners = new Set();
-		for (const owner of this.client.options.owners) {
+		for (const owner of this.options.owners) {
 			const user = this.users.get(owner);
 			if (user) owners.add(user);
 		}

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -66,7 +66,7 @@ class KlasaClient extends Discord.Client {
 	 * @property {GatewaysOptions} [gateways={}] The options for each built-in gateway
 	 * @property {string} [language='en-US'] The default language Klasa should opt-in for the commands
 	 * @property {boolean} [noPrefixDM=false] Whether the bot should allow prefixless messages in DMs
-	 * @property {string} [ownerID] The discord user id for the user the bot should respect as the owner (gotten from Discord api if not provided)
+	 * @property {string[]} [owners] The discord user id for the users the bot should respect as the owner (gotten from Discord api if not provided)
 	 * @property {PermissionLevelsOverload} [permissionLevels] The permission levels to use with this bot
 	 * @property {PieceDefaults} [pieceDefaults={}] Overrides the defaults for all pieces
 	 * @property {string|string[]} [prefix] The default prefix the bot should respond to
@@ -340,13 +340,18 @@ class KlasaClient extends Discord.Client {
 	}
 
 	/**
-	 * The owner for this bot
-	 * @since 0.1.1
-	 * @type {?KlasaUser}
+	 * The owners for this bot
+	 * @since 0.5.0
+	 * @type {Set<KlasaUser>}
 	 * @readonly
 	 */
-	get owner() {
-		return this.users.get(this.options.ownerID) || null;
+	get owners() {
+		const owners = new Discord.Collection();
+		for (const owner of this.client.options.owners) {
+			const user = this.users.get(owner);
+			if (user) owners.add(user);
+		}
+		return owners;
 	}
 
 	/**
@@ -501,8 +506,8 @@ KlasaClient.defaultPermissionLevels = new PermissionLevels()
 	.add(0, () => true)
 	.add(6, ({ guild, member }) => guild && member.permissions.has(FLAGS.MANAGE_GUILD), { fetch: true })
 	.add(7, ({ guild, member }) => guild && member === guild.owner, { fetch: true })
-	.add(9, ({ author, client }) => author === client.owner, { break: true })
-	.add(10, ({ author, client }) => author === client.owner);
+	.add(9, ({ author, client }) => client.owners.has(author), { break: true })
+	.add(10, ({ author, client }) => client.owners.has(author));
 
 
 /**

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -346,7 +346,7 @@ class KlasaClient extends Discord.Client {
 	 * @readonly
 	 */
 	get owners() {
-		const owners = new Discord.Collection();
+		const owners = new Set();
 		for (const owner of this.client.options.owners) {
 			const user = this.users.get(owner);
 			if (user) owners.add(user);

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -39,6 +39,7 @@ exports.DEFAULTS = {
 			users: {},
 			clientStorage: {}
 		},
+		owners: [],
 		// eslint-disable-next-line no-process-env
 		production: process.env.NODE_ENV === 'production',
 		prefixCaseInsensitive: false,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1010,7 +1010,7 @@ declare module 'klasa' {
 		gateways?: GatewaysOptions;
 		language?: string;
 		noPrefixDM?: boolean;
-		ownerID?: string;
+		owners?: string[];
 		permissionLevels?: PermissionLevels;
 		pieceDefaults?: PieceDefaults;
 		prefix?: string | string[];
@@ -1648,7 +1648,7 @@ declare module 'discord.js' {
 	export interface Client {
 		constructor: typeof KlasaClient;
 		readonly invite: string;
-		readonly owner: User | null;
+		readonly owners: Set<User>;
 		options: Required<KlasaClientOptions>;
 		userBaseDirectory: string;
 		console: KlasaConsole;

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,9 +342,9 @@
   dependencies:
     arrify "^1.0.1"
 
-"@types/node@^11.9.0":
-  version "11.13.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.7.tgz#85dbb71c510442d00c0631f99dae957ce44fd104"
+"@types/node@^12.0.2":
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
### Description of the PR
This preps the Klasa API for #632 . This finalizes the structure for teams, but without the API endpoint, it won't automatically be filled with the team owners until that is implemented.

This breaks usage of Client#owner and the ownerID client option.


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
