### PR TITLE
Fixed custom/mention prefix parsing.

### DIFF
--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -292,7 +292,7 @@ module.exports = Structures.extend('Message', Message => {
 			this.prompter = null;
 
 			try {
-				const prefix = this._customPrefix() || this._mentionPrefix() || this._naturalPrefix() || this._prefixLess();
+				const prefix = this._mentionPrefix() || this._customPrefix() || this._naturalPrefix() || this._prefixLess();
 
 				if (!prefix) return;
 


### PR DESCRIPTION
### Description of the PR
This PR changes the prefix parsing to allow checking for the mentionPrefix before the customPrefix. This will fix the issue where if a user changes the bot's prefix to `<` it causes the mention prefix to not work anymore.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.