### PR TITLE
Docs: Fix Settings#sync docs

### DIFF
--- a/src/lib/settings/Settings.js
+++ b/src/lib/settings/Settings.js
@@ -68,7 +68,7 @@ class Settings extends SettingsFolder {
 	 * Sync the data from the database with the cache.
 	 * @since 0.5.0
 	 * @param {boolean} [force=false] Whether the sync should download from the database
-	 * @returns {Promise<this>}
+	 * @returns {this}
 	 */
 	async sync(force = this.existenceStatus === null) {
 		// If not force and the instance has already been synchronized with the database, return this


### PR DESCRIPTION
### Description of the PR
In #862, Settings#sync was made async, however the docs weren't updated, so the parser marks the function as return Promise<Promise<this>> in the docs.


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
