### PR TITLE
Revert "Cooldown Inhibitor Change Seconds To Formatted String"

### DIFF
--- a/src/inhibitors/cooldown.js
+++ b/src/inhibitors/cooldown.js
@@ -17,15 +17,7 @@ module.exports = class extends Inhibitor {
 			return;
 		}
 
-		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', this.secondsToFormattedString(Math.ceil(existing.remainingTime / 1000)), command.cooldownLevel !== 'author');
-	}
-
-	secondsToFormattedString(time) {
-		const days = Math.floor(time / 86400);
-		const hours = Math.floor((time % 86400) / 3600);
-		const minutes = Math.floor((time % 3600) / 60);
-		const seconds = Math.floor(time % 60);
-		return `${days ? `${days}d ` : ''}${days || hours ? `${hours}h ` : ''}${days || hours || minutes ? `${minutes}m ` : ''}${seconds}s`;
+		if (existing && existing.limited) throw message.language.get('INHIBITOR_COOLDOWN', Math.ceil(existing.remainingTime / 1000), command.cooldownLevel !== 'author');
 	}
 
 };

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -55,7 +55,7 @@ module.exports = class extends Language {
 			MONITOR_COMMAND_HANDLER_REPEATING_REPROMPT: (tag, name, time, cancelOptions) => `${tag} | **${name}** is a repeating argument | You have **${time}** seconds to respond to this prompt with additional valid arguments. Type **${cancelOptions.join('**, **')}** to cancel this prompt.`,
 			MONITOR_COMMAND_HANDLER_ABORTED: 'Aborted',
 			// eslint-disable-next-line max-len
-			INHIBITOR_COOLDOWN: (remaining, guildCooldown) => `${guildCooldown ? 'Someone has' : 'You have'} already used this command. You can use this command again in ${remaining}.`,
+			INHIBITOR_COOLDOWN: (remaining, guildCooldown) => `${guildCooldown ? 'Someone has' : 'You have'} already used this command. You can use this command again in ${remaining} second${remaining === 1 ? '' : 's'}.`,
 			INHIBITOR_DISABLED_GUILD: 'This command has been disabled by an admin in this guild.',
 			INHIBITOR_DISABLED_GLOBAL: 'This command has been globally disabled by the bot owner.',
 			INHIBITOR_MISSING_BOT_PERMS: (missing) => `Insufficient permissions, missing: **${missing}**`,


### PR DESCRIPTION
### Description of the PR

Reverts dirigeants/klasa#763

The patch was completely wrong, it's in English, and English duration should never be injected into language files.

Fixes a headache when translating the bot into non-latin languages and languages that don't use the same letters to identify the times.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Reverted #763

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
