### PR TITLE
deepClone objects and arrays from settings

### DIFF
--- a/src/lib/settings/SettingsFolder.js
+++ b/src/lib/settings/SettingsFolder.js
@@ -1,4 +1,4 @@
-const { isObject, objectToTuples, arraysStrictEquals, toTitleCase, mergeObjects, makeObject, resolveGuild } = require('../util/util');
+const { isObject, objectToTuples, arraysStrictEquals, toTitleCase, mergeObjects, makeObject, resolveGuild, deepClone } = require('../util/util');
 const Type = require('../util/Type');
 
 /**
@@ -81,7 +81,7 @@ class SettingsFolder extends Map {
 	 */
 	get(path) {
 		// Map.prototype.get.call was used to avoid infinite recursion
-		return path.split('.').reduce((folder, key) => Map.prototype.get.call(folder, key), this);
+		return deepClone(path.split('.').reduce((folder, key) => Map.prototype.get.call(folder, key), this));
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR
Alternative to SettingsArray from #752. In both PRs the only way to achieve what we're looking for is to deepClone the result obtained from the database and return it in a .get() call or similar (we would still have to deepClone the private data field in that PR as well to fully achieve the purpose of the PR).

It makes more sense to go about it this route, which is significantly easier and less code. This will make updating objects, arrays, and the combination of both significantly easier throughout Klasa.

No external code changes necessary to make this work, and this is more of a bug fix then anything else.

You can now update doing things like this:
```javascript
const prefixes = message.guild.settings.get('prefix'); // ["!", "+"]
prefixes[1] = "?";
// message.guild.settings.get('prefix') = ["!", "+"]
// prefixes = ["!", "?"]
message.guild.settings.update('prefix', prefixes);
```
Without mutating references in settings.


### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
