### PR TITLE
fix: pressing forward at the last page requires two backwards afterwards

### DIFF
--- a/src/lib/util/ReactionHandler.ts
+++ b/src/lib/util/ReactionHandler.ts
@@ -225,7 +225,7 @@ export class ReactionHandler {
 			return this.update();
 		})
 		.set(ReactionMethods.Forward, function (this: ReactionHandler): Promise<boolean> {
-			if (this.#currentPage > this.display.pages.length - 1) return Promise.resolve(false);
+			if (this.#currentPage >= this.display.pages.length - 1) return Promise.resolve(false);
 			this.#currentPage++;
 			return this.update();
 		})


### PR DESCRIPTION
### Description of the PR

Fixed issue where if you clicked forward on the last page you would need to click back twice to go back to the previous page.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- [fix] last page bug on RichDisplay/ReactionHandler

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
