### PR TITLE
typings: Mark Task#run's return type as unknown

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -517,7 +517,7 @@ declare module 'klasa' {
 
 	export abstract class Task extends Piece {
 		public constructor(client: KlasaClient, store: TaskStore, file: string[], directory: string, options?: TaskOptions);
-		public abstract run(data: any): Promise<unknown>;
+		public abstract run(data: any): unknown;
 		public toJSON(): PieceTaskJSON;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -517,7 +517,7 @@ declare module 'klasa' {
 
 	export abstract class Task extends Piece {
 		public constructor(client: KlasaClient, store: TaskStore, file: string[], directory: string, options?: TaskOptions);
-		public abstract run(data: any): Promise<void>;
+		public abstract run(data: any): Promise<any>;
 		public toJSON(): PieceTaskJSON;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -517,7 +517,7 @@ declare module 'klasa' {
 
 	export abstract class Task extends Piece {
 		public constructor(client: KlasaClient, store: TaskStore, file: string[], directory: string, options?: TaskOptions);
-		public abstract run(data: any): Promise<any>;
+		public abstract run(data: any): Promise<unknown>;
 		public toJSON(): PieceTaskJSON;
 	}
 


### PR DESCRIPTION
### Description of the PR
This PR allows you to return anything from a task. It is really annoying to be forced to return void in tasks. In every one of my files when I want to cancel something I always do `return null` but in the tasks, I am being forced to do `return`. Forcing a return void destroys consistency across my bot.

Also, the fact that I can't just end the task like
```js
return this.client.emit('log', 'x task ran successfully')
```

But instead, have to do
```js
this.client.emit('log', 'x task ran successfully')
return
```

```js
Property 'run' in type 'default' is not assignable to the same property in base type 'Task'.
  Type '() => Promise<boolean | void>' is not assignable to type '(data: any) => Promise<void>'.
    Type 'Promise<boolean | void>' is not assignable to type 'Promise<void>'.
      Type 'boolean | void' is not assignable to type 'void'.
        Type 'false' is not assignable to type 'void'.ts(2416)
```

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Promise<void> => Promise<any>

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
