### PR TITLE
Feat event mention prefix only

### DIFF
--- a/src/events/coreMentionPrefixOnly.js
+++ b/src/events/coreMentionPrefixOnly.js
@@ -1,0 +1,15 @@
+const { Event } = require('klasa');
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { event: 'prefixOnly' });
+	}
+
+	async run(message) {
+		if (!message.commandText) {
+			await message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length ? message.guildSettings.prefix : undefined]);
+		}
+	}
+
+};

--- a/src/events/coreMentionPrefixOnly.js
+++ b/src/events/coreMentionPrefixOnly.js
@@ -3,7 +3,7 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	constructor(...args) {
-		super(...args, { event: 'prefixOnly' });
+		super(...args, { event: 'mentionPrefixOnly' });
 	}
 
 	async run(message) {

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -675,6 +675,13 @@ KlasaClient.defaultClientSchema = new Schema()
  */
 
 /**
+ * Emitted when a message is a mention prefix.
+ * @event KlasaClient#mentionPrefixOnly
+ * @since 0.5.0
+ * @param {KlasaMessage} The message that matched the prefix
+ */
+
+/**
  * Emitted when {@link Settings#update} or {@link Settings#reset} is run.
  * @event KlasaClient#settingsUpdateEntry
  * @since 0.5.0

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -10,8 +10,8 @@ module.exports = class extends Monitor {
 	async run(message) {
 		if (message.guild && !message.guild.me) await message.guild.members.fetch(this.client.user);
 		if (!message.channel.postable) return undefined;
-		if (!message.commandText && message.prefix === this.client.mentionPrefix) {
-			return message.sendLocale('PREFIX_REMINDER', [message.guildSettings.prefix.length ? message.guildSettings.prefix : undefined]);
+		if (message.prefix === this.client.mentionPrefix) {
+			return this.emit('mentionPrefixOnly', message);
 		}
 		if (!message.commandText) return undefined;
 		if (!message.command) return this.client.emit('commandUnknown', message, message.commandText, message.prefix, message.prefixLength);

--- a/src/monitors/commandHandler.js
+++ b/src/monitors/commandHandler.js
@@ -11,7 +11,7 @@ module.exports = class extends Monitor {
 		if (message.guild && !message.guild.me) await message.guild.members.fetch(this.client.user);
 		if (!message.channel.postable) return undefined;
 		if (message.prefix === this.client.mentionPrefix) {
-			return this.emit('mentionPrefixOnly', message);
+			return this.client.emit('mentionPrefixOnly', message);
 		}
 		if (!message.commandText) return undefined;
 		if (!message.command) return this.client.emit('commandUnknown', message, message.commandText, message.prefix, message.prefixLength);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1658,6 +1658,7 @@ declare module 'discord.js' {
 		on(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		on(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		on(event: 'commandUnknown', listener: (message: KlasaMessage, command: string, prefix: RegExp, prefixLength: number) => void): this;
+		on(event: 'mentionPrefixOnly', listener: (message: KlasaMessage) => void): this;
 		on(event: 'finalizerError', listener: (message: KlasaMessage, command: Command, response: KlasaMessage, runTime: Stopwatch, finalizer: Finalizer, error: Error | string) => void): this;
 		on(event: 'log', listener: (data: any) => void): this;
 		on(event: 'monitorError', listener: (message: KlasaMessage, monitor: Monitor, error: Error | string) => void): this;
@@ -1678,6 +1679,7 @@ declare module 'discord.js' {
 		once(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		once(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		once(event: 'commandUnknown', listener: (message: KlasaMessage, command: string, prefix: RegExp, prefixLength: number) => void): this;
+		once(event: 'mentionPrefixOnly', listener: (message: KlasaMessage) => void): this;
 		once(event: 'finalizerError', listener: (message: KlasaMessage, command: Command, response: KlasaMessage, runTime: Stopwatch, finalizer: Finalizer, error: Error | string) => void): this;
 		once(event: 'log', listener: (data: any) => void): this;
 		once(event: 'monitorError', listener: (message: KlasaMessage, monitor: Monitor, error: Error | string) => void): this;
@@ -1698,6 +1700,7 @@ declare module 'discord.js' {
 		off(event: 'commandRun', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		off(event: 'commandSuccess', listener: (message: KlasaMessage, command: Command, params: any[], response: any) => void): this;
 		off(event: 'commandUnknown', listener: (message: KlasaMessage, command: string, prefix: RegExp, prefixLength: number) => void): this;
+		off(event: 'mentionPrefixOnly', listener: (message: KlasaMessage) => void): this;
 		off(event: 'finalizerError', listener: (message: KlasaMessage, command: Command, response: KlasaMessage, runTime: Stopwatch, finalizer: Finalizer, error: Error | string) => void): this;
 		off(event: 'log', listener: (data: any) => void): this;
 		off(event: 'monitorError', listener: (message: KlasaMessage, monitor: Monitor, error: Error | string) => void): this;


### PR DESCRIPTION
### Description of the PR

Alternative to #792 but an event instead of an option, allows for developers to expand the logic of the prefix even further while trying to follow [Discord Bot Best Practices](https://github.com/meew0/discord-bot-best-practices) and prefixes the event with `core` to avoid overriding it unwillingly.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added `mentionPrefixOnly` event.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
