### PR TITLE
Convert .pluck and .resolve To Return Arrays

### DIFF
--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -120,15 +120,13 @@ class SettingsFolder extends Map {
  	 * @param  {...string} paths The paths to resolve
  	 * @returns {Promise<any[]>}
  	 */
-	async resolve(...paths) {
+	resolve(...paths) {
 		const guild = resolveGuild(this.base.gateway.client, this.base.target);
 		const language = guild ? guild.language : this.base.gateway.client.languages.default;
-		const promises = [];
-		const values = await Promise.all(paths.map(path => {
+		return Promise.all(paths.map(path => {
 			const entry = this.schema.get(this.relative(path));
 			return entry.resolve(this, language, guild).then(res => res)
 		}));
-		return values;
 	}
 
 	/**

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -118,7 +118,7 @@ class SettingsFolder extends Map {
  	 * Resolves paths into their full objects or values depending on the current set value
  	 * @since 0.5.0
  	 * @param  {...string} paths The paths to resolve
- 	 * @returns {Promise<any[]>}
+ 	 * @returns {Promise<Array<*>>}
  	 */
 	resolve(...paths) {
 		const guild = resolveGuild(this.base.gateway.client, this.base.target);

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -120,17 +120,17 @@ class SettingsFolder extends Map {
  	 * Resolves paths into their full objects or values depending on the current set value
  	 * @since 0.5.0
  	 * @param  {...string} paths The paths to resolve
- 	 * @returns {*}
+ 	 * @returns {Promise<any[]>}
  	 */
 	async resolve(...paths) {
 		const guild = resolveGuild(this.base.gateway.client, this.base.target);
 		const language = guild ? guild.language : this.base.gateway.client.languages.default;
 		const promises = [];
-		for (const path of paths) {
+		const values = await Promise.all(paths.map(path => {
 			const entry = this.schema.get(this.relative(path));
-			promises.push(entry.resolve(this, language, guild).then(res => ({ [entry.key]: res })));
+			return entry.resolve(this, language, guild).then(res => ({ [entry.key]: res }))
 		}
-		return Object.assign({}, ...await Promise.all(promises));
+		return values;
 	}
 
 	/**

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -126,8 +126,8 @@ class SettingsFolder extends Map {
 		const promises = [];
 		const values = await Promise.all(paths.map(path => {
 			const entry = this.schema.get(this.relative(path));
-			return entry.resolve(this, language, guild).then(res => ({ [entry.key]: res }))
-		}
+			return entry.resolve(this, language, guild).then(res => res)
+		}));
 		return values;
 	}
 

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -88,7 +88,7 @@ class SettingsFolder extends Map {
 	 * Plucks out one or more attributes from either an object or a sequence of objects
 	 * @since 0.5.0
 	 * @param  {...string} paths The paths to take
-	 * @returns {Array<any>}
+	 * @returns {Array<*>}
 	 * @example
 	 * const [x, y] = message.guild.settings.pluck('x', 'y');
 	 * console.log(x, y);

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -96,8 +96,8 @@ class SettingsFolder extends Map {
 	pluck(...paths) {
 		return paths.map(path => {
 			const value = this.get(path);
-			return typeof value !== 'undefined' ? values.push(value instanceof SettingsFolder ? value.toJSON() : value) : null;
-		})
+			return typeof value !== 'undefined' ? value instanceof SettingsFolder ? value.toJSON() : value : null;
+		});
 	}
 
 	/**
@@ -125,7 +125,7 @@ class SettingsFolder extends Map {
 		const language = guild ? guild.language : this.base.gateway.client.languages.default;
 		return Promise.all(paths.map(path => {
 			const entry = this.schema.get(this.relative(path));
-			return entry.resolve(this, language, guild).then(res => res)
+			return entry.resolve(this, language, guild).then(res => res);
 		}));
 	}
 

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -88,18 +88,18 @@ class SettingsFolder extends Map {
 	 * Plucks out one or more attributes from either an object or a sequence of objects
 	 * @since 0.5.0
 	 * @param  {...string} paths The paths to take
-	 * @returns {Object<string,*>}
+	 * @returns {Array<any>}
 	 * @example
-	 * const { x, y } = message.guild.settings.pluck('x', 'y');
+	 * const [x, y] = message.guild.settings.pluck('x', 'y');
 	 * console.log(x, y);
 	 */
 	pluck(...paths) {
-		const object = {};
+		const values = [];
 		for (const path of paths) {
 			const value = this.get(path);
-			if (typeof value !== 'undefined') object[path] = value instanceof SettingsFolder ? value.toJSON() : value;
+			if (typeof value !== 'undefined') values.push(value instanceof SettingsFolder ? value.toJSON() : value);
 		}
-		return object;
+		return values;
 	}
 
 	/**

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -96,7 +96,7 @@ class SettingsFolder extends Map {
 	pluck(...paths) {
 		return paths.map(path => {
 			const value = this.get(path);
-			return typeof value !== 'undefined' ? value instanceof SettingsFolder ? value.toJSON() : value : null;
+			return typeof value !== 'undefined' ? value instanceof SettingsFolder ? value.toJSON() : value : undefined;
 		});
 	}
 
@@ -125,7 +125,7 @@ class SettingsFolder extends Map {
 		const language = guild ? guild.language : this.base.gateway.client.languages.default;
 		return Promise.all(paths.map(path => {
 			const entry = this.schema.get(this.relative(path));
-			return entry.resolve(this, language, guild).then(res => res);
+			return entry.resolve(this, language, guild);
 		}));
 	}
 

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -94,12 +94,10 @@ class SettingsFolder extends Map {
 	 * console.log(x, y);
 	 */
 	pluck(...paths) {
-		const values = [];
-		for (const path of paths) {
+		return paths.map(path => {
 			const value = this.get(path);
-			if (typeof value !== 'undefined') values.push(value instanceof SettingsFolder ? value.toJSON() : value);
-		}
-		return values;
+			return typeof value !== 'undefined' ? values.push(value instanceof SettingsFolder ? value.toJSON() : value) : null;
+		})
 	}
 
 	/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -234,8 +234,8 @@ declare module 'klasa' {
 		public update(entries: Iterable<[string, any]>, options?: SettingsFolderUpdateOptions): Promise<SettingsFolderUpdateResult>;
 		public update(object: Record<string, any>, options?: SettingsFolderUpdateOptions): Promise<SettingsFolderUpdateResult>;
 		public display(message: KlasaMessage, path?: string | Schema | SchemaFolder | SchemaEntry): string;
-		public pluck<T extends string>(...paths: T[]): Partial<Record<T, any>>;
-		public resolve<T extends string>(...paths: T[]): Partial<Record<T, any>>;
+		public pluck<T extends string>(...paths: T[]): any[];
+		public resolve<T extends string>(...paths: T[]): any[];
 		public toJSON(): any;
 		public toString(): string;
 		private relative(pathOrPiece: string | Schema | SchemaEntry): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -235,7 +235,7 @@ declare module 'klasa' {
 		public update(object: Record<string, any>, options?: SettingsFolderUpdateOptions): Promise<SettingsFolderUpdateResult>;
 		public display(message: KlasaMessage, path?: string | Schema | SchemaFolder | SchemaEntry): string;
 		public pluck<T extends string>(...paths: T[]): any[];
-		public resolve<T extends string>(...paths: T[]): any[];
+		public resolve<T extends string>(...paths: T[]): Promise<any[]>;
 		public toJSON(): any;
 		public toString(): string;
 		private relative(pathOrPiece: string | Schema | SchemaEntry): string;


### PR DESCRIPTION
### Description of the PR
This PR changes `.pluck()` and `.resolve()` to return arrays instead of objects.

Instead of returning an object to deconstruct, returning an array in the order of the arguments provided which can be deconstructed is better.

```js
const { prefix, 'roles.administrator': adminRole } = message.guild.settings.pluck('prefix', 'roles.administrator');
```

to

```js
const [prefix, adminRole] = message.guild.settings.pluck('prefix', 'roles.administrator')
```

No need to type the path to the key twice.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change .pluck and .resolve return type to array

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
