### PR TITLE
fix(typings): add `news` as option for `runIn`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1298,7 +1298,7 @@ declare module 'klasa' {
 		promptTime?: number;
 		quotedStringSupport?: boolean;
 		requiredSettings?: string[];
-		runIn?: Array<'text' | 'dm'>;
+		runIn?: Array<'text' | 'dm' | 'news'>;
 		subcommands?: boolean;
 		usage?: string;
 		usageDelim?: string;


### PR DESCRIPTION
### Description of the PR

`news` was missing from the options for `runIn`

(and targeting master this time around)

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
