### PR TITLE
Settings Map/Set Implementation

### DIFF
--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -1,4 +1,5 @@
 const { isObject, objectToTuples, arraysStrictEquals, toTitleCase, mergeObjects, makeObject, resolveGuild } = require('../util/util');
+const SettingsArray = require('./group/SettingsArray');
 const Type = require('../util/Type');
 
 /**
@@ -434,7 +435,7 @@ class SettingsFolder extends Map {
 			if (typeof subkey === 'undefined') continue;
 
 			// Patch recursively if the key is a folder, set otherwise
-			if (subkey instanceof SettingsFolder) subkey._patch(value);
+			if (subkey instanceof SettingsFolder || subkey instanceof SettingsArray) subkey._patch(value);
 			else super.set(key, value);
 		}
 	}
@@ -484,6 +485,10 @@ class SettingsFolder extends Map {
 				const settings = new SettingsFolder(value);
 				folder.set(key, settings);
 				this.init(settings, value);
+			} else if (value.array) {
+				const sArray = new SettingsArray(value);
+				sArray.base = this;
+				folder.set(key, sArray);
 			} else {
 				folder.set(key, value.default);
 			}

--- a/src/lib/settings/group/GroupBase.js
+++ b/src/lib/settings/group/GroupBase.js
@@ -1,0 +1,48 @@
+class GroupBase {
+
+	constructor(entry) {
+		Object.defineProperty(this, 'base', { value: null, writable: true });
+
+		// The Entry this SettingArray refers to
+		Object.defineProperty(this, 'entry', { value: entry });
+
+		this.data = entry.default;
+	}
+
+	get gateway() {
+		return this.base.gateway;
+	}
+
+	async _save(results) {
+		const status = this.base.existenceStatus;
+		if (status === null) throw new Error('Cannot update out of sync.');
+
+		// Update DB
+
+		this._patch(results[0].value);
+	}
+
+	*keys() {
+		yield* this.data.keys();
+	}
+
+	*values() {
+		yield* this.data.values();
+	}
+
+	*entries() {
+		yield* this.data.entries();
+	}
+
+	*[Symbol.iterator]() {
+		yield* this.data[Symbol.iterator]();
+	}
+
+	// This should work fine in all 3 cases
+	toJSON() {
+		return [...this[Symbol.iterator]()];
+	}
+
+}
+
+module.exports = GroupBase;

--- a/src/lib/settings/group/GroupBase.js
+++ b/src/lib/settings/group/GroupBase.js
@@ -1,18 +1,88 @@
+/**
+ * The base class for group structs
+ */
 class GroupBase {
 
+	/**
+	 * @since 0.5.0
+	 * @param {SchemaEntry} entry The schema entry that manages this instance
+	 */
 	constructor(entry) {
+		/**
+		 * The base that owns this instance's data
+		 * @since 0.5.0
+		 * @name GroupBase#base
+		 * @type {?Settings}
+		 */
 		Object.defineProperty(this, 'base', { value: null, writable: true });
 
-		// The Entry this SettingArray refers to
+		/**
+		 * The schema entry that manage this instance's metadata
+		 * @since 0.5.0
+		 * @name GroupBase#entry
+		 * @type {SchemaEntry}
+		 * @readonly
+		 */
 		Object.defineProperty(this, 'entry', { value: entry });
 
+		/**
+		 * The data this instance holds, it is initially initialized as the schema entry's default
+		 * @since 0.5.0
+		 * @type {*}
+		 */
 		this.data = entry.default;
 	}
 
+	/**
+	 * The gateway that manages this instance's table
+	 * @since 0.5.0
+	 * @type {Gateway}
+	 * @readonly
+	 */
 	get gateway() {
 		return this.base.gateway;
 	}
 
+	/**
+	 * The get method to be overwritten
+	 * @since 0.5.0
+	 * @param {*} key The key to be retrieved
+	 * @abstract
+	 */
+	get() {
+		// Defined in extension Classes
+		throw new Error(`[GroupBase] Missing method 'update' of ${this.constructor.name}`);
+	}
+
+	/**
+	 * The update method to be overwritten
+	 * @since 0.5.0
+	 * @param {...*} param The parameters to be passed
+	 * @abstract
+	 */
+	update() {
+		// Defined in extension Classes
+		throw new Error(`[GroupBase] Missing method 'update' of ${this.constructor.name}`);
+	}
+
+	/**
+	 * The _patch method to be overwritten
+	 * @since 0.5.0
+	 * @param {*} param The value to be updated
+	 * @protected
+	 * @abstract
+	 */
+	_patch() {
+		// Defined in extension Classes
+		throw new Error(`[GroupBase] Missing method 'update' of ${this.constructor.name}`);
+	}
+
+	/**
+	 * Save the data to the database and patch the data.
+	 * @since 0.5.0
+	 * @param {Array<any[]>} results The data to save
+	 * @protected
+	 */
 	async _save(results) {
 		const status = this.base.existenceStatus;
 		if (status === null) throw new Error('Cannot update out of sync.');
@@ -22,23 +92,52 @@ class GroupBase {
 		this._patch(results[0].value);
 	}
 
+	/**
+	 * Returns a new Iterator object that contains the keys for each element contained in this group.
+	 * Similar to [Map#keys()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys)
+	 * @since 0.5.0
+	 * @yields {*}
+	 */
 	*keys() {
 		yield* this.data.keys();
 	}
 
+	/**
+	 * Returns a new Iterator object that contains the values for each element contained in this group.
+	 * Similar to [Map#values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values)
+	 * @since 0.5.0
+	 * @yields {*}
+	 */
 	*values() {
 		yield* this.data.values();
 	}
 
+	/**
+	 * Returns a new Iterator object that contains the entries for each element contained in this group.
+	 * Similar to [Map#entries()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries)
+	 * @since 0.5.0
+	 * @yields {*}
+	 */
 	*entries() {
 		yield* this.data.entries();
 	}
 
+	/**
+	 * Returns a new Iterator object that contains the keys for each element contained in this group.
+	 * Similar to [Map#[@@iterator]](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator)
+	 * or to [Array#[@@iterator]](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)
+	 * @since 0.5.0
+	 * @yields {*}
+	 */
 	*[Symbol.iterator]() {
 		yield* this.data[Symbol.iterator]();
 	}
 
-	// This should work fine in all 3 cases
+	/**
+	 * The serializable JSON array for storage in the database, it uses {@link GroupBase}'s `Symbol.iterator`.
+	 * @since 0.5.0
+	 * @returns {Array<*[]>}
+	 */
 	toJSON() {
 		return [...this[Symbol.iterator]()];
 	}

--- a/src/lib/settings/group/GroupBase.js
+++ b/src/lib/settings/group/GroupBase.js
@@ -136,7 +136,7 @@ class GroupBase {
 	/**
 	 * The serializable JSON array for storage in the database, it uses {@link GroupBase}'s `Symbol.iterator`.
 	 * @since 0.5.0
-	 * @returns {Array<*[]>}
+	 * @returns {Array<any[]>}
 	 */
 	toJSON() {
 		return [...this[Symbol.iterator]()];

--- a/src/lib/settings/group/SettingsArray.js
+++ b/src/lib/settings/group/SettingsArray.js
@@ -1,4 +1,4 @@
-const { resolveGuild, arraysStrictEquals, mergeObjects, makeObject } = require('../../util/util');
+const { resolveGuild, arraysStrictEquals } = require('../../util/util');
 
 const checkForIndex = (value) => Array.isArray(value) && value.length === 2 && typeof value[0] === 'number';
 

--- a/src/lib/settings/group/SettingsArray.js
+++ b/src/lib/settings/group/SettingsArray.js
@@ -85,7 +85,7 @@ class SettingsArray {
 				if (clone.length === 0 && index > 0) {
 					errors.push({ input: val, message: 'The current array is empty. The index must start at 0.' });
 				} else if (index < 0 || index > clone.length + 1) {
-					errors.push({ input: val, message: `The index ${index} is bigger than the current array. It must be a value in the range of 0..${clone.length + 1}.` });
+					errors.push({ input: val, message: `The index "${index}" is bigger than the current array. It must be a value in the range of 0..${clone.length}.` });
 				} else {
 					clone[index] = value;
 				}
@@ -98,13 +98,13 @@ class SettingsArray {
 			}
 		} else if (action.toLowerCase() === 'add') {
 			for (const val of values) {
-				if (clone.includes(val)) errors.push({ input: val, message: `The value ${val} for the key ${entry.path} already exists.` });
+				if (clone.includes(val)) errors.push({ input: val, message: `The value "${val}" for the key "${entry.path}" already exists.` });
 				else clone.push(val);
 			}
 		} else if (action.toLowerCase() === 'remove') {
 			for (const val of values) {
 				const index = clone.indexOf(val);
-				if (index === -1) errors.push({ input: val, message: `The value ${val} for the key ${entry.path} does not exist.` });
+				if (index === -1) errors.push({ input: val, message: `The value "${val}" for the key "${entry.path}" does not exist.` });
 				else clone.splice(index, 1);
 			}
 		} else {
@@ -143,7 +143,7 @@ class SettingsArray {
 	}
 
 	*entries() {
-		yield* this.data.values();
+		yield* this.data.entries();
 	}
 
 	*[Symbol.iterator]() {

--- a/src/lib/settings/group/SettingsArray.js
+++ b/src/lib/settings/group/SettingsArray.js
@@ -61,7 +61,7 @@ class SettingsArray {
 		} else values = await Promise.all(values.map(async val => serialize(await entry.parse(val, guild))));
 
 		const { action = 'auto' } = options;
-		if (!indexing && action === 'overwrite') return values;
+		if (!indexing && action.toLowerCase() === 'overwrite') return values;
 
 		const clone = this.get();
 
@@ -71,33 +71,32 @@ class SettingsArray {
 		// This value has an index paired with it
 		if (indexing) {
 			for (const val of values) {
-				let index = val[0];
+				let [index, value] = val;
 				if (clone.length === 0 && index > 0) {
 					errors.push({ input: val, message: 'The current array is empty. The index must start at 0.' });
 				} else if (index < 0 || index > clone.length + 1) {
 					errors.push({ input: val, message: `The index ${index} is bigger than the current array. It must be a value in the range of 0..${clone.length + 1}.` });
-				}
-				clone[index] = val[1];
+				} else clone[index] = value;
 			}
-		} else if (action === 'auto') {
+		} else if (action.toLowerCase() === 'auto') {
 			for (const val of values) {
 				const index = clone.indexOf(val);
 				if (index === -1) clone.push(val);
 				else clone.splice(index, 1)
 			}
-		} else if (action === 'add') {
+		} else if (action.toLowerCase() === 'add') {
 			for (const val of values) {
 				if (clone.includes(val)) errors.push({ input: val, message: `The value ${val} for the key ${entry.path} already exists.` });
 				else clone.push(val);
 			}
-		} else if (action === 'remove') {
+		} else if (action.toLowerCase() === 'remove') {
 			for (const val of values) {
 				const index = clone.indexOf(val);
 				if (index === -1) errors.push({ input: val, message: `The value ${val} for the key ${entry.path} does not exist.` });
 				else clone.splice(index, 1);
 			}
 		} else {
-			throw `The ${action} array action is not a valid SettingsUpdateArrayAction.`;
+			throw `The "${action}" array action is not a valid SettingsUpdateArrayAction.`;
 		}
 
 		return { errors, clone };

--- a/src/lib/settings/group/SettingsArray.js
+++ b/src/lib/settings/group/SettingsArray.js
@@ -1,4 +1,5 @@
-const { resolveGuild, arraysStrictEquals } = require('../../util/util');
+const { resolveGuild, arraysStrictEquals, isNumber } = require('../../util/util');
+const Type = require('../../util/Type');
 
 const checkForIndex = (value) => Array.isArray(value) && value.length === 2 && typeof value[0] === 'number';
 
@@ -19,13 +20,18 @@ class SettingsArray {
 
 	get(index) {
 		if (index !== undefined && index !== null) {
-			return this.data[index];
+			if (isNumber(index)) return this.data[index];
+			throw new TypeError(`The value for index must be of type 'number'. Got: ${new Type(index)}`);
 		}
 		return this.data.slice();
 	}
 
 	includes(value) {
 		return this.data.includes(value);
+	}
+
+	find(...args) {
+		return this.data.slice().find(...args);
 	}
 
 	async update(values, options) {
@@ -126,6 +132,22 @@ class SettingsArray {
 		// Will probably be removed for a better option of only patching indexes that are updated or if new values are added (which would be denoted by index === -1)
 		// For now, this will suffice
 		this.data = [...data];
+	}
+
+	*keys() {
+		yield* this.data.keys();
+	}
+
+	*values() {
+		yield* this.data.values();
+	}
+
+	*entries() {
+		yield* this.data.values();
+	}
+
+	*[Symbol.iterator]() {
+		yield* this.values();
 	}
 
 }

--- a/src/lib/settings/group/SettingsArray.js
+++ b/src/lib/settings/group/SettingsArray.js
@@ -3,113 +3,113 @@ const { resolveGuild, arraysStrictEquals, mergeObjects, makeObject } = require('
 const checkForIndex = (value) => Array.isArray(value) && value.length === 2 && typeof value[0] === 'number';
 
 class SettingsArray {
-    constructor(entry) {
-        Object.defineProperty(this, 'base', { value: null, writable: true });
-        
-        // The Entry this SettingArray refers to
-        Object.defineProperty(this, 'entry', { value: entry });
+	constructor(entry) {
+		Object.defineProperty(this, 'base', { value: null, writable: true });
+		
+		// The Entry this SettingArray refers to
+		Object.defineProperty(this, 'entry', { value: entry });
 
-        // The Cached data
-        Object.defineProperty(this, 'data', { value: entry.default, enumerable: true, writable: true });
-    }
+		// The Cached data
+		Object.defineProperty(this, 'data', { value: entry.default, enumerable: true, writable: true });
+	}
 
-    get gateway() {
-        return this.base.gateway;
-    }
+	get gateway() {
+		return this.base.gateway;
+	}
 
-    get(index) {
-        if (index !== undefined && index !== null) {
+	get(index) {
+		if (index !== undefined && index !== null) {
 
-        }
-        return this.data.slice();
-    }
+		}
+		return this.data.slice();
+	}
 
-    includes(value) {
-        return this.data.slice().includes(value);
-    }
+	includes(value) {
+		return this.data.slice().includes(value);
+	}
 
-    async update(values, options) {
-        if (!options) options = { throwOnError: false, indexing: false };
+	async update(values, options) {
+		if (!options) options = { throwOnError: false, indexing: false };
 		options.guild = resolveGuild(this.base.gateway.client, 'guild' in options ? options.guild : this.base.target);
-        const language = options.guild ? options.guild.language : this.base.gateway.client.languages.default;
+		const language = options.guild ? options.guild.language : this.base.gateway.client.languages.default;
 
-        if (!Array.isArray(values)) values = [values];
+		if (!Array.isArray(values)) values = [values];
 
-        const errors = [];     
-        let promise = null;
-        const { entry } = this;
-        
-        const onError = options.throwOnError ? (error) => { throw error; } : (error) => errors.push(error);
+		const errors = [];     
+		let promise = null;
+		const { entry } = this;
+		
+		const onError = options.throwOnError ? (error) => { throw error; } : (error) => errors.push(error);
 
-        const previous = this.get();
+		const previous = this.get();
 
-        try {
-            // Not sure of a better way to do this, come back at a later time
-            if (values.some(checkForIndex)) {
-                if (!(values.every(checkForIndex))) throw "Indexing found. You must only use straight indexing or no indexing, not a mixture of both.";
-                options.indexing = true;
-            }
-            promise = this._parse(entry, previous, values, options)
-                .catch(onError);
-        } catch (error) {
-            if (options.throwOnError) throw error;
-            errors.push(error);
-        }
+		try {
+			// Not sure of a better way to do this, come back at a later time
+			if (values.some(checkForIndex)) {
+				if (!(values.every(checkForIndex))) throw "Indexing found. You must only use straight indexing or no indexing, not a mixture of both.";
+				options.indexing = true;
+			}
+			promise = this._parse(entry, previous, values, options)
+				.catch(onError);
+		} catch (error) {
+			if (options.throwOnError) throw error;
+			errors.push(error);
+		}
 
-        // Has to be run before to actually catch errors, future error handling will be shoved into _parse() to actually reflect the individual values that error,
-        // rather then just throwing the first error to the top and disgarding the rest
-        const current = await promise;
+		// Has to be run before to actually catch errors, future error handling will be shoved into _parse() to actually reflect the individual values that error,
+		// rather then just throwing the first error to the top and disgarding the rest
+		const current = await promise;
 
-        if (errors.length) return { errors, updated: [] };
+		if (errors.length) return { errors, updated: [] };
 
-        // The arrays were already equal.
-        if (arraysStrictEquals(current, previous)) return;
+		// The arrays were already equal.
+		if (arraysStrictEquals(current, previous)) return;
 
-        const result = [{ key: entry.path, value: current, entry }];
-        
-        // Save to Cache and DB
-        this._save(result);
-        
-        return { errors, updated: result };
-    }
+		const result = [{ key: entry.path, value: current, entry }];
+		
+		// Save to Cache and DB
+		this._save(result);
+		
+		return { errors, updated: result };
+	}
 
-    async _parse(entry, previous, next, options) {
-        if (options.indexing) {
-            next = await Promise.all(next.map(async ([i, v]) => ([i, entry.serializer.serialize(await entry.parse(v, options.guild))])));
-        } else if (!Array.isArray(next)) {
-            next = entry.serializer.serialize(await entry.parse(next, options.guild));
-        } else next = await Promise.all(next.map(async val => entry.serializer.serialize(await entry.parse(val, options.guild))));
+	async _parse(entry, previous, next, options) {
+		if (options.indexing) {
+			next = await Promise.all(next.map(async ([i, v]) => ([i, entry.serializer.serialize(await entry.parse(v, options.guild))])));
+		} else if (!Array.isArray(next)) {
+			next = entry.serializer.serialize(await entry.parse(next, options.guild));
+		} else next = await Promise.all(next.map(async val => entry.serializer.serialize(await entry.parse(val, options.guild))));
 
-        const { action = 'auto' } = options;
-        
-        // Need to change logic behind indexing for this to work properly.
-        if (action === 'overwrite') return next;
+		const { action = 'auto' } = options;
+		
+		// Need to change logic behind indexing for this to work properly.
+		if (action === 'overwrite') return next;
 
-        const clone = previous.slice();
+		const clone = previous.slice();
 
-        // This value has an index paired with it
-        if (options.indexing) {
-            for (const val of next) {
-                let index = val[0];
-                if (clone.length === 0 && index > 0) {
-                    throw `The current array is empty. The index must start at 0.`
-                } else if (index < 0 || index > clone.length + 1) {
-                    throw `The index ${index} is bigger than the current array. It must be a value in the range of 0..${clone.length + 1}.`;
-                }
-                clone[index] = val[1];
-            }
-        } else if (action === 'auto') {
-            for (const val of next) {
-                const index = clone.indexOf(val);
-                if (index === -1) clone.push(val);
-                else clone.splice(index, 1)
-            }
-        } else if (action === 'add') {
-            for (const val of next) {
-                if (clone.includes(val)) throw `The value ${val} for the key ${entry.path} already exists.`;
-                clone.push(val);
-            }
-        } else if (action === 'remove') {
+		// This value has an index paired with it
+		if (options.indexing) {
+			for (const val of next) {
+				let index = val[0];
+				if (clone.length === 0 && index > 0) {
+					throw `The current array is empty. The index must start at 0.`
+				} else if (index < 0 || index > clone.length + 1) {
+					throw `The index ${index} is bigger than the current array. It must be a value in the range of 0..${clone.length + 1}.`;
+				}
+				clone[index] = val[1];
+			}
+		} else if (action === 'auto') {
+			for (const val of next) {
+				const index = clone.indexOf(val);
+				if (index === -1) clone.push(val);
+				else clone.splice(index, 1)
+			}
+		} else if (action === 'add') {
+			for (const val of next) {
+				if (clone.includes(val)) throw `The value ${val} for the key ${entry.path} already exists.`;
+				clone.push(val);
+			}
+		} else if (action === 'remove') {
 			for (const val of next) {
 				const index = clone.indexOf(val);
 				if (index === -1) throw `The value ${val} for the key ${entry.path} does not exist.`;
@@ -117,30 +117,30 @@ class SettingsArray {
 			}
 		} else {
 			throw `The ${action} array action is not a valid SettingsUpdateArrayAction.`;
-        }
+		}
 
 		return clone;
-    }
+	}
 
-    async _save(results) {
+	async _save(results) {
 		const status = this.base.existenceStatus;
-        if (status === null) throw new Error('Cannot update out of sync.');
+		if (status === null) throw new Error('Cannot update out of sync.');
 
-        // Update DB
+		// Update DB
 
-        this._patch(results[0].value);
-    }
+		this._patch(results[0].value);
+	}
 
-    _patch(data) {
-        if (!Array.isArray(data)) return;
+	_patch(data) {
+		if (!Array.isArray(data)) return;
 
-        // Our Array was completely removed, so reset to schema default
-        if (data.length === 0) this.data = this.entry.default;
+		// Our Array was completely removed, so reset to schema default
+		if (data.length === 0) this.data = this.entry.default;
 
-        // Will probably be removed for a better option of only patching indexes that are updated or if new values are added (which would be denoted by index === -1)
-        // For now, this will suffice
-        this.data = [...data];
-    }
+		// Will probably be removed for a better option of only patching indexes that are updated or if new values are added (which would be denoted by index === -1)
+		// For now, this will suffice
+		this.data = [...data];
+	}
 }
 
 module.exports = SettingsArray;

--- a/src/lib/settings/group/SettingsArray.js
+++ b/src/lib/settings/group/SettingsArray.js
@@ -1,0 +1,146 @@
+const { resolveGuild, arraysStrictEquals, mergeObjects, makeObject } = require('../../util/util');
+
+const checkForIndex = (value) => Array.isArray(value) && value.length === 2 && typeof value[0] === 'number';
+
+class SettingsArray {
+    constructor(entry) {
+        Object.defineProperty(this, 'base', { value: null, writable: true });
+        
+        // The Entry this SettingArray refers to
+        Object.defineProperty(this, 'entry', { value: entry });
+
+        // The Cached data
+        Object.defineProperty(this, 'data', { value: entry.default, enumerable: true, writable: true });
+    }
+
+    get gateway() {
+        return this.base.gateway;
+    }
+
+    get(index) {
+        if (index !== undefined && index !== null) {
+
+        }
+        return this.data.slice();
+    }
+
+    includes(value) {
+        return this.data.slice().includes(value);
+    }
+
+    async update(values, options) {
+        if (!options) options = { throwOnError: false, indexing: false };
+		options.guild = resolveGuild(this.base.gateway.client, 'guild' in options ? options.guild : this.base.target);
+        const language = options.guild ? options.guild.language : this.base.gateway.client.languages.default;
+
+        if (!Array.isArray(values)) values = [values];
+
+        const errors = [];     
+        let promise = null;
+        const { entry } = this;
+        
+        const onError = options.throwOnError ? (error) => { throw error; } : (error) => errors.push(error);
+
+        const previous = this.get();
+
+        try {
+            // Not sure of a better way to do this, come back at a later time
+            if (values.some(checkForIndex)) {
+                if (!(values.every(checkForIndex))) throw "Indexing found. You must only use straight indexing or no indexing, not a mixture of both.";
+                options.indexing = true;
+            }
+            promise = this._parse(entry, previous, values, options)
+                .catch(onError);
+        } catch (error) {
+            if (options.throwOnError) throw error;
+            errors.push(error);
+        }
+
+        // Has to be run before to actually catch errors, future error handling will be shoved into _parse() to actually reflect the individual values that error,
+        // rather then just throwing the first error to the top and disgarding the rest
+        const current = await promise;
+
+        if (errors.length) return { errors, updated: [] };
+
+        // The arrays were already equal.
+        if (arraysStrictEquals(current, previous)) return;
+
+        const result = [{ key: entry.path, value: current, entry }];
+        
+        // Save to Cache and DB
+        this._save(result);
+        
+        return { errors, updated: result };
+    }
+
+    async _parse(entry, previous, next, options) {
+        if (options.indexing) {
+            next = await Promise.all(next.map(async ([i, v]) => ([i, entry.serializer.serialize(await entry.parse(v, options.guild))])));
+        } else if (!Array.isArray(next)) {
+            next = entry.serializer.serialize(await entry.parse(next, options.guild));
+        } else next = await Promise.all(next.map(async val => entry.serializer.serialize(await entry.parse(val, options.guild))));
+
+        const { action = 'auto' } = options;
+        
+        // Need to change logic behind indexing for this to work properly.
+        if (action === 'overwrite') return next;
+
+        const clone = previous.slice();
+
+        // This value has an index paired with it
+        if (options.indexing) {
+            for (const val of next) {
+                let index = val[0];
+                if (clone.length === 0 && index > 0) {
+                    throw `The current array is empty. The index must start at 0.`
+                } else if (index < 0 || index > clone.length + 1) {
+                    throw `The index ${index} is bigger than the current array. It must be a value in the range of 0..${clone.length + 1}.`;
+                }
+                clone[index] = val[1];
+            }
+        } else if (action === 'auto') {
+            for (const val of next) {
+                const index = clone.indexOf(val);
+                if (index === -1) clone.push(val);
+                else clone.splice(index, 1)
+            }
+        } else if (action === 'add') {
+            for (const val of next) {
+                if (clone.includes(val)) throw `The value ${val} for the key ${entry.path} already exists.`;
+                clone.push(val);
+            }
+        } else if (action === 'remove') {
+			for (const val of next) {
+				const index = clone.indexOf(val);
+				if (index === -1) throw `The value ${val} for the key ${entry.path} does not exist.`;
+				clone.splice(index, 1);
+			}
+		} else {
+			throw `The ${action} array action is not a valid SettingsUpdateArrayAction.`;
+        }
+
+		return clone;
+    }
+
+    async _save(results) {
+		const status = this.base.existenceStatus;
+        if (status === null) throw new Error('Cannot update out of sync.');
+
+        // Update DB
+
+        this._patch(results[0].value);
+    }
+
+    _patch(data) {
+        if (!Array.isArray(data)) return;
+
+        // Our Array was completely removed, so reset to schema default
+        if (data.length === 0) this.data = this.entry.default;
+
+        // Will probably be removed for a better option of only patching indexes that are updated or if new values are added (which would be denoted by index === -1)
+        // For now, this will suffice
+        this.data = [...data];
+    }
+}
+
+module.exports = SettingsArray;

--- a/src/lib/settings/group/SettingsMap.js
+++ b/src/lib/settings/group/SettingsMap.js
@@ -1,24 +1,9 @@
 const { mapsStrictEquals, resolveGuild } = require('../../util/util');
+const GroupBase = require('./GroupBase');
 
 const checkForTuples = (value) => Array.isArray(value) && value.length === 2;
 
-class SettingsMap {
-
-	constructor(entry) {
-		Object.defineProperty(this, 'base', { value: null, writable: true });
-		Object.defineProperty(this, 'entry', { value: entry });
-
-		/**
-		 * The data for this map
-		 * @since 0.5.0
-		 * @type {Map<any, any>}
-		 */
-		this.data = entry.default;
-	}
-
-	get gateway() {
-		return this.base.gateway;
-	}
+class SettingsMap extends GroupBase {
 
 	get(key) {
 		if (key !== undefined && key !== null) {
@@ -63,41 +48,12 @@ class SettingsMap {
 		return { clone };
 	}
 
-	async _save(results) {
-		const status = this.base.existenceStatus;
-		if (status === null) throw new Error('Cannot update out of sync.');
-
-		// Update DB
-
-		this._patch(results[0].value);
-	}
-
-	toJSON() {
-		return [...this.data.entries()];
-	}
-
 	_patch(data) {
 		if (Array.isArray(data) && data.every(checkForTuples)) {
 			this.data = data.length ? new Map(data) : this.entry.default;
 		} else if (data instanceof Map) {
 			this.data = data.size ? new Map(data) : this.entry.default;
 		}
-	}
-
-	*keys() {
-		yield* this.data.keys();
-	}
-
-	*values() {
-		yield* this.data.values();
-	}
-
-	*entries() {
-		yield* this.data.entries();
-	}
-
-	*[Symbol.iterator]() {
-		yield* this.data[Symbol.iterator]();
 	}
 
 }

--- a/src/lib/settings/group/SettingsMap.js
+++ b/src/lib/settings/group/SettingsMap.js
@@ -19,18 +19,18 @@ class SettingsMap extends GroupBase {
 	async update(keyOrEntries, valueOrOptions, options) {
 		const isArray = Array.isArray(keyOrEntries);
 		if (isArray) {
-			if (!keyOrEntries.every(checkForTuples)) throw `Expected an array of tuples as first argument, but it contains a non-tuple.`;
+			if (!keyOrEntries.every(checkForTuples)) throw new TypeError(`Expected an array of tuples as first argument, but it contains a non-tuple.`);
 			options = valueOrOptions;
 		}
 		const guild = resolveGuild(this.base.gateway.client, options && 'guild' in options ? options.guild : this.base.target);
 		const entries = isArray ? entries : [[keyOrEntries, valueOrOptions]];
 
-		const { clone } = await this._parse(clone, entries, guild);
+		const clone = await this._parse(clone, entries, guild);
 
 		// The maps were already equal.
 		if (mapsStrictEquals(this.data, clone)) return { errors: [], updated: [] };
 
-		const updated = [{ key: this.entry.path, value: clone, entry: this.entry }];
+		const updated = [{ key: this.entry.path, value: [...clone.entries()], entry: this.entry }];
 		await this._save(updated);
 		return { errors: [], updated };
 	}
@@ -45,7 +45,7 @@ class SettingsMap extends GroupBase {
 			if (!clone.delete(key)) clone.set(key, value);
 		}
 
-		return { clone };
+		return clone;
 	}
 
 	_patch(data) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -273,7 +273,7 @@ declare module 'klasa' {
 
 	export class Gateway extends GatewayStorage {
 		protected syncQueue: WeakMap<Settings, Promise<Settings>>;
-		protected cache: Collection<string, Record<string, any> & { settings: Settings }>;
+		public cache: Collection<string, Record<string, any> & { settings: Settings }>;
 		public acquire(target: any, id?: string | number): Settings;
 		public create(target: any, id?: string | number): Settings;
 		public get(id: string | number): Settings | null;


### PR DESCRIPTION
### Description of the PR
This PR adds the ability to use Map/Set within Settings, along with array changes to make the entire interface more consistent. (This is WIP and not ready to be consumed in any way, shape, or form)

## Array
A new class called SettingsArray that all arrays will use. It does not extend Arrays as to not allow end-users to mutate the returned array. This class will hold several methods equivalent to normal array operations, the only difference being you won't be able to mutate the Array in cache (without willingly trying to).

#### Methods:
- [x] get - equivalent to Map/Set.get(); Takes a value or no value and returns clonedArray[index] or clonedArray
- [x] includes - equivalent to Array includes
- [x] update - new update method to update Arrays, SettingsFolder#update will route to this
- [ ] reset - new reset method to reset Arrays, SettingsFolder#reset will route to this
- [ ] forEach - equivalent to forEach except with a cloned array
- [x] Symbol.iterator - equivalent to Array iterator
- [ ] find - equivalent to Array find

> If you think other methods should be added, feel free to comment. I'm not trying to fill out the entire array prototype but I don't mind having helpful methods added back.

#### How to use the update function:
Assuming we have the array `[1,2,3,4,5]`, and all methods without an action are defaulted to 'auto'
Single Value:
```javascript
update(6); // [1,2,3,4,5,6]
```
Multiple Values:
```javascript
update([6, 7, 8]); // [1,2,3,4,5,6,7,8]
```
Single value by index:
```javascript
update([[2, 6]]); // [1,2,6,4,5]
```
Multiple values by index:
```javascript
update([[0, 6], [4, 7]]); // [6,2,3,4,7]
```
> Indexing bypasses all actions passed, and you cannot combine indexing with non-indexing.










I'll add the specifics here when the implementation is finished.


### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
