### PR TITLE
Fix AliasStore docs

### DIFF
--- a/src/lib/structures/base/AliasStore.js
+++ b/src/lib/structures/base/AliasStore.js
@@ -22,17 +22,17 @@ class AliasStore extends Store {
 	}
 
 	/**
-	 * Returns an argument in the store if it exists by its name or by an alias.
+	 * Returns an AliasPiece in the store if it exists by its name or by an alias.
 	 * @since 0.5.0
 	 * @param {string} name A argument or alias name
-	 * @returns {?Argument}
+	 * @returns {?AliasPiece}
 	 */
 	get(name) {
 		return super.get(name) || this.aliases.get(name);
 	}
 
 	/**
-	 * Returns a boolean if the argument or alias is found within the store.
+	 * Returns a boolean if the AliasPiece or alias is found within the store.
 	 * @since 0.5.0
 	 * @param {string} name A command or alias name
 	 * @returns {boolean}
@@ -42,33 +42,33 @@ class AliasStore extends Store {
 	}
 
 	/**
-	 * Sets up an argument in our store.
+	 * Sets up an AliasPiece in our store.
 	 * @since 0.5.0
-	 * @param {Argument} piece The command piece we are setting up
-	 * @returns {?Argument}
+	 * @param {AliasPiece} piece The command piece we are setting up
+	 * @returns {?AliasPiece}
 	 */
 	set(piece) {
-		const argument = super.set(piece);
-		if (!argument) return undefined;
-		for (const alias of argument.aliases) this.aliases.set(alias, argument);
-		return argument;
+		const aliasPiece = super.set(piece);
+		if (!aliasPiece) return undefined;
+		for (const alias of aliasPiece.aliases) this.aliases.set(alias, aliasPiece);
+		return aliasPiece;
 	}
 
 	/**
-	 * Deletes an argument from the store.
+	 * Deletes an AliasPiece from the store.
 	 * @since 0.5.0
-	 * @param {Argument|string} name An argument object or a string representing an argument or alias name
+	 * @param {AliasPiece|string} name An AliasPiece object or a string representing an AliasPiece or alias name
 	 * @returns {boolean} whether or not the delete was successful.
 	 */
 	delete(name) {
-		const argument = this.resolve(name);
-		if (!argument) return false;
-		for (const alias of argument.aliases) this.aliases.delete(alias);
-		return super.delete(argument);
+		const aliasPiece = this.resolve(name);
+		if (!aliasPiece) return false;
+		for (const alias of aliasPiece.aliases) this.aliases.delete(alias);
+		return super.delete(aliasPiece);
 	}
 
 	/**
-	 * Clears the arguments and aliases from this store
+	 * Clears the AliasPieces and aliases from this store
 	 * @since 0.5.0
 	 * @returns {void}
 	 */


### PR DESCRIPTION
### Description of the PR
Fixes documentation on the AliasStore which was falsely copied docs from ArgumentStore

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
