### PR TITLE
prevent duplicate aliases (settings banch)

### DIFF
--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -56,8 +56,8 @@ class Command extends AliasPiece {
 		this.name = this.name.toLowerCase();
 
 		if (options.autoAliases) {
-			if (this.name.includes('-')) this.aliases.push(this.name.replace(/-/g, ''));
-			for (const alias of this.aliases) if (alias.includes('-')) this.aliases.push(alias.replace(/-/g, ''));
+			if (this.name.includes('-') && !this.aliases.includes(this.name.replace(/-/g, ''))) this.aliases.push(this.name.replace(/-/g, ''));
+			for (const alias of this.aliases) if (alias.includes('-') && !this.aliases.includes(alias.replace(/-/g, ''))) this.aliases.push(alias.replace(/-/g, ''));
 		}
 
 		/**


### PR DESCRIPTION
### Description of the PR
Added a check to the autoAliases method to prevent aliases from being added if it is already present in the aliases array. Possibly added by the user manually or if you have aliases like `this-is-an-example`, `this-isan-example`, `thisisan-example` which would normally end up changing them all to `thisisanexample` and adding them to the aliases array.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
