### PR TITLE
Updated _parseCommand method

### DIFF
--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -298,12 +298,9 @@ module.exports = Structures.extend('Message', Message => {
 		_parseCommand() {
 			try {
 				const prefix = this._customPrefix() || this._mentionPrefix() || this._naturalPrefix() || this._prefixLess();
-
-				if (!prefix) return;
-
-				this.prefix = prefix.regex;
-				this.prefixLength = prefix.length;
-				this.commandText = this.content.slice(prefix.length).trim().split(' ')[0].toLowerCase();
+				this.prefix = prefix ? prefix.regex : null;
+				this.prefixLength = prefix ? prefix.length : null;
+				this.commandText = prefix ? this.content.slice(prefix.length).trim().split(' ')[0].toLowerCase() : null;
 				this.command = this.client.commands.get(this.commandText) || null;
 
 				if (!this.command) return;


### PR DESCRIPTION
### Description of the PR
#### How it worked before this PR
If a user edits their command message and replaces its content with an invalid command and the command previously run contained subcommands it would error but if it didn't contain subcommands the client would run the same command a second time because the values were not redefined.

#### How it works now
Once a user runs a command then edits the contents that don't contain a valid prefix the properties are set to null since it would be an invalid command. Which tells the commandHandler that it's not a valid command to run.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
