### PR TITLE
src: Replace client.shard.id with client.options.shards

### DIFF
--- a/src/commands/Admin/disable.js
+++ b/src/commands/Admin/disable.js
@@ -18,7 +18,7 @@ module.exports = class extends Command {
 		piece.disable();
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').disable();
+				if (String(this.options.shards) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').disable();
 			`);
 		}
 		return message.sendLocale('COMMAND_DISABLE', [piece.type, piece.name], { code: 'diff' });

--- a/src/commands/Admin/disable.js
+++ b/src/commands/Admin/disable.js
@@ -18,7 +18,7 @@ module.exports = class extends Command {
 		piece.disable();
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.shard.id}') this.${piece.store}.get('${piece.name}').disable();
+				if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').disable();
 			`);
 		}
 		return message.sendLocale('COMMAND_DISABLE', [piece.type, piece.name], { code: 'diff' });

--- a/src/commands/Admin/enable.js
+++ b/src/commands/Admin/enable.js
@@ -15,7 +15,7 @@ module.exports = class extends Command {
 		piece.enable();
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').enable();
+				if (String(this.options.shards) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').enable();
 			`);
 		}
 		return message.sendCode('diff', message.language.get('COMMAND_ENABLE', piece.type, piece.name));

--- a/src/commands/Admin/enable.js
+++ b/src/commands/Admin/enable.js
@@ -15,7 +15,7 @@ module.exports = class extends Command {
 		piece.enable();
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.shard.id}') this.${piece.store}.get('${piece.name}').enable();
+				if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').enable();
 			`);
 		}
 		return message.sendCode('diff', message.language.get('COMMAND_ENABLE', piece.type, piece.name));

--- a/src/commands/Admin/load.js
+++ b/src/commands/Admin/load.js
@@ -26,7 +26,7 @@ module.exports = class extends Command {
 			await piece.init();
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.shard.id}') {
+					if (String(this.shard.id) !== '${this.client.options.shards}') {
 						const piece = this.${piece.store}.load('${piece.directory}', ${JSON.stringify(path)});
 						if (piece) piece.init();
 					}

--- a/src/commands/Admin/load.js
+++ b/src/commands/Admin/load.js
@@ -26,7 +26,7 @@ module.exports = class extends Command {
 			await piece.init();
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.options.shards}') {
+					if (String(this.options.shards) !== '${this.client.options.shards}') {
 						const piece = this.${piece.store}.load('${piece.directory}', ${JSON.stringify(path)});
 						if (piece) piece.init();
 					}

--- a/src/commands/Admin/reload.js
+++ b/src/commands/Admin/reload.js
@@ -20,7 +20,7 @@ module.exports = class extends Command {
 			await piece.init();
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.shard.id}') this.${piece.name}.loadAll().then(() => this.${piece.name}.init());
+					if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.name}.loadAll().then(() => this.${piece.name}.init());
 				`);
 			}
 			return message.sendLocale('COMMAND_RELOAD_ALL', [piece, timer.stop()]);
@@ -31,7 +31,7 @@ module.exports = class extends Command {
 			const timer = new Stopwatch();
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.shard.id}') this.${piece.store}.get('${piece.name}').reload();
+					if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').reload();
 				`);
 			}
 			return message.sendLocale('COMMAND_RELOAD', [itm.type, itm.name, timer.stop()]);
@@ -49,7 +49,7 @@ module.exports = class extends Command {
 		}));
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.shard.id}') this.pieceStores.map(async (store) => {
+				if (String(this.shard.id) !== '${this.client.options.shards}') this.pieceStores.map(async (store) => {
 					await store.loadAll();
 					await store.init();
 				});

--- a/src/commands/Admin/reload.js
+++ b/src/commands/Admin/reload.js
@@ -20,7 +20,7 @@ module.exports = class extends Command {
 			await piece.init();
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.name}.loadAll().then(() => this.${piece.name}.init());
+					if (String(this.options.shards) !== '${this.client.options.shards}') this.${piece.name}.loadAll().then(() => this.${piece.name}.init());
 				`);
 			}
 			return message.sendLocale('COMMAND_RELOAD_ALL', [piece, timer.stop()]);
@@ -31,7 +31,7 @@ module.exports = class extends Command {
 			const timer = new Stopwatch();
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').reload();
+					if (String(this.options.shards) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').reload();
 				`);
 			}
 			return message.sendLocale('COMMAND_RELOAD', [itm.type, itm.name, timer.stop()]);
@@ -49,7 +49,7 @@ module.exports = class extends Command {
 		}));
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.options.shards}') this.pieceStores.map(async (store) => {
+				if (String(this.options.shards) !== '${this.client.options.shards}') this.pieceStores.map(async (store) => {
 					await store.loadAll();
 					await store.init();
 				});

--- a/src/commands/Admin/transfer.js
+++ b/src/commands/Admin/transfer.js
@@ -22,7 +22,7 @@ module.exports = class extends Command {
 			piece.store.load(piece.store.userDirectory, piece.file);
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.load(${piece.store.userDirectory}, ${JSON.stringify(piece.file)});
+					if (String(this.options.shards) !== '${this.client.options.shards}') this.${piece.store}.load(${piece.store.userDirectory}, ${JSON.stringify(piece.file)});
 				`);
 			}
 			return message.sendLocale('COMMAND_TRANSFER_SUCCESS', [piece.type, piece.name]);

--- a/src/commands/Admin/transfer.js
+++ b/src/commands/Admin/transfer.js
@@ -22,7 +22,7 @@ module.exports = class extends Command {
 			piece.store.load(piece.store.userDirectory, piece.file);
 			if (this.client.shard) {
 				await this.client.shard.broadcastEval(`
-					if (String(this.shard.id) !== '${this.client.shard.id}') this.${piece.store}.load(${piece.store.userDirectory}, ${JSON.stringify(piece.file)});
+					if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.load(${piece.store.userDirectory}, ${JSON.stringify(piece.file)});
 				`);
 			}
 			return message.sendLocale('COMMAND_TRANSFER_SUCCESS', [piece.type, piece.name]);

--- a/src/commands/Admin/unload.js
+++ b/src/commands/Admin/unload.js
@@ -19,7 +19,7 @@ module.exports = class extends Command {
 		piece.unload();
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').unload();
+				if (String(this.options.shards) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').unload();
 			`);
 		}
 		return message.sendLocale('COMMAND_UNLOAD', [piece.type, piece.name]);

--- a/src/commands/Admin/unload.js
+++ b/src/commands/Admin/unload.js
@@ -19,7 +19,7 @@ module.exports = class extends Command {
 		piece.unload();
 		if (this.client.shard) {
 			await this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.shard.id}') this.${piece.store}.get('${piece.name}').unload();
+				if (String(this.shard.id) !== '${this.client.options.shards}') this.${piece.store}.get('${piece.name}').unload();
 			`);
 		}
 		return message.sendLocale('COMMAND_UNLOAD', [piece.type, piece.name]);

--- a/src/events/coreSettingsUpdateEntry.js
+++ b/src/events/coreSettingsUpdateEntry.js
@@ -10,7 +10,7 @@ module.exports = class extends Event {
 	run(settings) {
 		if (gateways.includes(settings.gateway.type)) {
 			this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.shard.id}') {
+				if (String(this.shard.id) !== '${this.client.options.shards}') {
 					const entry = this.gateways.${settings.gateway.type}.get('${settings.id}');
 					if (entry) {
 						entry._patch(${JSON.stringify(settings)});

--- a/src/events/coreSettingsUpdateEntry.js
+++ b/src/events/coreSettingsUpdateEntry.js
@@ -10,7 +10,7 @@ module.exports = class extends Event {
 	run(settings) {
 		if (gateways.includes(settings.gateway.type)) {
 			this.client.shard.broadcastEval(`
-				if (String(this.shard.id) !== '${this.client.options.shards}') {
+				if (String(this.options.shards) !== '${this.client.options.shards}') {
 					const entry = this.gateways.${settings.gateway.type}.get('${settings.id}');
 					if (entry) {
 						entry._patch(${JSON.stringify(settings)});

--- a/src/lib/schedule/ScheduledTask.js
+++ b/src/lib/schedule/ScheduledTask.js
@@ -236,8 +236,7 @@ class ScheduledTask {
 	 * @private
 	 */
 	static _generateID(client) {
-		const id = client.shard ? (Array.isArray(client.shard.id) ? client.shard.id[0] : client.shard.id).toString(36) : '';
-		return Date.now().toString(36) + id;
+		return `${Date.now().toString(36)}${client.options.shards[0].toString(36)}`;
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR

This PR replaces all usages of `client.shard.id` with `client.options.shards` (skipping a getter, and fixing a bug, since `shard.id` is undefined, while `shard.ids` isn't)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
