### PR TITLE
add null to usageDelim typings

### DIFF
--- a/src/commands/Admin/eval.js
+++ b/src/commands/Admin/eval.js
@@ -10,7 +10,8 @@ module.exports = class extends Command {
 			guarded: true,
 			description: language => language.get('COMMAND_EVAL_DESCRIPTION'),
 			extendedHelp: language => language.get('COMMAND_EVAL_EXTENDEDHELP'),
-			usage: '<expression:str>'
+			usage: '<expression:str>',
+			usageDelim: null
 		});
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -396,7 +396,7 @@ declare module 'klasa' {
 		public readonly category: string;
 		public readonly cooldown: number;
 		public readonly subCategory: string;
-		public readonly usageDelim: string;
+		public readonly usageDelim: string | null;
 		public readonly usageString: string;
 		public aliases: string[];
 		public requiredPermissions: Permissions;
@@ -622,7 +622,7 @@ declare module 'klasa' {
 	}
 
 	export class CommandUsage extends Usage {
-		public constructor(client: KlasaClient, usageString: string, usageDelim: string, command: Command);
+		public constructor(client: KlasaClient, usageString: string, usageDelim: string | null, command: Command);
 		public names: string[];
 		public commands: string;
 		public nearlyFullUsage: string;
@@ -694,11 +694,11 @@ declare module 'klasa' {
 	}
 
 	export class Usage {
-		public constructor(client: KlasaClient, usageString: string, usageDelim: string);
+		public constructor(client: KlasaClient, usageString: string, usageDelim: string | null);
 		public readonly client: KlasaClient;
 		public deliminatedUsage: string;
 		public usageString: string;
-		public usageDelim: string;
+		public usageDelim: string | null;
 		public parsedUsage: Tag[];
 		public customResolvers: Record<string, ArgResolverCustomMethod>;
 
@@ -1373,7 +1373,7 @@ declare module 'klasa' {
 		requiredPermissions: string[];
 		usage: {
 			usageString: string;
-			usageDelim: string;
+			usageDelim: string | null;
 			nearlyFullUsage: string;
 		};
 	}


### PR DESCRIPTION
### Description of the PR
Adds `null` as a valid usageDelim type.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Add null to usage delim typings
- Changes `usageDelim` in eval command to be `null`

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
