### PR TITLE
Fix cooldown response

### DIFF
--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -11,7 +11,7 @@ module.exports = class extends Inhibitor {
 
 		const existing = command.cooldowns.get(message.levelID);
 
-		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Math.ceil(existing.remainingTime / 1000), command.cooldownLevel === 'guild');
+		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Math.ceil(existing.remainingTime / 1000), command.cooldownLevel !== 'author');
 	}
 
 };

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -11,7 +11,7 @@ module.exports = class extends Inhibitor {
 
 		const existing = command.cooldowns.get(message.levelID);
 
-		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Math.ceil(existing.remainingTime / 1000));
+		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Math.ceil(existing.remainingTime / 1000), command.cooldownLevel === 'guild');
 	}
 
 };

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -54,7 +54,7 @@ module.exports = class extends Language {
 			// eslint-disable-next-line max-len
 			MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT: (tag, name, time, cancelOptions) => `${tag} | **${name}** is a repeating argument | You have **${time}** seconds to respond to this prompt with additional valid arguments. Type **${cancelOptions.join('**, **')}** to cancel this prompt.`,
 			MONITOR_COMMAND_HANDLER_ABORTED: 'Aborted',
-			INHIBITOR_COOLDOWN: (remaining) => `You have just used this command. You can use this command again in ${remaining} second${remaining === 1 ? '' : 's'}.`,
+			INHIBITOR_COOLDOWN: (remaining, guildCooldown) => `${guildCooldown ? 'Someone has' : 'You have'} already used this command. You can use this command again in ${remaining} second${remaining === 1 ? '' : 's'}.`,
 			INHIBITOR_DISABLED_GUILD: 'This command has been disabled by an admin in this guild.',
 			INHIBITOR_DISABLED_GLOBAL: 'This command has been globally disabled by the bot owner.',
 			INHIBITOR_MISSING_BOT_PERMS: (missing) => `Insufficient permissions, missing: **${missing}**`,

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -54,6 +54,7 @@ module.exports = class extends Language {
 			// eslint-disable-next-line max-len
 			MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT: (tag, name, time, cancelOptions) => `${tag} | **${name}** is a repeating argument | You have **${time}** seconds to respond to this prompt with additional valid arguments. Type **${cancelOptions.join('**, **')}** to cancel this prompt.`,
 			MONITOR_COMMAND_HANDLER_ABORTED: 'Aborted',
+			// eslint-disable-next-line max-len
 			INHIBITOR_COOLDOWN: (remaining, guildCooldown) => `${guildCooldown ? 'Someone has' : 'You have'} already used this command. You can use this command again in ${remaining} second${remaining === 1 ? '' : 's'}.`,
 			INHIBITOR_DISABLED_GUILD: 'This command has been disabled by an admin in this guild.',
 			INHIBITOR_DISABLED_GLOBAL: 'This command has been globally disabled by the bot owner.',


### PR DESCRIPTION
### Description of the PR
This PR fixes the response of the cooldown inhibitor when the cooldown level is for a guild. At the moment, it always responds saying **you** as opposed to someone even if someone else used that command. It also changes the word `just` => `already`. In case, commands that have long cooldowns like 24 hours, this can be extremely confusing making users think something is wrong because they did not JUST use it.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fix inhibitor cooldown response

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
