### PR TITLE
fix: pressing forward at the last page requires two backwards afterwards

### DIFF
--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -146,7 +146,7 @@ class ReactionHandler extends ReactionCollector {
 	 * @returns {void}
 	 */
 	forward() {
-		if (this.currentPage > this.display.pages.length - 1) return;
+		if (this.currentPage >= this.display.pages.length - 1) return;
 		this.currentPage++;
 		this.update();
 	}


### PR DESCRIPTION
[Fix] Last page RichDisplay bug

### Description of the PR

Fixed issue where if you clicked forward on the last page you would need to click back twice to go back to the previous page.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- [fix] last page bug on RichDisplay/ReactionHandler

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
