### PR TITLE
seperate argumentError from commandError

### DIFF
--- a/src/events/argumentError.js
+++ b/src/events/argumentError.js
@@ -1,0 +1,9 @@
+const { Event } = require('klasa');
+
+module.exports = class extends Event {
+
+	run(message, command, params, error) {
+		message.sendMessage(error).catch(err => this.client.emit('wtf', err));
+	}
+
+};

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -617,7 +617,17 @@ KlasaClient.defaultClientSchema = new Schema()
  * @param {KlasaMessage} message The message that triggered the command
  * @param {Command} command The command run
  * @param {any[]} params The resolved parameters of the command
- * @param {(string|Object)} error The command error
+ * @param {Object} error The command error
+ */
+
+/**
+ * Emitted when an invlaid argument is passed to a command.
+ * @event KlasaClient#argumentError
+ * @since 0.5.0
+ * @param {KlasaMessage} message The message that triggered the command
+ * @param {Command} command The command run
+ * @param {any[]} params The resolved parameters of the command
+ * @param {string} error The argument error
  */
 
 /**

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -27,14 +27,18 @@ module.exports = class extends Monitor {
 			await this.client.inhibitors.run(message, message.command);
 			try {
 				await message.prompter.run();
-				const subcommand = message.command.subcommands ? message.params.shift() : undefined;
-				const commandRun = subcommand ? message.command[subcommand](message, message.params) : message.command.run(message, message.params);
-				timer.stop();
-				const response = await commandRun;
-				this.client.finalizers.run(message, message.command, response, timer);
-				this.client.emit('commandSuccess', message, message.command, message.params, response);
-			} catch (error) {
-				this.client.emit('commandError', message, message.command, message.params, error);
+				try {
+					const subcommand = message.command.subcommands ? message.params.shift() : undefined;
+					const commandRun = subcommand ? message.command[subcommand](message, message.params) : message.command.run(message, message.params);
+					timer.stop();
+					const response = await commandRun;
+					this.client.finalizers.run(message, message.command, response, timer);
+					this.client.emit('commandSuccess', message, message.command, message.params, response);
+				} catch (error) {
+					this.client.emit('commandError', message, message.command, message.params, error);
+				}
+			} catch (argumentError) {
+				this.client.emit('argumentError', message, message.command, message.params, argumentError);
 			}
 		} catch (response) {
 			this.client.emit('commandInhibited', message, message.command, response);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1693,7 +1693,8 @@ declare module 'discord.js' {
 		registerStore<K, V extends Piece, VConstructor = Constructor<V>>(store: Store<K, V, VConstructor>): KlasaClient;
 		unregisterStore<K, V extends Piece, VConstructor = Constructor<V>>(store: Store<K, V, VConstructor>): KlasaClient;
 		sweepMessages(lifetime?: number, commandLifeTime?: number): number;
-		on(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
+		on(event: 'argumentError', listener: (message: KlasaMessage, command: Command, params: any[], error: string) => void): this;
+		on(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error | string) => void): this;
 		on(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
 		on(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		on(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
@@ -1712,7 +1713,8 @@ declare module 'discord.js' {
 		on(event: 'taskError', listener: (scheduledTask: ScheduledTask, task: Task, error: Error) => void): this;
 		on(event: 'verbose', listener: (data: any) => void): this;
 		on(event: 'wtf', listener: (failure: Error) => void): this;
-		once(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
+		once(event: 'argumentError', listener: (message: KlasaMessage, command: Command, params: any[], error: string) => void): this;
+		once(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error | string) => void): this;
 		once(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
 		once(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		once(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
@@ -1731,7 +1733,8 @@ declare module 'discord.js' {
 		once(event: 'taskError', listener: (scheduledTask: ScheduledTask, task: Task, error: Error) => void): this;
 		once(event: 'verbose', listener: (data: any) => void): this;
 		once(event: 'wtf', listener: (failure: Error) => void): this;
-		off(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error) => void): this;
+		off(event: 'argumentError', listener: (message: KlasaMessage, command: Command, params: any[], error: string) => void): this;
+		off(event: 'commandError', listener: (message: KlasaMessage, command: Command, params: any[], error: Error | string) => void): this;
 		off(event: 'commandInhibited', listener: (message: KlasaMessage, command: Command, response: string | Error) => void): this;
 		off(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		off(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;


### PR DESCRIPTION
### Description of the PR
Separates argumentErrors from commandErrors

Before they are one, now they are separate.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
