### PR TITLE
Added a replyLocale method to KlasaMessage

### DIFF
--- a/src/extendables/SendAliases.js
+++ b/src/extendables/SendAliases.js
@@ -28,6 +28,12 @@ module.exports = class extends Extendable {
 		const language = this.guild ? this.guild.language : this.client.languages.default;
 		return this.send(APIMessage.transformOptions(language.get(key, ...args), undefined, options));
 	}
+	
+	replyLocale(key, args = [], options = {}) {
+		if (!Array.isArray(args)) [options, args] = [args, []];
+		const language = this.guild ? this.guild.language : this.client.languages.default;
+		return this.send(APIMessage.transformOptions(language.get(key, ...args), options, { reply: this.member || this.author }));
+	}
 
 	sendMessage(content, options) {
 		return this.send(content, options);

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -251,6 +251,11 @@ module.exports = Structures.extend('Message', Message => {
 			if (!Array.isArray(localeArgs)) [options, localeArgs] = [localeArgs, []];
 			return this.sendMessage(APIMessage.transformOptions(this.language.get(key, ...localeArgs), undefined, options));
 		}
+		
+		replyLocale(key, localeArgs = [], options = {}) {
+			if (!Array.isArray(localeArgs)) [options, localeArgs] = [localeArgs, []];
+			return this.sendMessage(APIMessage.transformOptions(this.language.get(key, ...localeArgs), options, { reply: this.member || this.author }));
+		}
 
 		/**
 		 * Since d.js is dumb and has 2 patch methods, this is for edits

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -252,6 +252,14 @@ module.exports = Structures.extend('Message', Message => {
 			return this.sendMessage(APIMessage.transformOptions(this.language.get(key, ...localeArgs), undefined, options));
 		}
 		
+		/**
+		 * Sends a message with a mention of the user who sent the message that will be editable via command editing (if nothing is attached)
+		 * @since 0.5.0
+		 * @param {string} key The Language key to send
+		 * @param {Array<*>} [localeArgs] The language arguments to pass
+		 * @param {external:MessageOptions} [options] The D.JS message options plus Language arguments
+		 * @returns {Promise<KlasaMessage|KlasaMessage[]>}
+		 */
 		replyLocale(key, localeArgs = [], options = {}) {
 			if (!Array.isArray(localeArgs)) [options, localeArgs] = [localeArgs, []];
 			return this.sendMessage(APIMessage.transformOptions(this.language.get(key, ...localeArgs), options, { reply: this.member || this.author }));


### PR DESCRIPTION
### Description of the PR
I added a replyLocale method to KlasaMessage which will be useful instead of doing `message.reply(message.language.get('KEY'))` or `message.sendLocale('KEY', { reply: msg.author })` you can now do `message.replyLocale('KEY')`

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
