### PR TITLE
Define this.typings In TextPrompt

### DIFF
--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -157,6 +157,14 @@ class TextPrompt {
 		 * @type external:Collection
 		 */
 		this.responses = new Collection();
+		
+		/**
+		 * The typing state of this CommandPrompt
+		 * @since 0.5.0
+		 * @type {boolean}
+		 * @private
+		 */
+		this.typing = this.client.options.typing;
 	}
 
 	/**

--- a/src/lib/usage/TextPrompt.js
+++ b/src/lib/usage/TextPrompt.js
@@ -157,7 +157,7 @@ class TextPrompt {
 		 * @type external:Collection
 		 */
 		this.responses = new Collection();
-		
+
 		/**
 		 * The typing state of this CommandPrompt
 		 * @since 0.5.0


### PR DESCRIPTION
### Description of the PR
This PR adds a missing property in the TextPrompt that is used in the file various times but is never defined.
Example:
```js
async reprompt(this: TextPrompt, prompt) {
		this._prompted++
		if (this.typing) this.message.channel.stopTyping()
```

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Add missing property

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
