### PR TITLE
Fix: disable command warning on proper event

### DIFF
--- a/src/commands/Admin/disable.js
+++ b/src/commands/Admin/disable.js
@@ -12,7 +12,7 @@ module.exports = class extends Command {
 	}
 
 	async run(message, [piece]) {
-		if ((piece.type === 'event' && piece.name === 'message') || (piece.type === 'monitor' && piece.name === 'commandHandler')) {
+		if ((piece.type === 'event' && piece.name === 'coreMessage') || (piece.type === 'monitor' && piece.name === 'commandHandler')) {
 			return message.sendLocale('COMMAND_DISABLE_WARN');
 		}
 		piece.disable();


### PR DESCRIPTION
### Description of the PR
The `message` event was renamed to `coreMessage`, but this still checked if the name was `message`


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
