### PR TITLE
docs(html): change mode to file

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "coverage:report": "npx nyc report --reporter=html",
     "lint": "eslint --fix --ext ts src test",
     "docs": "typedoc",
-    "docs:html": "typedoc --inputFiles src --mode modules --out docs"
+    "docs:html": "typedoc --inputFiles src --mode file --out docs"
   },
   "dependencies": {
     "@klasa/cache": "^0.0.3",


### PR DESCRIPTION
### Description of the PR

Setting the mode to "file" creates a much more readable HTML layout for Typedoc, for an example see https://skyra-project.github.io/skyra-decorators/, comparing it to for example https://dirigeants.github.io/klasa/. The difference being of course that with "modules" you get an extremely long list of files, most of which only have 1 or 2 exports. Furthermore the layout of "files" is much more in line with the layout of a page such as the "Classes" tab on https://klasa.js.org/#/docs/klasa/settings/Getting%20Started/GettingStarted.

Kyra told me to PR this change:

![](https://favna.s-ul.eu/Lv9MNbgz.png)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change of how typedoc outputs files so the HTML rendered page looks much better

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
