### PR TITLE
More perms fixes to ReactionHandler

### DIFF
--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -330,9 +330,13 @@ class ReactionHandler extends ReactionCollector {
 	 */
 	async _queueEmojiReactions(emojis) {
 		if (this.message.deleted) return this.stop();
-		if (this.ended) return this.message.reactions.removeAll();
-		await this.message.react(emojis.shift());
-		if (emojis.length) return this._queueEmojiReactions(emojis);
+		const clientPermissions = this.message.channel.permissionsFor(this.message.client);
+		if (this.ended && clientPermissions.has('MANAGE_MESSAGES')) return this.message.reactions.removeAll();
+		if (this.ended) return null;
+		if (clientPermissions.has('ADD_REACTIONS')) {
+			await this.message.react(emojis.shift());
+			if (emojis.length) return this._queueEmojiReactions(emojis);
+		}
 		this.reactionsDone = true;
 		return null;
 	}


### PR DESCRIPTION
# Description of the PR
Should fix more of ReactionHandler's permissions errors.
Forgot to add them in the first pull request. Sorry.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Check if client has permission MANAGE_MESSAGES so it is can remove all reactions from the focused message. Returns null if it hasn't got permissions (so it can still close the ReactionHandler like it did before this PR)
- Check if client has permission ADD_REACTIONS so it can add reactions to the focused message, if not it will just continue and close the ReactionHandler.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
