### PR TITLE
Update index.d.ts

### DIFF
--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -162,7 +162,7 @@ class TextPrompt {
 	/**
 	 * Runs the custom prompt.
 	 * @since 0.5.0
-	 * @param {string} prompt The message to initially prompt with
+	 * @param {StringResolvable | MessageOptions | MessageAdditions | APIMessage} prompt The message to initially prompt with
 	 * @returns {any[]} The parameters resolved
 	 */
 	async run(prompt) {
@@ -174,7 +174,7 @@ class TextPrompt {
 
 	/**
 	 * Prompts the target for a response
-	 * @param {string} text The text to prompt
+	 * @param {StringResolvable | MessageOptions | MessageAdditions | APIMessage} text The text to prompt
 	 * @returns {KlasaMessage}
 	 * @private
 	 */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -675,7 +675,7 @@ declare module 'klasa' {
 		private _prompted: number;
 		private _currentUsage: Tag;
 
-		public run<T = any[]>(prompt: string | MessageEmbed): Promise<T>;
+		public run<T = any[]>(prompt: StringResolvable | MessageOptions | MessageAdditions | APIMessage): Promise<T>;
 		private prompt(text: string): Promise<KlasaMessage>;
 		private reprompt(prompt: string): Promise<any[]>;
 		private repeatingPrompt(): Promise<any[]>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,6 +3,7 @@ declare module 'klasa' {
 	import { ExecOptions } from 'child_process';
 
 	import {
+		APIMessage,
 		BufferResolvable,
 		CategoryChannel,
 		Channel,
@@ -19,6 +20,7 @@ declare module 'klasa' {
 		GuildEmoji,
 		GuildMember,
 		Message,
+		MessageAdditions,
 		MessageAttachment,
 		MessageCollector,
 		MessageEmbed,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -675,7 +675,7 @@ declare module 'klasa' {
 		private _prompted: number;
 		private _currentUsage: Tag;
 
-		public run<T = any[]>(prompt: string): Promise<T>;
+		public run<T = any[]>(prompt: string | MessageEmbed): Promise<T>;
 		private prompt(text: string): Promise<KlasaMessage>;
 		private reprompt(prompt: string): Promise<any[]>;
 		private repeatingPrompt(): Promise<any[]>;


### PR DESCRIPTION
### Description of the PR
This PR allows passing an embed to TextPrompt.run() for Typescript users. At the moment, it only accepts a string.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Support embeds in TextPrompt.run()

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
