### PR TITLE
typings: Make Task#run's data field be optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -517,7 +517,7 @@ declare module 'klasa' {
 
 	export abstract class Task extends Piece {
 		public constructor(client: KlasaClient, store: TaskStore, file: string[], directory: string, options?: TaskOptions);
-		public abstract run(data: any): Promise<void>;
+		public abstract run(data?: any): Promise<void>;
 		public toJSON(): PieceTaskJSON;
 	}
 


### PR DESCRIPTION
### Description of the PR
This PR allows using Tasks with no arguments. The typings currently have it set as required.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Make Task.run() optional to pass in a argument

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
