### PR TITLE
Fix(Extendable): Fix TS decorators breaking Extendables

### DIFF
--- a/src/lib/structures/Extendable.js
+++ b/src/lib/structures/Extendable.js
@@ -31,8 +31,10 @@ class Extendable extends Piece {
 		super(store, file, directory, options);
 
 		const staticPropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf(this.constructor))
+			.concat(Object.getOwnPropertyNames(this.constructor)
 			.filter(name => !['length', 'prototype', 'name'].includes(name));
 		const instancePropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf(this.constructor.prototype))
+			.concat(Object.getOwnPropertyNames(this.constructor.prototype)
 			.filter(name => name !== 'constructor');
 
 		/**
@@ -42,7 +44,7 @@ class Extendable extends Piece {
 		 * @private
 		 */
 		this.staticPropertyDescriptors = Object.assign({}, ...staticPropertyNames
-			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.constructor), name) })));
+			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(this.constructor, name) || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.constructor), name) })));
 
 		/**
 		 * The instance property descriptors of this extendable
@@ -51,7 +53,7 @@ class Extendable extends Piece {
 		 * @private
 		 */
 		this.instancePropertyDescriptors = Object.assign({}, ...instancePropertyNames
-			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.constructor.prototype), name) })));
+			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(this.constructor.prototype, name) || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.constructor.prototype), name) })));
 
 		/**
 		 * The original property descriptors for each of the original classes

--- a/src/lib/structures/Extendable.js
+++ b/src/lib/structures/Extendable.js
@@ -30,9 +30,9 @@ class Extendable extends Piece {
 	constructor(store, file, directory, options = {}) {
 		super(store, file, directory, options);
 
-		const staticPropertyNames = Object.getOwnPropertyNames(this.constructor)
+		const staticPropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf(this.constructor))
 			.filter(name => !['length', 'prototype', 'name'].includes(name));
-		const instancePropertyNames = Object.getOwnPropertyNames(this.constructor.prototype)
+		const instancePropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf(this.constructor.prototype))
 			.filter(name => name !== 'constructor');
 
 		/**
@@ -42,7 +42,7 @@ class Extendable extends Piece {
 		 * @private
 		 */
 		this.staticPropertyDescriptors = Object.assign({}, ...staticPropertyNames
-			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(this.constructor, name) })));
+			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.constructor), name) })));
 
 		/**
 		 * The instance property descriptors of this extendable
@@ -51,7 +51,7 @@ class Extendable extends Piece {
 		 * @private
 		 */
 		this.instancePropertyDescriptors = Object.assign({}, ...instancePropertyNames
-			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(this.constructor.prototype, name) })));
+			.map(name => ({ [name]: Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.constructor.prototype), name) })));
 
 		/**
 		 * The original property descriptors for each of the original classes

--- a/src/lib/structures/Extendable.js
+++ b/src/lib/structures/Extendable.js
@@ -31,10 +31,10 @@ class Extendable extends Piece {
 		super(store, file, directory, options);
 
 		const staticPropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf(this.constructor))
-			.concat(Object.getOwnPropertyNames(this.constructor)
+			.concat(Object.getOwnPropertyNames(this.constructor))
 			.filter(name => !['length', 'prototype', 'name'].includes(name));
 		const instancePropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf(this.constructor.prototype))
-			.concat(Object.getOwnPropertyNames(this.constructor.prototype)
+			.concat(Object.getOwnPropertyNames(this.constructor.prototype))
 			.filter(name => name !== 'constructor');
 
 		/**


### PR DESCRIPTION
### Description of the PR
When an extendable is decorated, Object.getOwnPropertyKeys() no longer returns the property names, not even the built in ones (constructor, prototype, name, length)

The fix in action can be viewed [here](https://gist.github.com/PyroTechniac/ebf07fa3c1c458810563bbf0957295d9)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
