### PR TITLE
perf(Timestamp): Increased performance and move patterns to maps

### DIFF
--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -72,8 +72,6 @@ const tokens = new Map([
 ]);
 /* eslint-enable max-len */
 
-const tokenRepeatingCounts = new Map(Object.entries(TOKENS));
-
 /**
  * Klasa's Timestamp class, parses the pattern once, displays the desired Date or UNIX timestamp with the selected pattern.
  */
@@ -196,7 +194,7 @@ class Timestamp {
 		for (let i = 0; i < pattern.length; i++) {
 			let current = '';
 			const currentChar = pattern[i];
-			const tokenMax = tokenRepeatingCounts.get(currentChar);
+			const tokenMax = TOKENS.get(currentChar);
 			if (typeof tokenMax === 'number') {
 				current += currentChar;
 				while (pattern[i + 1] === currentChar && current.length < tokenMax) current += pattern[++i];
@@ -207,7 +205,7 @@ class Timestamp {
 				template.push({ type: 'literal', content: current });
 			} else {
 				current += currentChar;
-				while (i + 1 < pattern.length && !tokenRepeatingCounts.has(pattern[i + 1]) && pattern[i + 1] !== '[') current += pattern[++i];
+				while (i + 1 < pattern.length && !TOKENS.has(pattern[i + 1]) && pattern[i + 1] !== '[') current += pattern[++i];
 				template.push({ type: 'literal', content: current });
 			}
 		}

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -1,116 +1,76 @@
 const { TIME: { SECOND, MINUTE, DAY, DAYS, MONTHS, TIMESTAMP: { TOKENS } } } = require('./constants');
 
-/* eslint-disable id-length, new-cap */
-
-// Dates
-
-const Y = time => String(time.getFullYear()).slice(0, 2);
-const YYY = time => String(time.getFullYear());
-const Q = time => String((time.getMonth() + 1) / 3);
-const M = time => String(time.getMonth() + 1);
-const MM = time => M(time).padStart(2, '0');
-const MMM = time => MONTHS[time.getMonth()];
-const D = time => String(time.getDate());
-const DD = time => D(time).padStart(2, '0');
-const DDD = time => {
-	const start = new Date(time.getFullYear(), 0, 0);
-	const diff = ((time.getMilliseconds() - start.getMilliseconds()) + (start.getTimezoneOffset() - time.getTimezoneOffset())) * MINUTE;
-	return String(Math.floor(diff / DAY));
-};
-const d = time => {
-	const day = D(time);
-	if (day !== '11' && day.endsWith('1')) return `${day}st`;
-	if (day !== '12' && day.endsWith('2')) return `${day}nd`;
-	if (day !== '13' && day.endsWith('3')) return `${day}rd`;
-	return `${day}th`;
-};
-const dd = time => DAYS[time.getDay()].slice(0, 2);
-const ddd = time => DAYS[time.getDay()].slice(0, 3);
-const dddd = time => DAYS[time.getDay()];
-const X = time => String(time.valueOf() / SECOND);
-const x = time => String(time.valueOf());
-
-// Times
-
-const H = time => String(time.getHours());
-const HH = time => H(time).padStart(2, '0');
-const h = time => String(time.getHours() % 12 || 12);
-const hh = time => String(time.getHours() % 12 || 12).padStart(2, '0');
-const a = time => time.getHours() < 12 ? 'am' : 'pm';
-const A = time => time.getHours() < 12 ? 'AM' : 'PM';
-const m = time => String(time.getMinutes());
-const mm = time => m(time).padStart(2, '0');
-const s = time => String(time.getSeconds());
-const ss = time => s(time).padStart(2, '0');
-const S = time => String(time.getMilliseconds());
-const SS = time => SS(time).padStart(2, '0');
-const SSS = time => SS(time).padStart(3, '0');
-
-// Locales
-
-const T = (time) => `${h(time)}:${mm(time)} ${A(time)}`;
-const t = (time) => `${h(time)}:${mm(time)}:${ss(time)} ${A(time)}`;
-const L = (time) => `${MM(time)}/${DD(time)}/${YYY(time)}`;
-const l = (time) => `${M(time)}/${DD(time)}/${YYY(time)}`;
-const LL = (time) => `${MMM(time)} ${DD(time)}, ${YYY(time)}`;
-const ll = (time) => `${MMM(time).slice(0, 3)} ${DD(time)}, ${YYY(time)}`;
-const LLL = (time) => `${LL(time)} ${T(time)}`;
-const lll = (time) => `${ll(time)} ${T(time)}`;
-const LLLL = (time) => `${dddd(time)}, ${LLL(time)}`;
-const llll = (time) => `${ddd(time)} ${lll(time)}`;
-const Z = time => {
-	const offset = time.getTimezoneOffset();
-	return `${offset >= 0 ? '+' : '-'}${String(offset / -60).padStart(2, '0')}:${String(offset % 60).padStart(2, '0')}`;
-};
-
-/* eslint-enable id-length, new-cap */
-
+/* eslint-disable max-len */
 const tokens = new Map([
-	['Y', Y],
-	['YY', Y],
-	['YYY', YYY],
-	['YYYY', YYY],
-	['Q', Q],
-	['M', M],
-	['MM', MM],
-	['MMM', MMM],
-	['MMMM', MMM],
-	['D', D],
-	['DD', DD],
-	['DDD', DDD],
-	['DDDD', DDD],
-	['d', d],
-	['dd', dd],
-	['ddd', ddd],
-	['dddd', dddd],
-	['X', X],
-	['x', x],
-	['H', H],
-	['HH', HH],
-	['h', h],
-	['hh', hh],
-	['a', a],
-	['A', A],
-	['m', m],
-	['mm', mm],
-	['s', s],
-	['ss', ss],
-	['S', S],
-	['SS', SS],
-	['SSS', SSS],
-	['T', T],
-	['t', t],
-	['L', L],
-	['l', l],
-	['LL', LL],
-	['ll', ll],
-	['LLL', LLL],
-	['lll', lll],
-	['LLLL', LLLL],
-	['llll', llll],
-	['Z', Z],
-	['ZZ', Z]
+	// Dates
+	['Y', time => String(time.getFullYear()).slice(0, 2)],
+	['YY', time => String(time.getFullYear()).slice(0, 2)],
+	['YYY', time => String(time.getFullYear())],
+	['YYYY', time => String(time.getFullYear())],
+	['Q', time => String((time.getMonth() + 1) / 3)],
+	['M', time => String(time.getMonth() + 1)],
+	['MM', time => String(time.getMonth() + 1).padStart(2, '0')],
+	['MMM', time => MONTHS[time.getMonth()]],
+	['MMMM', time => MONTHS[time.getMonth()]],
+	['D', time => String(time.getDate())],
+	['DD', time => String(time.getDate()).padStart(2, '0')],
+	['DDD', time => {
+		const start = new Date(time.getFullYear(), 0, 0);
+		const diff = ((time.getMilliseconds() - start.getMilliseconds()) + (start.getTimezoneOffset() - time.getTimezoneOffset())) * MINUTE;
+		return String(Math.floor(diff / DAY));
+	}],
+	['DDDD', time => {
+		const start = new Date(time.getFullYear(), 0, 0);
+		const diff = ((time.getMilliseconds() - start.getMilliseconds()) + (start.getTimezoneOffset() - time.getTimezoneOffset())) * MINUTE;
+		return String(Math.floor(diff / DAY));
+	}],
+	['d', time => {
+		const day = String(time.getDate());
+		if (day !== '11' && day.endsWith('1')) return `${day}st`;
+		if (day !== '12' && day.endsWith('2')) return `${day}nd`;
+		if (day !== '13' && day.endsWith('3')) return `${day}rd`;
+		return `${day}th`;
+	}],
+	['dd', time => DAYS[time.getDay()].slice(0, 2)],
+	['ddd', time => DAYS[time.getDay()].slice(0, 3)],
+	['dddd', time => DAYS[time.getDay()]],
+	['X', time => String(time.valueOf() / SECOND)],
+	['x', time => String(time.valueOf())],
+
+	// Locales
+	['H', time => String(time.getHours())],
+	['HH', time => String(time.getHours()).padStart(2, '0')],
+	['h', time => String(time.getHours() % 12 || 12)],
+	['hh', time => String(time.getHours() % 12 || 12).padStart(2, '0')],
+	['a', time => time.getHours() < 12 ? 'am' : 'pm'],
+	['A', time => time.getHours() < 12 ? 'AM' : 'PM'],
+	['m', time => String(time.getMinutes())],
+	['mm', time => String(time.getMinutes()).padStart(2, '0')],
+	['s', time => String(time.getSeconds())],
+	['ss', time => String(time.getSeconds()).padStart(2, '0')],
+	['S', time => String(time.getMilliseconds())],
+	['SS', time => String(time.getMilliseconds()).padStart(2, '0')],
+	['SSS', time => String(time.getMilliseconds()).padStart(3, '0')],
+	['T', time => `${String(time.getHours() % 12 || 12)}:${String(time.getMinutes()).padStart(2, '0')} ${time.getHours() < 12 ? 'AM' : 'PM'}`],
+	['t', time => `${String(time.getHours() % 12 || 12)}:${String(time.getMinutes()).padStart(2, '0')}:${String(time.getSeconds()).padStart(2, '0')} ${time.getHours() < 12 ? 'am' : 'pm'}`],
+	['L', time => `${String(time.getMonth() + 1).padStart(2, '0')}/${String(time.getDate()).padStart(2, '0')}/${String(time.getFullYear())}`],
+	['l', time => `${String(time.getMonth() + 1)}/${String(time.getDate()).padStart(2, '0')}/${String(time.getFullYear())}`],
+	['LL', time => `${MONTHS[time.getMonth()]} ${String(time.getDate()).padStart(2, '0')}, ${String(time.getFullYear())}`],
+	['ll', time => `${MONTHS[time.getMonth()].slice(0, 3)} ${String(time.getDate()).padStart(2, '0')}, ${String(time.getFullYear())}`],
+	['LLL', time => `${MONTHS[time.getMonth()]} ${String(time.getDate()).padStart(2, '0')}, ${String(time.getFullYear())} ${String(time.getHours() % 12 || 12)}:${String(time.getMinutes()).padStart(2, '0')} ${time.getHours() < 12 ? 'AM' : 'PM'}`],
+	['lll', time => `${MONTHS[time.getMonth()].slice(0, 3)} ${String(time.getDate()).padStart(2, '0')}, ${String(time.getFullYear())} ${String(time.getHours() % 12 || 12)}:${String(time.getMinutes()).padStart(2, '0')} ${time.getHours() < 12 ? 'AM' : 'PM'}`],
+	['LLLL', time => `${DAYS[time.getDay()]}, ${MONTHS[time.getMonth()]} ${String(time.getDate()).padStart(2, '0')}, ${String(time.getFullYear())} ${String(time.getHours() % 12 || 12)}:${String(time.getMinutes()).padStart(2, '0')} ${time.getHours() < 12 ? 'AM' : 'PM'}`],
+	['llll', time => `${DAYS[time.getDay()].slice(0, 3)} ${MONTHS[time.getMonth()].slice(0, 3)} ${String(time.getDate()).padStart(2, '0')}, ${String(time.getFullYear())} ${String(time.getHours() % 12 || 12)}:${String(time.getMinutes()).padStart(2, '0')} ${time.getHours() < 12 ? 'AM' : 'PM'}`],
+	['Z', time => {
+		const offset = time.getTimezoneOffset();
+		return `${offset >= 0 ? '+' : '-'}${String(offset / -60).padStart(2, '0')}:${String(offset % 60).padStart(2, '0')}`;
+	}],
+	['ZZ', time => {
+		const offset = time.getTimezoneOffset();
+		return `${offset >= 0 ? '+' : '-'}${String(offset / -60).padStart(2, '0')}:${String(offset % 60).padStart(2, '0')}`;
+	}]
 ]);
+/* eslint-enable max-len */
 
 const tokenRepeatingCounts = new Map(Object.entries(TOKENS));
 

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -234,9 +234,9 @@ class Timestamp {
 		for (let i = 0; i < pattern.length; i++) {
 			let current = '';
 			const currentChar = pattern[i];
-			if (this.mapTokens.has(currentChar)) {
+			if (this.tokenRepeatingCounts.has(currentChar)) {
 				current += currentChar;
-				const tokenMax = this.mapTokens.get(currentChar);
+				const tokenMax = this.tokenRepeatingCounts.get(currentChar);
 				while (pattern[i + 1] === currentChar && current.length < tokenMax) current += pattern[++i];
 				template.push({ type: current, content: null });
 			} else if (currentChar === '[') {
@@ -245,7 +245,7 @@ class Timestamp {
 				template.push({ type: 'literal', content: current });
 			} else {
 				current += currentChar;
-				while (i + 1 < pattern.length && !this.mapTokens.has(pattern[i + 1]) && pattern[i + 1] !== '[') current += pattern[++i];
+				while (i + 1 < pattern.length && !this.tokenRepeatingCounts.has(pattern[i + 1]) && pattern[i + 1] !== '[') current += pattern[++i];
 				template.push({ type: 'literal', content: current });
 			}
 		}
@@ -275,11 +275,11 @@ class Timestamp {
 Timestamp.timezoneOffset = new Date().getTimezoneOffset() * 60000;
 
 /**
- * The map tokens, mapped from the constants.
+ * The repeating counts for each token, mapped from the constants.
  * @since 0.5.0
- * @type {Map<string, Function>}
+ * @type {Map<string, number>}
  * @static
  */
-Timestamp.mapTokens = new Map(Object.entries(TOKENS));
+Timestamp.tokenRepeatingCounts = new Map(Object.entries(TOKENS));
 
 module.exports = Timestamp;

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -3,8 +3,8 @@ const { TIME: { SECOND, MINUTE, DAY, DAYS, MONTHS, TIMESTAMP: { TOKENS } } } = r
 /* eslint-disable max-len */
 const tokens = new Map([
 	// Dates
-	['Y', time => String(time.getFullYear()).slice(0, 2)],
-	['YY', time => String(time.getFullYear()).slice(0, 2)],
+	['Y', time => String(time.getFullYear()).slice(2)],
+	['YY', time => String(time.getFullYear()).slice(2)],
 	['YYY', time => String(time.getFullYear())],
 	['YYYY', time => String(time.getFullYear())],
 	['Q', time => String((time.getMonth() + 1) / 3)],

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -112,6 +112,8 @@ const tokens = new Map([
 	['ZZ', Z]
 ]);
 
+const tokenRepeatingCounts = new Map(Object.entries(TOKENS));
+
 /**
  * Klasa's Timestamp class, parses the pattern once, displays the desired Date or UNIX timestamp with the selected pattern.
  */
@@ -234,9 +236,9 @@ class Timestamp {
 		for (let i = 0; i < pattern.length; i++) {
 			let current = '';
 			const currentChar = pattern[i];
-			if (this.tokenRepeatingCounts.has(currentChar)) {
+			if (tokenRepeatingCounts.has(currentChar)) {
 				current += currentChar;
-				const tokenMax = this.tokenRepeatingCounts.get(currentChar);
+				const tokenMax = tokenRepeatingCounts.get(currentChar);
 				while (pattern[i + 1] === currentChar && current.length < tokenMax) current += pattern[++i];
 				template.push({ type: current, content: null });
 			} else if (currentChar === '[') {
@@ -245,7 +247,7 @@ class Timestamp {
 				template.push({ type: 'literal', content: current });
 			} else {
 				current += currentChar;
-				while (i + 1 < pattern.length && !this.tokenRepeatingCounts.has(pattern[i + 1]) && pattern[i + 1] !== '[') current += pattern[++i];
+				while (i + 1 < pattern.length && !tokenRepeatingCounts.has(pattern[i + 1]) && pattern[i + 1] !== '[') current += pattern[++i];
 				template.push({ type: 'literal', content: current });
 			}
 		}
@@ -273,13 +275,5 @@ class Timestamp {
  * @static
  */
 Timestamp.timezoneOffset = new Date().getTimezoneOffset() * 60000;
-
-/**
- * The repeating counts for each token, mapped from the constants.
- * @since 0.5.0
- * @type {Map<string, number>}
- * @static
- */
-Timestamp.tokenRepeatingCounts = new Map(Object.entries(TOKENS));
 
 module.exports = Timestamp;

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -277,7 +277,7 @@ Timestamp.timezoneOffset = new Date().getTimezoneOffset() * 60000;
 /**
  * The map tokens, mapped from the constants.
  * @since 0.5.0
- * @type {Map<string, (time: Date) => string>}
+ * @type {Map<string, Function>}
  * @static
  */
 Timestamp.mapTokens = new Map(Object.entries(TOKENS));

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -266,7 +266,20 @@ class Timestamp {
 
 }
 
+/**
+ * The timezone offset in seconds.
+ * @since 0.5.0
+ * @type {number}
+ * @static
+ */
 Timestamp.timezoneOffset = new Date().getTimezoneOffset() * 60000;
+
+/**
+ * The map tokens, mapped from the constants.
+ * @since 0.5.0
+ * @type {Map<string, (time: Date) => string>}
+ * @static
+ */
 Timestamp.mapTokens = new Map(Object.entries(TOKENS));
 
 module.exports = Timestamp;

--- a/src/lib/util/Timestamp.js
+++ b/src/lib/util/Timestamp.js
@@ -196,9 +196,9 @@ class Timestamp {
 		for (let i = 0; i < pattern.length; i++) {
 			let current = '';
 			const currentChar = pattern[i];
-			if (tokenRepeatingCounts.has(currentChar)) {
+			const tokenMax = tokenRepeatingCounts.get(currentChar);
+			if (typeof tokenMax === 'number') {
 				current += currentChar;
-				const tokenMax = tokenRepeatingCounts.get(currentChar);
 				while (pattern[i + 1] === currentChar && current.length < tokenMax) current += pattern[++i];
 				template.push({ type: current, content: null });
 			} else if (currentChar === '[') {

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -174,29 +174,27 @@ exports.TIME = {
 	MONTHS: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
 
 	TIMESTAMP: {
-		TOKENS: {
-			/* eslint-disable id-length */
-			Y: 4,
-			Q: 1,
-			M: 4,
-			D: 4,
-			d: 4,
-			X: 1,
-			x: 1,
-			H: 2,
-			h: 2,
-			a: 1,
-			A: 1,
-			m: 2,
-			s: 2,
-			S: 3,
-			Z: 2,
-			l: 4,
-			L: 4,
-			T: 1,
-			t: 1
-			/* eslint-enable id-length */
-		}
+		TOKENS: new Map([
+			['Y', 4],
+			['Q', 1],
+			['M', 4],
+			['D', 4],
+			['d', 4],
+			['X', 1],
+			['x', 1],
+			['H', 2],
+			['h', 2],
+			['a', 1],
+			['A', 1],
+			['m', 2],
+			['s', 2],
+			['S', 3],
+			['Z', 2],
+			['l', 4],
+			['L', 4],
+			['T', 1],
+			['t', 1]
+		])
 	},
 
 	CRON: {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -912,6 +912,8 @@ declare module 'klasa' {
 		public displayUTC(time?: Date | number | string): string;
 		public edit(pattern: string): this;
 
+		public static timezoneOffset: number;
+		public static mapTokens: Map<string, (time: Date) => string>;
 		public static utc(time?: Date | number | string): Date;
 		public static displayArbitrary(pattern: string, time?: Date | number | string): string;
 		private static _resolveDate(time: Date | number | string): Date;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -913,7 +913,6 @@ declare module 'klasa' {
 		public edit(pattern: string): this;
 
 		public static timezoneOffset: number;
-		public static tokenRepeatingCounts: Map<string, number>;
 		public static utc(time?: Date | number | string): Date;
 		public static displayArbitrary(pattern: string, time?: Date | number | string): string;
 		private static _resolveDate(time: Date | number | string): Date;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -914,42 +914,6 @@ declare module 'klasa' {
 
 		public static utc(time?: Date | number | string): Date;
 		public static displayArbitrary(pattern: string, time?: Date | number | string): string;
-
-		public static A(time: Date): string;
-		public static a(time: Date): string;
-		public static d(time: Date): string;
-		public static D(time: Date): string;
-		public static dd(time: Date): string;
-		public static DD(time: Date): string;
-		public static ddd(time: Date): string;
-		public static DDD(time: Date): string;
-		public static dddd(time: Date): string;
-		public static DDDD(time: Date): string;
-		public static h(time: Date): string;
-		public static H(time: Date): string;
-		public static hh(time: Date): string;
-		public static HH(time: Date): string;
-		public static m(time: Date): string;
-		public static M(time: Date): string;
-		public static mm(time: Date): string;
-		public static MM(time: Date): string;
-		public static MMM(time: Date): string;
-		public static MMMM(time: Date): string;
-		public static Q(time: Date): string;
-		public static S(time: Date): string;
-		public static s(time: Date): string;
-		public static ss(time: Date): string;
-		public static SS(time: Date): string;
-		public static SSS(time: Date): string;
-		public static x(time: Date): string;
-		public static X(time: Date): string;
-		public static Y(time: Date): string;
-		public static YY(time: Date): string;
-		public static YYY(time: Date): string;
-		public static YYYY(time: Date): string;
-		public static Z(time: Date): string;
-		public static ZZ(time: Date): string;
-
 		private static _resolveDate(time: Date | number | string): Date;
 		private static _display(template: string, time: Date | number | string): string;
 		private static _patch(pattern: string): TimestampObject[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1071,23 +1071,7 @@ declare module 'klasa' {
 		DAYS: string[];
 		MONTHS: string[];
 		TIMESTAMP: {
-			TOKENS: {
-				Y: number;
-				Q: number;
-				M: number;
-				D: number;
-				d: number;
-				X: number;
-				x: number;
-				H: number;
-				h: number;
-				a: number;
-				A: number;
-				m: number;
-				s: number;
-				S: number;
-				Z: number;
-			};
+			TOKENS: Map<string, number>;
 		};
 		CRON: {
 			partRegex: RegExp;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -913,7 +913,7 @@ declare module 'klasa' {
 		public edit(pattern: string): this;
 
 		public static timezoneOffset: number;
-		public static mapTokens: Map<string, (time: Date) => string>;
+		public static tokenRepeatingCounts: Map<string, number>;
 		public static utc(time?: Date | number | string): Date;
 		public static displayArbitrary(pattern: string, time?: Date | number | string): string;
 		private static _resolveDate(time: Date | number | string): Date;


### PR DESCRIPTION
### Description of the PR

<!-- Speedwhore enough? -->

There were two branches V8 marked as megamorphic:

https://github.com/dirigeants/klasa/blob/3360292f349cc791063a6b4dcb709080c486a1d8/src/lib/util/Timestamp.js#L109

At `klasa/src/lib/util/Timestamp.js:109:75`

Old State | New State | Key | Map
-- | -- | -- | --
unintialized | premonomorphic | YYYY | 0x211d961a39e9
premonomorphic | monomorphic | MM | 0x211d961a39e9
monomorphic | megamorphic | DD | 0x211d961a39e9

---

https://github.com/dirigeants/klasa/blob/3360292f349cc791063a6b4dcb709080c486a1d8/src/lib/util/Timestamp.js#L127

At `klasa/src/lib/util/Timestamp.js:127:69`

Old State | New State | Key | Map
-- | -- | -- | --
unintialized | premonomorphic | Y | 0x211d96198f11
premonomorphic | monomorphic | Y | 0x211d96198f11
monomorphic | megamorphic | M | 0x211d96198f11

---

This also implements a breaking change, moving all public and exported `Timestamp[token]` to a private and non-exposed `Map`, following `Duration`'s design:

https://github.com/dirigeants/klasa/blob/3360292f349cc791063a6b4dcb709080c486a1d8/src/lib/util/Duration.js#L1-L47

Also adds `Timestamp.mapTokens` and documented `timezoneOffset`.


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added `Timestamp.mapTokens` and documented `Timestamp.timezoneOffset`.
- Removed all `Timestamp[token]`.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
