### PR TITLE
Throw error instead of emit error for fixing unexpected type

### DIFF
--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -133,13 +133,10 @@ class Store extends Collection {
 	 * Sets up a piece in our store.
 	 * @since 0.0.1
 	 * @param {Piece} piece The piece we are setting up
-	 * @returns {?Piece}
+	 * @returns {Piece}
 	 */
 	set(piece) {
-		if (!(piece instanceof this.holds)) {
-			this.client.emit('error', `Only ${this} may be stored in this Store.`);
-			return null;
-		}
+		if (!(piece instanceof this.holds)) throw new Error(`Only ${this} may be stored in this Store.`);
 		const existing = this.get(piece.name);
 		if (existing) this.delete(existing);
 		else if (this.client.listenerCount('pieceLoaded')) this.client.emit('pieceLoaded', piece);

--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -136,7 +136,10 @@ class Store extends Collection {
 	 * @returns {?Piece}
 	 */
 	set(piece) {
-		if (!(piece instanceof this.holds)) return this.client.emit('error', `Only ${this} may be stored in this Store.`);
+		if (!(piece instanceof this.holds)) {
+			this.client.emit('error', `Only ${this} may be stored in this Store.`);
+			return null;
+		}
 		const existing = this.get(piece.name);
 		if (existing) this.delete(existing);
 		else if (this.client.listenerCount('pieceLoaded')) this.client.emit('pieceLoaded', piece);

--- a/src/lib/structures/base/Store.js
+++ b/src/lib/structures/base/Store.js
@@ -136,7 +136,7 @@ class Store extends Collection {
 	 * @returns {Piece}
 	 */
 	set(piece) {
-		if (!(piece instanceof this.holds)) throw new Error(`Only ${this} may be stored in this Store.`);
+		if (!(piece instanceof this.holds)) throw new TypeError(`Only ${this} may be stored in this Store.`);
 		const existing = this.get(piece.name);
 		if (existing) this.delete(existing);
 		else if (this.client.listenerCount('pieceLoaded')) this.client.emit('pieceLoaded', piece);


### PR DESCRIPTION
### Description of the PR

Store#set() is expected to return `?Piece`, but may return boolean because of returns client.emit() directly.
EventEmitter.emit() returns true if the event had listeners, false otherwise.
See: https://nodejs.org/api/events.html#events_emitter_emit_eventname_args

Code affected by this behavior: https://github.com/dirigeants/klasa/blob/ea059931fad07bdea870620181de453efe816646/src/lib/structures/base/AliasStore.js#L50-L52

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed unexpected return type of Store#set() becouse of returning the client.emit() directly

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
