### PR TITLE
Added an options property to the Command class

### DIFF
--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -204,7 +204,12 @@ class Command extends AliasPiece {
 		 * @private
 		 */
 		this.cooldowns = new RateLimitManager(options.bucket, options.cooldown * 1000);
-		
+
+		/**
+		 * Extra options passed to the command
+		 * @since 0.5.0
+		 * @type {any}
+		 */
 		this.options = options;
 	}
 

--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -204,6 +204,8 @@ class Command extends AliasPiece {
 		 * @private
 		 */
 		this.cooldowns = new RateLimitManager(options.bucket, options.cooldown * 1000);
+		
+		this.options = options;
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR
I added an options property for commands. This will allow users to extend their commands further, by allowing them to pass extra options to commands then access them in for example 'Inhibitors'. The extra options can be accessed by doing `command.options['option name here']` the original built-in options can be accessed normally by doing something like `command.name` or `command.options.name`. This is also useful so users won't have to create a whole new Command class extending the existing klasa Command class, just to allow for more command options, with this they can continue to still use the original klasa command class for their commands while having the property to allow accessing extra options they want for their commands.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
