### PR TITLE
Fix(Timestamp): h and hh tags return proper value.

### DIFF
--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -209,9 +209,9 @@ Timestamp.H = time => String(time.getHours());
 
 Timestamp.HH = time => String(time.getHours()).padStart(2, '0');
 
-Timestamp.h = time => String(time.getHours() % 12);
+Timestamp.h = time => String(time.getHours() % 12 || 12);
 
-Timestamp.hh = time => String(time.getHours() % 12).padStart(2, '0');
+Timestamp.hh = time => String(time.getHours() % 12 || 12).padStart(2, '0');
 
 Timestamp.a = time => time.getHours() < 12 ? 'am' : 'pm';
 


### PR DESCRIPTION
### Description of the PR
When using the `h` and `hh` tags in Timestamps it would break and return 0 on the 12th hour. this PR fixes that

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)
- Make h and hh tags return proper value.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
