### PR TITLE
Fix ReactionHandler's permissions issues

### DIFF
--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -111,7 +111,8 @@ class ReactionHandler extends ReactionCollector {
 		else return this.stop();
 
 		this.on('collect', (reaction, user) => {
-			reaction.users.remove(user);
+			const clientPermissions = reaction.message.channel.permissionsFor(reaction.message.client);
+			if (clientPermissions.has("MANAGE_MESSAGES")) reaction.users.remove(user);
 			this[this.methodMap.get(reaction.emoji.id || reaction.emoji.name)](user);
 		});
 		this.on('end', () => {

--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -112,7 +112,7 @@ class ReactionHandler extends ReactionCollector {
 
 		this.on('collect', (reaction, user) => {
 			const clientPermissions = reaction.message.channel.permissionsFor(reaction.message.client);
-			if (clientPermissions.has("MANAGE_MESSAGES")) reaction.users.remove(user);
+			if (clientPermissions.has('MANAGE_MESSAGES')) reaction.users.remove(user);
 			this[this.methodMap.get(reaction.emoji.id || reaction.emoji.name)](user);
 		});
 		this.on('end', () => {


### PR DESCRIPTION
# Description of the PR
So, I'm using this class a lot, such as in my help command, music playlists, etc and I found out I would often get issues due to missing bot permissions. 
I thought it'd be nice to add the permission check inside the class itself rather than some custom checks I would add into Klasa's code (which is not a good solution since I have to upload separately the klasa module now rather than just `npm install`-ing it).

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added permission check inside ReactionHandler for "MANAGE_MESSAGES" when deleting a reaction from a message.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
