### PR TITLE
[Fix] TypeError: Cannot read property 'broadcastEval' of null

### DIFF
--- a/src/events/coreSettingsUpdate.js
+++ b/src/events/coreSettingsUpdate.js
@@ -23,7 +23,7 @@ module.exports = class extends Event {
 	}
 
 	init() {
-		if (!this.client.shard) this.disable();
+		if (!this.client.shard || this.client.shard === null) this.disable();
 	}
 
 };


### PR DESCRIPTION
### Description of the PR

Fixes `TypeError: Cannot read property 'broadcastEval' of null` when the bot isn't sharded.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed `Cannot read property 'broadcastEval' of null` when the bot isn't sharded.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
