### PR TITLE
Argument#run has incorrect parameter type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -373,7 +373,7 @@ declare module 'klasa' {
 	export abstract class Argument extends AliasPiece {
 		public constructor(client: KlasaClient, store: ArgumentStore, file: string[], directory: string, options?: ArgumentOptions);
 		public aliases: string[];
-		public abstract run(arg: string, possible: Possible, message: KlasaMessage): any;
+		public abstract run(arg: string | undefined, possible: Possible, message: KlasaMessage): any;
 		public static regex: MentionRegex;
 		private static minOrMax(client: KlasaClient, value: number, min: number, max: number, possible: Possible, message: KlasaMessage, suffix: string): boolean;
 	}


### PR DESCRIPTION
### Description of the PR
The `arg` parameter of Argument#run can be undefined, but the typings do not reflect this.

Credit to @bdistin for making me notice this: https://discordapp.com/channels/339942739275677727/339948585325953026/581229018548797454

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change `Argument#run`'s `arg`'s type to `string | undefined`

### Semver Classification

- [X] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
