### PR TITLE
Adding the option to have an object used for command args

### DIFF
--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -79,6 +79,7 @@ class KlasaClient extends Discord.Client {
 	 * @property {number} [slowmode=0] Amount of time in ms before the bot will respond to a users command since the last command that user has run
 	 * @property {boolean} [slowmodeAggressive=false] If the slowmode time should reset if a user spams commands faster than the slowmode allows for
 	 * @property {boolean} [typing=false] Whether the bot should type while processing commands
+	 * @property {boolean} [useObjectCommandArgs=false] Whether the bot should use an object instead of an array for command args
 	 * @property {boolean} [prefixCaseInsensitive=false] Wether the bot should respond to case insensitive prefix or not
 	 */
 


### PR DESCRIPTION
### Description of the PR
This PR allows adding the option to have an object instead of an array as the args passed to commands. 

Current Method:
```js
async run(message, [arg1, arg2, arg3])
```

This is because of the following code in commandHandler
```js
    const commandRun = subcommand ? message.command[subcommand](message, message.params) : message.command.run(message, message.params)
```

An array is passed in which requires decontructing with an array. As an optional choice it would be nice to have the ability to deconstruct objects instead.

```ts
async run(message, { arg1, arg3 }) {
// Notice how i no longer need to deconstruct arg2 in this subcommand
// This would also make it better for TS users so they can do

{ arg1: Type, arg3: Type} 

// Instead of
[arg1, _arg2, arg3]: [Type, undefined, Type]
}
```

Another benefit is you would no longer need to worry about order.

**Note:** It is also possible to do this through a commandOption instead of a clientOption so you can chose either or. I personally chose the clientOption but this can be done with whichever method you believe is best.

P.S. This does not break any current Klasa code but simply adds a option that users could enable if they want it kinda like `commandEditing`

Tested Usage:
`[menu:string] [number:number|reason:string] [args:string] [...]`

Command Ran:
`,settings prefix 5 !`

Result:
```js
{ menu: 'prefix', number: 5, reason: 5, args: '!' }
```

**Note:** Literal arguments will be done will use the literal argument itself. So for example if your usage has a literal like `<this|that>` and someone passes this you will get `{ this: 'this' }`


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Adds option to have objects in command args

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
