### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,7 @@ NOTE: For the contributors, you add new entries to this document following this 
 
 ### Fixed
 
+- [] Fixed shard count in the stats command.
 - [[#383](https://github.com/dirigeants/klasa/pull/383)] Fixed abstract `SQLProvider#qb` property being missing in typings. (kyranet)
 - [[#362](https://github.com/dirigeants/klasa/pull/362)] Fixed object mutation in `GatewayDriver#toJSON()`. (kyranet)
 - [[#355](https://github.com/dirigeants/klasa/pull/355)] Fixed Schedule not deleting entries that do not exist in ClientStorage but are still cached in Schedule#tasks. (kyranet)

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -171,7 +171,7 @@ module.exports = class extends Language {
 				`• Klasa      :: v${klasaVersion}`,
 				`• Discord.js :: v${discordVersion}`,
 				`• Node.js    :: ${processVersion}`,
-				`• Shard      :: ${(message.guild ? message.guild.shardID : 0) + 1} / ${this.client.options.totalShardCount}`
+				`• Shard      :: ${(message.guild ? message.guild.shardID : 0) + 1} / ${this.client.options.shardCount}`
 			],
 			COMMAND_STATS_DESCRIPTION: 'Provides some details about the bot and stats.',
 			MESSAGE_PROMPT_TIMEOUT: 'The prompt has timed out.',


### PR DESCRIPTION
# Description of the PR
Modified `this.client.options.totalShardCount` to `this.client.options.shardCount` as per discord.js master branch documentation.


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed the `stats` command as which didn't show the actual shard count due because of non-existent property usage.

### Semver Classification

- [x] This PR fixes a bug and does not change the (intended) framework interface.