### PR TITLE
Update help.js

### DIFF
--- a/src/commands/System/help.js
+++ b/src/commands/System/help.js
@@ -48,7 +48,7 @@ module.exports = class extends Command {
 				.then(() => {
 					if (!help.hasOwnProperty(command.category)) help[command.category] = {};
 					if (!help[command.category].hasOwnProperty(command.subCategory)) help[command.category][command.subCategory] = [];
-					help[command.category][command.subCategory].push(`${msg.guildSettings.prefix}${command.name.padEnd(longest)} :: ${command.description}`);
+					help[command.category][command.subCategory].push(`${msg.guildSettings.prefix.startsWith("//") ?  "\/\/" :msg.guildSettings.prefix}${command.name.padEnd(longest)} :: ${command.description}`);
 					return;
 				})
 				.catch(() => {


### PR DESCRIPTION
fix command help menu when the prefix is //

### Description of the PR
fixes a bug where when the prefix is //, the entire asciidoc code block breaks

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- fix bug where when prefix is //, the entire asciidoc code block breaks

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
