### PR TITLE
misc: Freeze all objects from Settings

### DIFF
--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -435,7 +435,7 @@ class SettingsFolder extends Map {
 
 			// Patch recursively if the key is a folder, set otherwise
 			if (subkey instanceof SettingsFolder) subkey._patch(value);
-			else super.set(key, value);
+			else super.set(key, Object.freeze(value));
 		}
 	}
 

--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -1,4 +1,4 @@
-const { isObject, objectToTuples, arraysStrictEquals, toTitleCase, mergeObjects, makeObject, resolveGuild } = require('../util/util');
+const { isObject, objectToTuples, arraysStrictEquals, toTitleCase, mergeObjects, makeObject, resolveGuild, deepFreeze } = require('../util/util');
 const Type = require('../util/Type');
 
 /**
@@ -435,7 +435,7 @@ class SettingsFolder extends Map {
 
 			// Patch recursively if the key is a folder, set otherwise
 			if (subkey instanceof SettingsFolder) subkey._patch(value);
-			else super.set(key, Object.freeze(value));
+			else super.set(key, deepFreeze(value));
 		}
 	}
 

--- a/src/lib/settings/schema/SchemaEntry.js
+++ b/src/lib/settings/schema/SchemaEntry.js
@@ -1,4 +1,4 @@
-const { isFunction, isNumber } = require('../../util/util');
+const { isFunction, isNumber, deepFreeze } = require('../../util/util');
 
 /**
  * The SchemaEntry class that stores the metadata for an entry from the schema
@@ -86,7 +86,7 @@ class SchemaEntry {
 		 * @since 0.5.0
 		 * @type {*}
 		 */
-		this.default = 'default' in options ? Object.freeze(options.default) : this._generateDefault();
+		this.default = 'default' in options ? deepFreeze(options.default) : this._generateDefault();
 
 		/**
 		 * The minimum value for this key.
@@ -152,7 +152,7 @@ class SchemaEntry {
 		if ('array' in options) this.array = options.array;
 		if ('configurable' in options) this.configurable = options.configurable;
 		if ('filter' in options) this.filter = options.filter;
-		if ('default' in options) this.default = Object.freeze(options.default);
+		if ('default' in options) this.default = deepFreeze(options.default);
 		if (('min' in options) || ('max' in options)) {
 			const { min = null, max = null } = options;
 			this.min = min;

--- a/src/lib/settings/schema/SchemaEntry.js
+++ b/src/lib/settings/schema/SchemaEntry.js
@@ -86,7 +86,7 @@ class SchemaEntry {
 		 * @since 0.5.0
 		 * @type {*}
 		 */
-		this.default = 'default' in options ? options.default : this._generateDefault();
+		this.default = 'default' in options ? Object.freeze(options.default) : this._generateDefault();
 
 		/**
 		 * The minimum value for this key.
@@ -152,7 +152,7 @@ class SchemaEntry {
 		if ('array' in options) this.array = options.array;
 		if ('configurable' in options) this.configurable = options.configurable;
 		if ('filter' in options) this.filter = options.filter;
-		if ('default' in options) this.default = options.default;
+		if ('default' in options) this.default = Object.freeze(options.default);
 		if (('min' in options) || ('max' in options)) {
 			const { min = null, max = null } = options;
 			this.min = min;

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -142,6 +142,26 @@ class Util {
 	}
 
 	/**
+	 * Deep freeze a value
+	 * @since 0.5.0
+	 * @param {*} source The object to freeze
+	 * @returns {Readonly<*>}
+	 */
+	static deepFreeze(source) {
+		if (typeof source === 'object' && source !== null) {
+			Object.freeze(source);
+			if (Array.isArray(source)) {
+				for (const value of source) Util.deepFreeze(value);
+			} else {
+				for (const value of Object.values(source)) {
+					Util.deepFreeze(value);
+				}
+			}
+		}
+		return source;
+	}
+
+	/**
 	 * Verify if the input is a function.
 	 * @since 0.5.0
 	 * @param {*} input The function to verify

--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -152,10 +152,12 @@ class Util {
 			Object.freeze(source);
 			if (Array.isArray(source)) {
 				for (const value of source) Util.deepFreeze(value);
+			} else if (source instanceof Map) {
+				for (const value of source.values()) Util.deepFreeze(value);
+			} else if (source instanceof Set) {
+				for (const value of source) Util.deepFreeze(value);
 			} else {
-				for (const value of Object.values(source)) {
-					Util.deepFreeze(value);
-				}
+				for (const value of Object.values(source)) Util.deepFreeze(value);
 			}
 		}
 		return source;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -223,7 +223,7 @@ declare module 'klasa' {
 //#region Settings
 
 
-	export class SettingsFolder extends Map<string, SettingsFolder | SettingsValue | readonly SettingsValue[]> {
+	export class SettingsFolder extends Map<string, SettingsFolder | DeepFrozen<SettingsValue | SettingsValue[]>> {
 		public constructor(schema: SchemaFolder);
 		public readonly schema: SchemaFolder;
 		public readonly base: Settings | null;
@@ -237,7 +237,7 @@ declare module 'klasa' {
 		public display(message: KlasaMessage, path?: string | Schema | SchemaFolder | SchemaEntry): string;
 		public pluck(...paths: readonly string[]): any[];
 		public resolve(...paths: readonly string[]): Promise<any[]>;
-		public toJSON(): Readonly<Record<string, SettingsValue>>;
+		public toJSON(): Record<string, DeepFrozen<SettingsValue | SettingsValue[]>>;
 		public toString(): string;
 		private relative(pathOrPiece: string | Schema | SchemaEntry): string;
 		private _save(results: Array<SettingsFolderUpdateResultEntry>): Promise<void>;
@@ -994,7 +994,7 @@ declare module 'klasa' {
 		public static clean(text: string): string;
 		public static codeBlock(lang: string, expression: string | number | Stringifible): string;
 		public static deepClone<T = any>(source: T): T;
-		public static deepFreeze<T = any>(source: T): Readonly<T>;
+		public static deepFreeze<T = any>(source: T): DeepFrozen<T>;
 		public static exec(exec: string, options?: ExecOptions): Promise<{ stdout: string, stderr: string }>;
 		public static getTypeName(input: any): string;
 		public static isClass(input: any): input is Constructor<any>;
@@ -1645,6 +1645,17 @@ declare module 'klasa' {
 	type Filter<T, K extends keyof T> = {
 		[P in keyof T]: P extends K ? unknown : T[P];
 	};
+
+	type DeepFrozen<T> = T extends object ?
+		T extends Array<infer AT> ? DeepFrozenArray<AT> :
+			T extends Map<infer MK, infer MV> ? DeepFrozenMap<MK, MV> :
+				T extends Set<infer ST> ? DeepFrozenSet<ST> :
+					{ readonly [K in keyof T]: DeepFrozen<T[K]>; } : T;
+
+	type Box<T> = T;
+	interface DeepFrozenArray<T> extends Box<readonly DeepFrozen<T>[]> { }
+	interface DeepFrozenMap<K, V> extends Map<K, DeepFrozen<V>> { }
+	interface DeepFrozenSet<T> extends Set<DeepFrozen<T>> { }
 
 	export interface TitleCaseVariants extends Record<string, string> {
 		textchannel: 'TextChannel';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1646,7 +1646,7 @@ declare module 'klasa' {
 		[P in keyof T]: P extends K ? unknown : T[P];
 	};
 
-	type DeepFrozen<T> = T extends object ?
+	export type DeepFrozen<T> = T extends object ?
 		T extends Array<infer AT> ? DeepFrozenArray<AT> :
 			T extends Map<infer MK, infer MV> ? DeepFrozenMap<MK, MV> :
 				T extends Set<infer ST> ? DeepFrozenSet<ST> :

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -994,6 +994,7 @@ declare module 'klasa' {
 		public static clean(text: string): string;
 		public static codeBlock(lang: string, expression: string | number | Stringifible): string;
 		public static deepClone<T = any>(source: T): T;
+		public static deepFreeze<T = any>(source: T): Readonly<T>;
 		public static exec(exec: string, options?: ExecOptions): Promise<{ stdout: string, stderr: string }>;
 		public static getTypeName(input: any): string;
 		public static isClass(input: any): input is Constructor<any>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1652,10 +1652,9 @@ declare module 'klasa' {
 				T extends Set<infer ST> ? DeepFrozenSet<ST> :
 					{ readonly [K in keyof T]: DeepFrozen<T[K]>; } : T;
 
-	type Box<T> = T;
-	interface DeepFrozenArray<T> extends Box<readonly DeepFrozen<T>[]> { }
-	interface DeepFrozenMap<K, V> extends Map<K, DeepFrozen<V>> { }
-	interface DeepFrozenSet<T> extends Set<DeepFrozen<T>> { }
+	interface DeepFrozenArray<T> extends ReadonlyArray<DeepFrozen<T>> { }
+	interface DeepFrozenMap<K, V> extends ReadonlyMap<K, DeepFrozen<V>> { }
+	interface DeepFrozenSet<T> extends ReadonlySet<DeepFrozen<T>> { }
 
 	export interface TitleCaseVariants extends Record<string, string> {
 		textchannel: 'TextChannel';


### PR DESCRIPTION
### Description of the PR

TypeScript's hints weren't enough, so let's get the `readonly` into the real world.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Freeze absolutely all objects cached from SG.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
