### PR TITLE
rename Message#flags

### DIFF
--- a/src/commands/Admin/eval.js
+++ b/src/commands/Admin/eval.js
@@ -20,7 +20,7 @@ module.exports = class extends Command {
 		const output = message.language.get(success ? 'COMMAND_EVAL_OUTPUT' : 'COMMAND_EVAL_ERROR',
 			time, util.codeBlock('js', result), footer);
 
-		if ('silent' in message.flags) return null;
+		if ('silent' in message.flagArgs) return null;
 
 		// Handle too-long-messages
 		if (output.length > 2000) {

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -94,7 +94,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @type {Object}
 		 * @readonly
 		 */
-		get flags() {
+		get flagArgs() {
 			return this.prompter ? this.prompter.flags : {};
 		}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1750,7 +1750,7 @@ declare module 'discord.js' {
 		readonly responses: KlasaMessage[];
 		readonly args: string[];
 		readonly params: any[];
-		readonly flags: Record<string, string>;
+		readonly flagArgs: Record<string, string>;
 		readonly reprompted: boolean;
 		readonly reactable: boolean;
 		send(content?: StringResolvable, options?: MessageOptions): Promise<KlasaMessage | KlasaMessage[]>;


### PR DESCRIPTION
### Description of the PR
because discord added their own message flags. fixes #826 

This is a breaking bug-fix because discord.js added Message#flags as noted in that issue. It is now named Message#flagArgs.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [x] This PR removes or renames methods or properties in the framework interface.
