### PR TITLE
Changed `RichDisplayRunOptions.time` docs

### DIFF
--- a/src/lib/util/RichDisplay.js
+++ b/src/lib/util/RichDisplay.js
@@ -28,7 +28,7 @@ class RichDisplay {
 	 * @property {number} [max] The maximum total amount of reactions to collect
 	 * @property {number} [maxEmojis] The maximum number of emojis to collect
 	 * @property {number} [maxUsers] The maximum number of users to react
-	 * @property {number} [time] The maximum amount of time before this RichDisplay should expire
+	 * @property {number} [time] The maximum amount of time in milliseconds before this RichDisplay should expire
 	 */
 
 	/**


### PR DESCRIPTION
### Description of the PR

This PR changes `RichDisplayRunOptions.time` documentation info, adding `in milliseconds` to the info.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Changed `RichDisplayRunOptions.time` documentation info to display the unit of time used.

### Semver Classification

- [X] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
