### PR TITLE
feat(typings): language.get() generics improvement

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -477,7 +477,7 @@ declare module 'klasa' {
 		public constructor(store: LanguageStore, file: string[], directory: string, options?: LanguageOptions);
 		public language: Record<string, string | string[] | ((...args: any[]) => string | string[])>;
 
-		public get<T = string>(term: string, ...args: any[]): T;
+		public get<T = string, A extends any[] = any[]>(term: string, ...args: A): T;
 		public toJSON(): PieceLanguageJSON;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -477,7 +477,7 @@ declare module 'klasa' {
 		public constructor(store: LanguageStore, file: string[], directory: string, options?: LanguageOptions);
 		public language: Record<string, string | string[] | ((...args: any[]) => string | string[])>;
 
-		public get<T = string, A extends any[] = any[]>(term: string, ...args: A): T;
+		public get<T = string, A extends readonly unknown[] = readonly unknown[]>(term: string, ...args: A): T;
 		public toJSON(): PieceLanguageJSON;
 	}
 


### PR DESCRIPTION
### Description of the PR

Adding an optional generic to `Language.get` allows for stricter type checking when using structures such as `throw message.language.get()`. This is best shown through screenshots, see below.

- First, some language key is defined with some parameters. This can be virtually anywhere in the code.
- The types of the parameters of that key are extracted with `Parameters<typeof [name of the key]>`
- They are passed in to the `get()` function with `get<string, Parameters<typeof [name of the key]>`

In the fourth screenshot you can see this in action, where I purposely go against the `langParams` by giving an array of numbers instead of an array of strings as is defined in the language key. 

![19-28-09_12-09-2019_Code](https://user-images.githubusercontent.com/4019718/64807914-7ff3b700-d596-11e9-83d9-0a3b1f3938c3.png)
![19-27-50_12-09-2019_Code](https://user-images.githubusercontent.com/4019718/64807910-7d915d00-d596-11e9-8322-21bb1ca8e9d3.png)
![19-27-54_12-09-2019_Code](https://user-images.githubusercontent.com/4019718/64807913-7ec28a00-d596-11e9-8504-66f5ce4ff35b.png)

In action:
![image](https://user-images.githubusercontent.com/4019718/64808140-f7c1e180-d596-11e9-9360-6df2d924aae3.png)

Notes about the PR:
- I tried to exclude the `extends any[]` however then TSC says `A rest parameter must be of an array type.ts(2370)` despite being defaulted to it.x	

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Improved type generic for `language.get()`

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.