### PR TITLE
Cooldown Inhibitor Change Seconds To Formatted String

### DIFF
--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -14,11 +14,11 @@ module.exports = class extends Inhibitor {
 		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', this.secondsToFormattedString(Math.ceil(existing.remainingTime / 1000)), command.cooldownLevel !== 'author');
 	}
 	
-	secondsToFormattedString(seconds) {
-		const days = Math.floor(duration / 86400);
-		const hours = Math.floor(duration / 3600);
-		const minutes = Math.floor(duration / 60);
-		const seconds = Math.floor(duration % 60);
+	secondsToFormattedString(time) {
+		const days = Math.floor(time / 86400);
+		const hours = Math.floor(time / 3600);
+		const minutes = Math.floor(time / 60);
+		const seconds = Math.floor(time % 60);
 		return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
 	}
 

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -1,4 +1,4 @@
-const { Inhibitor, Duration } = require('klasa');
+const { Inhibitor } = require('klasa');
 
 module.exports = class extends Inhibitor {
 
@@ -11,7 +11,15 @@ module.exports = class extends Inhibitor {
 
 		const existing = command.cooldowns.get(message.levelID);
 
-		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Duration.toNow(Date.now() + existing.remainingTime, false, true), command.cooldownLevel !== 'author');
+		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', this.secondsToFormattedString(Math.ceil(existing.remainingTime / 1000)), command.cooldownLevel !== 'author');
+	}
+	
+	secondsToFormattedString(seconds) {
+		const days = Math.floor(duration / 86400);
+		const hours = Math.floor(duration / 3600);
+		const minutes = Math.floor(duration / 60);
+		const seconds = Math.floor(duration % 60);
+		return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
 	}
 
 };

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -11,7 +11,7 @@ module.exports = class extends Inhibitor {
 
 		const existing = command.cooldowns.get(message.levelID);
 
-		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Duration.toNow(Date.now() + existing.remainingTime), command.cooldownLevel !== 'author');
+		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Duration.toNow(Date.now() + existing.remainingTime, false, true), command.cooldownLevel !== 'author');
 	}
 
 };

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -13,7 +13,7 @@ module.exports = class extends Inhibitor {
 
 		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', this.secondsToFormattedString(Math.ceil(existing.remainingTime / 1000)), command.cooldownLevel !== 'author');
 	}
-	
+
 	secondsToFormattedString(time) {
 		const days = Math.floor(time / 86400);
 		const hours = Math.floor(time / 3600);

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -17,8 +17,8 @@ module.exports = class extends Inhibitor {
 	secondsToFormattedString(time) {
 		const days = Math.floor(time / 86400);
 		const hours = Math.floor(time / 3600);
-		const minutes = Math.floor(time / 60);
-		const seconds = Math.floor(time % 60);
+		const minutes = Math.floor(time / 3600 / 60);
+		const seconds = Math.floor(time / 3600 % 60);
 		return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
 	}
 

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -11,7 +11,7 @@ module.exports = class extends Inhibitor {
 
 		const existing = command.cooldowns.get(message.levelID);
 
-		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Duration.toNow(Date.now() + Math.ceil(existing.remainingTime)), command.cooldownLevel !== 'author');
+		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Duration.toNow(Date.now() + existing.remainingTime), command.cooldownLevel !== 'author');
 	}
 
 };

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -16,9 +16,9 @@ module.exports = class extends Inhibitor {
 
 	secondsToFormattedString(time) {
 		const days = Math.floor(time / 86400);
-		const hours = Math.floor(time / 3600);
-		const minutes = Math.floor(time / 3600 / 60);
-		const seconds = Math.floor(time / 3600 % 60);
+		const hours = Math.floor((time % 86400) / 3600);
+		const minutes = Math.floor((time % 86400 % 3600) / 60);
+		const seconds = Math.floor(time % 86400 % 3600 % 60);
 		return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
 	}
 

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -17,8 +17,8 @@ module.exports = class extends Inhibitor {
 	secondsToFormattedString(time) {
 		const days = Math.floor(time / 86400);
 		const hours = Math.floor((time % 86400) / 3600);
-		const minutes = Math.floor((time % 86400 % 3600) / 60);
-		const seconds = Math.floor(time % 86400 % 3600 % 60);
+		const minutes = Math.floor((time % 3600) / 60);
+		const seconds = Math.floor(time % 60);
 		return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
 	}
 

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -19,7 +19,7 @@ module.exports = class extends Inhibitor {
 		const hours = Math.floor((time % 86400) / 3600);
 		const minutes = Math.floor((time % 3600) / 60);
 		const seconds = Math.floor(time % 60);
-		return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
+		return `${days ? `${days}d ` : ""}${days || hours ? `${hours}h ` : ""}${days || hours || minutes ? `${minutes}m ` : ""}${seconds}s`;
 	}
 
 };

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -1,4 +1,4 @@
-const { Inhibitor } = require('klasa');
+const { Inhibitor, Duration } = require('klasa');
 
 module.exports = class extends Inhibitor {
 
@@ -11,7 +11,7 @@ module.exports = class extends Inhibitor {
 
 		const existing = command.cooldowns.get(message.levelID);
 
-		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Math.ceil(existing.remainingTime / 1000));
+		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Duration.toNow(Date.now() + Math.ceil(existing.remainingTime)));
 	}
 
 };

--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -19,7 +19,7 @@ module.exports = class extends Inhibitor {
 		const hours = Math.floor((time % 86400) / 3600);
 		const minutes = Math.floor((time % 3600) / 60);
 		const seconds = Math.floor(time % 60);
-		return `${days ? `${days}d ` : ""}${days || hours ? `${hours}h ` : ""}${days || hours || minutes ? `${minutes}m ` : ""}${seconds}s`;
+		return `${days ? `${days}d ` : ''}${days || hours ? `${hours}h ` : ''}${days || hours || minutes ? `${minutes}m ` : ''}${seconds}s`;
 	}
 
 };

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -55,7 +55,7 @@ module.exports = class extends Language {
 			MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT: (tag, name, time, cancelOptions) => `${tag} | **${name}** is a repeating argument | You have **${time}** seconds to respond to this prompt with additional valid arguments. Type **${cancelOptions.join('**, **')}** to cancel this prompt.`,
 			MONITOR_COMMAND_HANDLER_ABORTED: 'Aborted',
 			// eslint-disable-next-line max-len
-			INHIBITOR_COOLDOWN: (remaining, guildCooldown) => `${guildCooldown ? 'Someone has' : 'You have'} already used this command. You can use this command again in ${remaining} second${remaining === 1 ? '' : 's'}.`,
+			INHIBITOR_COOLDOWN: (remaining, guildCooldown) => `${guildCooldown ? 'Someone has' : 'You have'} already used this command. You can use this command again in ${remaining}.`,
 			INHIBITOR_DISABLED_GUILD: 'This command has been disabled by an admin in this guild.',
 			INHIBITOR_DISABLED_GLOBAL: 'This command has been globally disabled by the bot owner.',
 			INHIBITOR_MISSING_BOT_PERMS: (missing) => `Insufficient permissions, missing: **${missing}**`,

--- a/src/lib/util/Duration.js
+++ b/src/lib/util/Duration.js
@@ -115,21 +115,12 @@ class Duration {
 	 * @since 0.5.0
 	 * @param {(Date|number|string)} earlier The time to compare
 	 * @param {boolean} [showIn] Whether the output should be prefixed
-	 * @param {boolean} [exact] Whether the output should be exact in DD-HH-MM-SS format
 	 * @returns {string}
 	 */
-	static toNow(earlier, showIn, exact) {
+	static toNow(earlier, showIn) {
 		if (!(earlier instanceof Date)) earlier = new Date(earlier);
 		const returnString = showIn ? 'in ' : '';
 		let duration = Math.abs((Date.now() - earlier) / 1000);
-
-		if (exact) {
-			const days = Math.floor(duration / 86400);
-			const hours = Math.floor(duration / 3600);
-			const minutes = Math.floor(duration / 60);
-			const seconds = Math.floor(duration % 60);
-			return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
-		}
 
 		// Compare the duration in seconds
 		if (duration < 45) return `${returnString}seconds`;

--- a/src/lib/util/Duration.js
+++ b/src/lib/util/Duration.js
@@ -115,12 +115,21 @@ class Duration {
 	 * @since 0.5.0
 	 * @param {(Date|number|string)} earlier The time to compare
 	 * @param {boolean} [showIn] Whether the output should be prefixed
+	 * @param {boolean} [exact] Whether the output should be exact in DD-HH-MM-SS format
 	 * @returns {string}
 	 */
-	static toNow(earlier, showIn) {
+	static toNow(earlier, showIn, exact) {
 		if (!(earlier instanceof Date)) earlier = new Date(earlier);
 		const returnString = showIn ? 'in ' : '';
 		let duration = Math.abs((Date.now() - earlier) / 1000);
+		
+		if (exact) {
+			const days = Math.floor(duration / 86400)
+			const hours = Math.floor(duration / 3600)
+			const minutes = Math.floor(duration / 60)
+			const seconds = Math.floor(duration % 60)
+			return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;	
+		}
 
 		// Compare the duration in seconds
 		if (duration < 45) return `${returnString}seconds`;
@@ -145,6 +154,7 @@ class Duration {
 
 		return `${returnString + Math.round(duration / 365)} years`;
 	}
+	
 
 }
 

--- a/src/lib/util/Duration.js
+++ b/src/lib/util/Duration.js
@@ -122,13 +122,13 @@ class Duration {
 		if (!(earlier instanceof Date)) earlier = new Date(earlier);
 		const returnString = showIn ? 'in ' : '';
 		let duration = Math.abs((Date.now() - earlier) / 1000);
-		
+
 		if (exact) {
-			const days = Math.floor(duration / 86400)
-			const hours = Math.floor(duration / 3600)
-			const minutes = Math.floor(duration / 60)
-			const seconds = Math.floor(duration % 60)
-			return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;	
+			const days = Math.floor(duration / 86400);
+			const hours = Math.floor(duration / 3600);
+			const minutes = Math.floor(duration / 60);
+			const seconds = Math.floor(duration % 60);
+			return `${days ? `${days}d ` : ''}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds ? `${seconds}s ` : ''}`;
 		}
 
 		// Compare the duration in seconds
@@ -154,7 +154,6 @@ class Duration {
 
 		return `${returnString + Math.round(duration / 365)} years`;
 	}
-	
 
 }
 


### PR DESCRIPTION
### Description of the PR
This PR changes the cooldown inhibitor to respond with a more user friendly string showing how much time is left. Currently, it always shows the number of seconds. However, for a command like a `!daily` command this looks really bad when it says like 86,395 seconds remaining. Using the Duration class this is converted into a more readable version.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fix cooldown timer.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
