### PR TITLE
Add prefixReminder client option to disable prefix reminder

### DIFF
--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -79,7 +79,8 @@ class KlasaClient extends Discord.Client {
 	 * @property {number} [slowmode=0] Amount of time in ms before the bot will respond to a users command since the last command that user has run
 	 * @property {boolean} [slowmodeAggressive=false] If the slowmode time should reset if a user spams commands faster than the slowmode allows for
 	 * @property {boolean} [typing=false] Whether the bot should type while processing commands
-	 * @property {boolean} [prefixCaseInsensitive=false] Wether the bot should respond to case insensitive prefix or not
+	 * @property {boolean} [prefixCaseInsensitive=false] Whether the bot should respond to case insensitive prefix or not
+	 * @property {boolean} [prefixReminder=true] Whether the bot should respond with a prefix reminder when directly mentioned
 	 */
 
 	/**

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -24,6 +24,7 @@ exports.DEFAULTS = {
 		createPiecesFolders: true,
 		disabledCorePieces: [],
 		language: 'en-US',
+		prefixReminder: true,
 		noPrefixDM: false,
 		prefix: '',
 		preserveSettings: true,

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -10,7 +10,7 @@ module.exports = class extends Monitor {
 	async run(message) {
 		if (message.guild && !message.guild.me) await message.guild.members.fetch(this.client.user);
 		if (!message.channel.postable) return undefined;
-		if (!message.commandText && message.prefix === this.client.mentionPrefix) {
+		if (this.client.options.prefixReminder && !message.commandText && message.prefix === this.client.mentionPrefix) {
 			return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length ? message.guildSettings.prefix : undefined]);
 		}
 		if (!message.commandText) return undefined;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1006,6 +1006,7 @@ declare module 'klasa' {
 		slowmode?: number;
 		slowmodeAggressive?: boolean;
 		typing?: boolean;
+		prefixReminder?: boolean;
 	}
 
 	export interface ScheduleOptions {


### PR DESCRIPTION
### Description of the PR
This PR adds the ability to disable the prefix reminder in commandHandler without transfering and modifying the commandHandler monitor.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
