### PR TITLE
feat(sg): add Serializer#indexOf

### DIFF
--- a/src/lib/settings/Settings.ts
+++ b/src/lib/settings/Settings.ts
@@ -425,7 +425,7 @@ export class Settings extends Cache<string, unknown> {
 		if (options.arrayAction === ArrayActions.Auto) {
 			// Array action auto must add or remove values, depending on their existence
 			for (const value of values) {
-				const index = clone.indexOf(value);
+				const index = serializer.indexOf(clone, value, context);
 				if (index === -1) clone.push(value);
 				else clone.splice(index, 1);
 			}
@@ -438,7 +438,7 @@ export class Settings extends Cache<string, unknown> {
 		} else if (options.arrayAction === ArrayActions.Remove) {
 			// Array action remove must add values, throw on non-existent
 			for (const value of values) {
-				const index = clone.indexOf(value);
+				const index = serializer.indexOf(clone, value, context);
 				if (index === -1) throw new Error(context.language.get('SETTING_GATEWAY_MISSING_VALUE', context.entry, serializer.stringify(value, context.guild)));
 				clone.splice(index, 1);
 			}

--- a/src/lib/structures/Serializer.ts
+++ b/src/lib/structures/Serializer.ts
@@ -17,6 +17,17 @@ export abstract class Serializer extends AliasPiece {
 	}
 
 	/**
+	 * The indexOf method to be overwritten in non-primitive Serializers.
+	 * @param array The array to be looked up at
+	 * @param data The entry to find in the array
+	 * @param context The context in which this serializer is called
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	public indexOf(array: readonly unknown[], data: unknown, _context: SerializerUpdateContext): number {
+		return array.indexOf(data);
+	}
+
+	/**
 	 * Resolve a value given directly from the {@link Settings#resolve} call.
 	 * @param data The data to resolve
 	 * @param context The context in which this serializer is called


### PR DESCRIPTION
### Description of the PR

Adds `Serializer#indexOf`, which is a last piece needed for non-primitive serializers, such as ScheduledTasks.

### Changes Proposed in this Pull Request (List changes in CHANGELOG.MD)

- Added `Serializer#indexOf`

- [ ] This PR has been tested.
