### PR TITLE
Remove client from CommandUsage constructor, and remove some old typings

### DIFF
--- a/src/lib/structures/Command.js
+++ b/src/lib/structures/Command.js
@@ -185,7 +185,7 @@ class Command extends AliasPiece {
 		 * @since 0.0.1
 		 * @type {CommandUsage}
 		 */
-		this.usage = new CommandUsage(this.client, options.usage, options.usageDelim, this);
+		this.usage = new CommandUsage(this, options.usage, options.usageDelim);
 
 		/**
 		 * The level at which cooldowns should apply

--- a/src/lib/usage/CommandUsage.js
+++ b/src/lib/usage/CommandUsage.js
@@ -9,13 +9,12 @@ class CommandUsage extends Usage {
 
 	/**
 	 * @since 0.0.1
-	 * @param {KlasaClient} client The klasa client
+	 * @param {Command} command The command this parsed usage is for
 	 * @param {usageString} usageString The usage string for this command
 	 * @param {usageDelim} usageDelim The usage deliminator for this command
-	 * @param {Command} command The command this parsed usage is for
 	 */
-	constructor(client, usageString, usageDelim, command) {
-		super(client, usageString, usageDelim);
+	constructor(command, usageString, usageDelim) {
+		super(command.client, usageString, usageDelim);
 
 		/**
 		 * All names and aliases for the command

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -95,63 +95,6 @@ declare module 'klasa' {
 
 //#endregion Extensions
 
-//#region Parsers
-
-	export class Resolver {
-		public constructor(client: KlasaClient);
-		public readonly client: KlasaClient;
-
-		public boolean(input: boolean | string): Promise<boolean>;
-		public channel(input: Channel | Snowflake): Promise<Channel>;
-		public float(input: string | number): Promise<number>;
-		public guild(input: KlasaGuild | Snowflake): Promise<KlasaGuild>;
-		public integer(input: string | number): Promise<number>;
-		public member(input: KlasaUser | GuildMember | Snowflake, guild: KlasaGuild): Promise<GuildMember>;
-		public message(input: KlasaMessage | Snowflake, channel: Channel): Promise<KlasaMessage>;
-		public role(input: Role | Snowflake, guild: KlasaGuild): Promise<Role>;
-		public string(input: string): Promise<string>;
-		public url(input: string): Promise<string>;
-		public user(input: KlasaUser | GuildMember | KlasaMessage | Snowflake): Promise<KlasaUser>;
-
-		public static readonly regex: {
-			userOrMember: RegExp,
-			channel: RegExp,
-			role: RegExp,
-			snowflake: RegExp
-		};
-	}
-
-	export class SettingResolver extends Resolver {
-		public any(data: any): Promise<any>;
-		public boolean(data: any, guild: KlasaGuild, name: string): Promise<boolean>;
-		public boolean(input: boolean | string): Promise<boolean>;
-		public channel(data: any, guild: KlasaGuild, name: string): Promise<Channel>;
-		public channel(input: Channel | Snowflake): Promise<Channel>;
-		public command(data: any, guild: KlasaGuild, name: string): Promise<Command>;
-		public float(data: any, guild: KlasaGuild, name: string, minMax: { min: number, max: number }): Promise<number>;
-		public float(input: string | number): Promise<number>;
-		public guild(data: any, guild: KlasaGuild, name: string): Promise<KlasaGuild>;
-		public guild(input: KlasaGuild | Snowflake): Promise<KlasaGuild>;
-		public integer(data: any, guild: KlasaGuild, name: string, minMax: { min: number, max: number }): Promise<number>;
-		public integer(input: string | number): Promise<number>;
-		public language(data: any, guild: KlasaGuild, name: string): Promise<Language>;
-		public role(data: any, guild: KlasaGuild, name: string): Promise<Role>;
-		public role(input: Role | Snowflake, guild: KlasaGuild): Promise<Role>;
-		public string(data: any, guild: KlasaGuild, name: string, minMax: { min: number, max: number }): Promise<string>;
-		public string(input: string): Promise<string>;
-		public textchannel(data: any, guild: KlasaGuild, name: string): Promise<TextChannel>;
-		public url(data: any, guild: KlasaGuild, name: string): Promise<string>;
-		public url(input: string): Promise<string>;
-		public user(data: any, guild: KlasaGuild, name: string): Promise<KlasaUser>;
-		public user(input: KlasaUser | GuildMember | KlasaMessage | Snowflake): Promise<KlasaUser>;
-		public voicechannel(data: any, guild: KlasaGuild, name: string): Promise<VoiceChannel>;
-		public categorychannel(data: any, guild: KlasaGuild, name: string): Promise<VoiceChannel>;
-
-		public static maxOrMin(guild: KlasaGuild, value: number, min: number, max: number, name: string, suffix: string): boolean;
-	}
-
-//#endregion Parsers
-
 //#region Permissions
 
 	export class PermissionLevels extends Collection<number, PermissionLevel> {
@@ -621,7 +564,7 @@ declare module 'klasa' {
 	}
 
 	export class CommandUsage extends Usage {
-		public constructor(client: KlasaClient, usageString: string, usageDelim: string | null, command: Command);
+		public constructor(command: Command, usageString: string, usageDelim: string | null);
 		public names: string[];
 		public commands: string;
 		public nearlyFullUsage: string;


### PR DESCRIPTION
### Description of the PR
Removes the client from the CommandUsage constructor (as it's present on the Command instance) and cleans up some typings.


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
